### PR TITLE
get simplify tables to remove duplicate sites

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -257,6 +257,9 @@ msp_strerror(int err)
         case MSP_ERR_MUTATION_PARENT_AFTER_CHILD:
             ret = "Parent mutation ID must be < current ID.";
             break;
+        case MSP_ERR_CONTRADICTORY_ANCESTRAL_STATES:
+            ret = "More than one site record with the same position but different ancestral states.";
+            break;
         case MSP_ERR_BAD_OFFSET:
             ret = "Bad offset provided in input array.";
             break;

--- a/lib/util.h
+++ b/lib/util.h
@@ -127,6 +127,7 @@
 #define MSP_ERR_MUTATION_PARENT_DIFFERENT_SITE                      -69
 #define MSP_ERR_MUTATION_PARENT_EQUAL                               -70
 #define MSP_ERR_MUTATION_PARENT_AFTER_CHILD                         -71
+#define MSP_ERR_CONTRADICTORY_ANCESTRAL_STATES                      -72
 
 const char * msp_strerror(int err);
 void __msp_safe_free(void **ptr);


### PR DESCRIPTION
Since sites are supposed to be unique, when outputting from a simulation we ought to check for each new mutation whether the site has been mutated before or not.  This information is not necessarily available in the simulator, if for instance the site has mutated before but those mutations have been lost, so the site is no longer variable. The simulator could be made to remember this, e.g., by maintaining a list of positions currently in the site table and checking for membership at addition of each new mutation, However, 

- this is a lot of checking to do, esp as most sites will be new;
- duplicate sites can be easily removed when `sort_tables` is called

This PR modifies `sort_tables` to remove additional entries from the site table that have the same position, after first checking that ancestral state is the same for each such duplicate entry (and throwing an error otherwise). If a simulator wishes to have different ancestral states, then it will have to keep track of this.

FWIW, this modification passes existing tests; but I have not added tests of the new, site-removing functionality; I wanted to get feedback first.