### PR TITLE
record and reset positions in table collections

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -1221,6 +1221,32 @@ out:
     return ret;
 }
 
+static PyObject *
+IndividualTable_truncate(IndividualTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (IndividualTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = individual_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
 
 static PyObject *
 IndividualTable_get_max_rows_increment(IndividualTable *self, void *closure)
@@ -1359,6 +1385,8 @@ static PyMethodDef IndividualTable_methods[] = {
         "Copies the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) IndividualTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) IndividualTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -1694,6 +1722,33 @@ out:
 }
 
 static PyObject *
+NodeTable_truncate(NodeTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (NodeTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = node_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 NodeTable_get_max_rows_increment(NodeTable *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -1844,6 +1899,8 @@ static PyMethodDef NodeTable_methods[] = {
         "Copies the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) NodeTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) NodeTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -2121,6 +2178,33 @@ out:
 }
 
 static PyObject *
+EdgeTable_truncate(EdgeTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (EdgeTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = edge_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 EdgeTable_get_max_rows_increment(EdgeTable *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -2244,6 +2328,8 @@ static PyMethodDef EdgeTable_methods[] = {
         "Copies the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) EdgeTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) EdgeTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -2536,6 +2622,33 @@ out:
 }
 
 static PyObject *
+MigrationTable_truncate(MigrationTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (MigrationTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = migration_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 MigrationTable_get_max_rows_increment(MigrationTable *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -2684,6 +2797,8 @@ static PyMethodDef MigrationTable_methods[] = {
         "Appends the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) MigrationTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) MigrationTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -3005,6 +3120,32 @@ out:
     return ret;
 }
 
+static PyObject *
+SiteTable_truncate(SiteTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (SiteTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = site_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
 
 static PyObject *
 SiteTable_get_max_rows_increment(SiteTable *self, void *closure)
@@ -3153,6 +3294,8 @@ static PyMethodDef SiteTable_methods[] = {
         "Appends the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) SiteTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) SiteTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -3505,6 +3648,33 @@ out:
 }
 
 static PyObject *
+MutationTable_truncate(MutationTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (MutationTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = mutation_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 MutationTable_get_max_rows_increment(MutationTable *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -3682,6 +3852,8 @@ static PyMethodDef MutationTable_methods[] = {
         "Appends the data in the specified  arrays into the columns."},
     {"clear", (PyCFunction) MutationTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) MutationTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -3960,6 +4132,33 @@ out:
 }
 
 static PyObject *
+PopulationTable_truncate(PopulationTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (PopulationTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = population_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 PopulationTable_get_max_rows_increment(PopulationTable *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -4050,6 +4249,8 @@ static PyMethodDef PopulationTable_methods[] = {
         "Copies the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) PopulationTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) PopulationTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 
@@ -4351,6 +4552,33 @@ out:
 }
 
 static PyObject *
+ProvenanceTable_truncate(ProvenanceTable *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    Py_ssize_t num_rows;
+    int err;
+
+    if (ProvenanceTable_check_state(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "n", &num_rows)) {
+        goto out;
+    }
+    if (num_rows < 0 || num_rows > (Py_ssize_t) self->table->num_rows) {
+        PyErr_SetString(PyExc_ValueError, "num_rows out of bounds");
+        goto out;
+    }
+    err = provenance_table_truncate(self->table, (size_t) num_rows);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = Py_BuildValue("");
+out:
+    return ret;
+}
+
+static PyObject *
 ProvenanceTable_get_max_rows_increment(ProvenanceTable *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -4472,6 +4700,8 @@ static PyMethodDef ProvenanceTable_methods[] = {
         "Copies the data in the specified arrays into the columns."},
     {"clear", (PyCFunction) ProvenanceTable_clear, METH_NOARGS,
         "Clears this table."},
+    {"truncate", (PyCFunction) ProvenanceTable_truncate, METH_VARARGS,
+        "Truncates this table to the specified number of rows."},
     {NULL}  /* Sentinel */
 };
 

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -5327,3 +5327,199 @@ out:
     msp_safe_free(bottom_mutation);
     return ret;
 }
+
+/*****************************
+ * Table collection position *
+ *****************************/
+
+void
+table_collection_record_position(table_collection_t *tables,
+        table_collection_position_t *position)
+{
+    /* Record the current "end" position of a table collection,
+     * which is the current number of rows in the table.
+     * */
+
+    position->individual_position = tables->individuals->num_rows;
+    position->node_position = tables->nodes->num_rows;
+    position->edge_position = tables->edges->num_rows;
+    position->migration_position = tables->migrations->num_rows;
+    position->site_position = tables->sites->num_rows;
+    position->mutation_position = tables->mutations->num_rows;
+    position->population_position = tables->populations->num_rows;
+    position->provenance_position = tables->provenances->num_rows;
+}
+
+static int WARN_UNUSED
+individual_table_reset_position(individual_table_t *individuals, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > individuals->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    individuals->num_rows = n;
+    individuals->location_length = individuals->location_offset[n];
+    individuals->metadata_length = individuals->metadata_offset[n];
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+node_table_reset_position(node_table_t *nodes, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > nodes->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    nodes->num_rows = n;
+    nodes->metadata_length = nodes->metadata_offset[n];
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+edge_table_reset_position(edge_table_t *edges, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > edges->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    edges->num_rows = n;
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+migration_table_reset_position(migration_table_t *migrations, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > migrations->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    migrations->num_rows = n;
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+site_table_reset_position(site_table_t *sites, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > sites->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    sites->num_rows = n;
+    sites->ancestral_state_length = sites->ancestral_state_offset[n];
+    sites->metadata_length = sites->metadata_offset[n];
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+mutation_table_reset_position(mutation_table_t *mutations, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > mutations->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    mutations->num_rows = n;
+    mutations->derived_state_length = mutations->derived_state_offset[n];
+    mutations->metadata_length = mutations->metadata_offset[n];
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+population_table_reset_position(population_table_t *populations, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > populations->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    populations->num_rows = n;
+    populations->metadata_length = populations->metadata_offset[n];
+out:
+    return ret;
+}
+
+static int WARN_UNUSED
+provenance_table_reset_position(provenance_table_t *provenances, table_size_t n)
+{
+    /* Remove rows, so that the new number of rows is n */
+    int ret = 0;
+    if (n > provenances->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    provenances->num_rows = n;
+    provenances->timestamp_length = provenances->timestamp_offset[n];
+    provenances->record_length = provenances->record_offset[n];
+out:
+    return ret;
+}
+
+int WARN_UNUSED
+table_collection_reset_position(table_collection_t *tables,
+        table_collection_position_t *position)
+{
+    int ret = 0;
+
+    /* "Reset" a table collection to the previously recorded position. */
+    ret = individual_table_reset_position(tables->individuals,
+                                          position->individual_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = node_table_reset_position(tables->nodes,
+                                    position->node_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = edge_table_reset_position(tables->edges,
+                                    position->edge_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = migration_table_reset_position(tables->migrations,
+                                         position->migration_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = site_table_reset_position(tables->sites,
+                                    position->site_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = mutation_table_reset_position(tables->mutations,
+                                    position->mutation_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = population_table_reset_position(tables->populations,
+                                          position->population_position);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = provenance_table_reset_position(tables->provenances,
+                                          position->provenance_position);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -5479,6 +5479,10 @@ table_collection_reset_position(table_collection_t *tables,
     int ret = 0;
 
     /* "Reset" a table collection to the previously recorded position. */
+    ret = table_collection_drop_indexes(tables);
+    if (ret != 0) {
+        goto out;
+    }
     ret = individual_table_reset_position(tables->individuals,
                                           position->individual_position);
     if (ret != 0) {

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -404,12 +404,26 @@ out:
     return ret;
 }
 
-int
+int WARN_UNUSED
 node_table_clear(node_table_t *self)
 {
-    self->num_rows = 0;
-    self->metadata_length = 0;
-    return 0;
+    return node_table_truncate(self, 0);
+}
+
+int
+node_table_truncate(node_table_t *self, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+    self->metadata_length = self->metadata_offset[n];
+out:
+    return ret;
 }
 
 int
@@ -660,8 +674,22 @@ out:
 int
 edge_table_clear(edge_table_t *self)
 {
-    self->num_rows = 0;
-    return 0;
+    return edge_table_truncate(self, 0);
+}
+
+int
+edge_table_truncate(edge_table_t *self, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+out:
+    return ret;
 }
 
 int
@@ -1033,12 +1061,23 @@ site_table_equals(site_table_t *self, site_table_t *other)
 int
 site_table_clear(site_table_t *self)
 {
-    self->num_rows = 0;
-    self->ancestral_state_length = 0;
-    self->ancestral_state_offset[0] = 0;
-    self->metadata_length = 0;
-    self->metadata_offset[0] = 0;
-    return 0;
+    return site_table_truncate(self, 0);
+}
+
+int
+site_table_truncate(site_table_t *self, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+    self->ancestral_state_length = self->ancestral_state_offset[n];
+    self->metadata_length = self->metadata_offset[n];
+out:
+    return ret;
 }
 
 int
@@ -1447,12 +1486,24 @@ mutation_table_equals(mutation_table_t *self, mutation_table_t *other)
 int
 mutation_table_clear(mutation_table_t *self)
 {
-    self->num_rows = 0;
-    self->derived_state_length = 0;
-    self->derived_state_offset[0] = 0;
-    self->metadata_length = 0;
-    self->metadata_offset[0] = 0;
-    return 0;
+    return mutation_table_truncate(self, 0);
+}
+
+int
+mutation_table_truncate(mutation_table_t *mutations, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > mutations->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    mutations->num_rows = n;
+    mutations->derived_state_length = mutations->derived_state_offset[n];
+    mutations->metadata_length = mutations->metadata_offset[n];
+out:
+    return ret;
 }
 
 int
@@ -1706,8 +1757,22 @@ out:
 int
 migration_table_clear(migration_table_t *self)
 {
-    self->num_rows = 0;
-    return 0;
+    return migration_table_truncate(self, 0);
+}
+
+int
+migration_table_truncate(migration_table_t *self, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+out:
+    return ret;
 }
 
 int
@@ -2066,10 +2131,23 @@ out:
 int
 individual_table_clear(individual_table_t *self)
 {
+    return individual_table_truncate(self, 0);
+}
+
+int
+individual_table_truncate(individual_table_t *self, size_t num_rows)
+{
     int ret = 0;
-    self->num_rows = 0;
-    self->metadata_length = 0;
-    self->location_length = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+    self->location_length = self->location_offset[n];
+    self->metadata_length = self->metadata_offset[n];
+out:
     return ret;
 }
 
@@ -2390,9 +2468,23 @@ out:
 int
 population_table_clear(population_table_t *self)
 {
-    self->num_rows = 0;
-    self->metadata_length = 0;
-    return 0;
+    return population_table_truncate(self, 0);
+}
+
+int
+population_table_truncate(population_table_t *self, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+    self->metadata_length = self->metadata_offset[n];
+out:
+    return ret;
 }
 
 int
@@ -2736,10 +2828,24 @@ out:
 int
 provenance_table_clear(provenance_table_t *self)
 {
-    self->num_rows = 0;
-    self->timestamp_length = 0;
-    self->record_length = 0;
-    return 0;
+    return provenance_table_truncate(self, 0);
+}
+
+int
+provenance_table_truncate(provenance_table_t *self, size_t num_rows)
+{
+    int ret = 0;
+    table_size_t n = (table_size_t) num_rows;
+
+    if (n > self->num_rows) {
+        ret = MSP_ERR_BAD_TABLE_POSITION;
+        goto out;
+    }
+    self->num_rows = n;
+    self->timestamp_length = self->timestamp_offset[n];
+    self->record_length = self->record_offset[n];
+out:
+    return ret;
 }
 
 int
@@ -5328,202 +5434,67 @@ out:
     return ret;
 }
 
-/*****************************
- * Table collection position *
- *****************************/
-
-void
-table_collection_record_position(table_collection_t *tables,
+/* Record the current "end" position of a table collection,
+ * which is the current number of rows in each table.
+ */
+int
+table_collection_record_position(table_collection_t *self,
         table_collection_position_t *position)
 {
-    /* Record the current "end" position of a table collection,
-     * which is the current number of rows in the table.
-     * */
-
-    position->individual_position = tables->individuals->num_rows;
-    position->node_position = tables->nodes->num_rows;
-    position->edge_position = tables->edges->num_rows;
-    position->migration_position = tables->migrations->num_rows;
-    position->site_position = tables->sites->num_rows;
-    position->mutation_position = tables->mutations->num_rows;
-    position->population_position = tables->populations->num_rows;
-    position->provenance_position = tables->provenances->num_rows;
+    position->individuals = self->individuals->num_rows;
+    position->nodes = self->nodes->num_rows;
+    position->edges = self->edges->num_rows;
+    position->migrations = self->migrations->num_rows;
+    position->sites = self->sites->num_rows;
+    position->mutations = self->mutations->num_rows;
+    position->populations = self->populations->num_rows;
+    position->provenances = self->provenances->num_rows;
+    return 0;
 }
 
-static int WARN_UNUSED
-individual_table_reset_position(individual_table_t *individuals, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > individuals->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    individuals->num_rows = n;
-    individuals->location_length = individuals->location_offset[n];
-    individuals->metadata_length = individuals->metadata_offset[n];
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-node_table_reset_position(node_table_t *nodes, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > nodes->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    nodes->num_rows = n;
-    nodes->metadata_length = nodes->metadata_offset[n];
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-edge_table_reset_position(edge_table_t *edges, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > edges->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    edges->num_rows = n;
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-migration_table_reset_position(migration_table_t *migrations, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > migrations->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    migrations->num_rows = n;
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-site_table_reset_position(site_table_t *sites, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > sites->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    sites->num_rows = n;
-    sites->ancestral_state_length = sites->ancestral_state_offset[n];
-    sites->metadata_length = sites->metadata_offset[n];
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-mutation_table_reset_position(mutation_table_t *mutations, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > mutations->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    mutations->num_rows = n;
-    mutations->derived_state_length = mutations->derived_state_offset[n];
-    mutations->metadata_length = mutations->metadata_offset[n];
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-population_table_reset_position(population_table_t *populations, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > populations->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    populations->num_rows = n;
-    populations->metadata_length = populations->metadata_offset[n];
-out:
-    return ret;
-}
-
-static int WARN_UNUSED
-provenance_table_reset_position(provenance_table_t *provenances, table_size_t n)
-{
-    /* Remove rows, so that the new number of rows is n */
-    int ret = 0;
-    if (n > provenances->num_rows) {
-        ret = MSP_ERR_BAD_TABLE_POSITION;
-        goto out;
-    }
-    provenances->num_rows = n;
-    provenances->timestamp_length = provenances->timestamp_offset[n];
-    provenances->record_length = provenances->record_offset[n];
-out:
-    return ret;
-}
-
+/* Reset to the previously recorded position. */
 int WARN_UNUSED
 table_collection_reset_position(table_collection_t *tables,
         table_collection_position_t *position)
 {
     int ret = 0;
 
-    /* "Reset" a table collection to the previously recorded position. */
     ret = table_collection_drop_indexes(tables);
     if (ret != 0) {
         goto out;
     }
-    ret = individual_table_reset_position(tables->individuals,
-                                          position->individual_position);
+    ret = individual_table_truncate(tables->individuals, position->individuals);
     if (ret != 0) {
         goto out;
     }
-    ret = node_table_reset_position(tables->nodes,
-                                    position->node_position);
+    ret = node_table_truncate(tables->nodes, position->nodes);
     if (ret != 0) {
         goto out;
     }
-    ret = edge_table_reset_position(tables->edges,
-                                    position->edge_position);
+    ret = edge_table_truncate(tables->edges, position->edges);
     if (ret != 0) {
         goto out;
     }
-    ret = migration_table_reset_position(tables->migrations,
-                                         position->migration_position);
+    ret = migration_table_truncate(tables->migrations, position->migrations);
     if (ret != 0) {
         goto out;
     }
-    ret = site_table_reset_position(tables->sites,
-                                    position->site_position);
+    ret = site_table_truncate(tables->sites, position->sites);
     if (ret != 0) {
         goto out;
     }
-    ret = mutation_table_reset_position(tables->mutations,
-                                    position->mutation_position);
+    ret = mutation_table_truncate(tables->mutations, position->mutations);
     if (ret != 0) {
         goto out;
     }
-    ret = population_table_reset_position(tables->populations,
-                                          position->population_position);
+    ret = population_table_truncate(tables->populations, position->populations);
     if (ret != 0) {
         goto out;
     }
-    ret = provenance_table_reset_position(tables->provenances,
-                                          position->provenance_position);
+    ret = provenance_table_truncate(tables->provenances, position->provenances);
     if (ret != 0) {
         goto out;
     }
 out:
     return ret;
 }
-

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -160,15 +160,15 @@ typedef struct {
 } table_collection_t;
 
 typedef struct {
-    table_collection_t *tables;
-    table_size_t individual_position;
-    table_size_t node_position;
-    table_size_t edge_position;
-    table_size_t migration_position;
-    table_size_t site_position;
-    table_size_t mutation_position;
-    table_size_t population_position;
-    table_size_t provenance_position;
+    table_size_t individuals;
+    table_size_t nodes;
+    table_size_t edges;
+    table_size_t migrations;
+    table_size_t sites;
+    table_size_t mutations;
+    table_size_t populations;
+    table_size_t provenances;
+    /* TODO add reserved space for future tables. */
 } table_collection_position_t;
 
 /* Definitions for the basic objects */
@@ -344,6 +344,7 @@ int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *fla
         population_id_t *population, individual_id_t *individual,
         const char *metadata, table_size_t *metadata_length);
 int node_table_clear(node_table_t *self);
+int node_table_truncate(node_table_t *self, size_t num_rows);
 int node_table_free(node_table_t *self);
 int node_table_dump_text(node_table_t *self, FILE *out);
 int node_table_copy(node_table_t *self, node_table_t *dest);
@@ -358,6 +359,7 @@ int edge_table_set_columns(edge_table_t *self, size_t num_rows, double *left,
 int edge_table_append_columns(edge_table_t *self, size_t num_rows, double *left,
         double *right, node_id_t *parent, node_id_t *child);
 int edge_table_clear(edge_table_t *self);
+int edge_table_truncate(edge_table_t *self, size_t num_rows);
 int edge_table_free(edge_table_t *self);
 int edge_table_dump_text(edge_table_t *self, FILE *out);
 int edge_table_copy(edge_table_t *self, edge_table_t *dest);
@@ -370,7 +372,6 @@ int site_table_alloc(site_table_t *self, size_t max_rows_increment,
 site_id_t site_table_add_row(site_table_t *self, double position,
         const char *ancestral_state, table_size_t ancestral_state_length,
         const char *metadata, table_size_t metadata_length);
-
 int site_table_set_columns(site_table_t *self, size_t num_rows, double *position,
         const char *ancestral_state, table_size_t *ancestral_state_length,
         const char *metadata, table_size_t *metadata_length);
@@ -379,6 +380,7 @@ int site_table_append_columns(site_table_t *self, size_t num_rows, double *posit
         const char *metadata, table_size_t *metadata_length);
 bool site_table_equals(site_table_t *self, site_table_t *other);
 int site_table_clear(site_table_t *self);
+int site_table_truncate(site_table_t *self, size_t num_rows);
 int site_table_copy(site_table_t *self, site_table_t *dest);
 int site_table_free(site_table_t *self);
 int site_table_dump_text(site_table_t *self, FILE *out);
@@ -402,6 +404,7 @@ int mutation_table_append_columns(mutation_table_t *self, size_t num_rows,
         const char *metadata, table_size_t *metadata_length);
 bool mutation_table_equals(mutation_table_t *self, mutation_table_t *other);
 int mutation_table_clear(mutation_table_t *self);
+int mutation_table_truncate(mutation_table_t *self, size_t num_rows);
 int mutation_table_copy(mutation_table_t *self, mutation_table_t *dest);
 int mutation_table_free(mutation_table_t *self);
 int mutation_table_dump_text(mutation_table_t *self, FILE *out);
@@ -418,6 +421,7 @@ int migration_table_append_columns(migration_table_t *self, size_t num_rows,
         double *left, double *right, node_id_t *node, population_id_t *source,
         population_id_t *dest, double *time);
 int migration_table_clear(migration_table_t *self);
+int migration_table_truncate(migration_table_t *self, size_t num_rows);
 int migration_table_free(migration_table_t *self);
 int migration_table_copy(migration_table_t *self, migration_table_t *dest);
 int migration_table_dump_text(migration_table_t *self, FILE *out);
@@ -436,6 +440,7 @@ int individual_table_append_columns(individual_table_t *self, size_t num_rows, u
         double *location, table_size_t *location_length,
         const char *metadata, table_size_t *metadata_length);
 int individual_table_clear(individual_table_t *self);
+int individual_table_truncate(individual_table_t *self, size_t num_rows);
 int individual_table_free(individual_table_t *self);
 int individual_table_dump_text(individual_table_t *self, FILE *out);
 int individual_table_copy(individual_table_t *self, individual_table_t *dest);
@@ -451,6 +456,7 @@ int population_table_set_columns(population_table_t *self, size_t num_rows,
 int population_table_append_columns(population_table_t *self, size_t num_rows,
         const char *metadata, table_size_t *metadata_offset);
 int population_table_clear(population_table_t *self);
+int population_table_truncate(population_table_t *self, size_t num_rows);
 int population_table_copy(population_table_t *self, population_table_t *dest);
 int population_table_free(population_table_t *self);
 void population_table_print_state(population_table_t *self, FILE *out);
@@ -470,6 +476,7 @@ int provenance_table_append_columns(provenance_table_t *self, size_t num_rows,
         char *timestamp, table_size_t *timestamp_offset,
         char *record, table_size_t *record_offset);
 int provenance_table_clear(provenance_table_t *self);
+int provenance_table_truncate(provenance_table_t *self, size_t num_rows);
 int provenance_table_copy(provenance_table_t *self, provenance_table_t *dest);
 int provenance_table_free(provenance_table_t *self);
 int provenance_table_dump_text(provenance_table_t *self, FILE *out);
@@ -496,6 +503,10 @@ int table_collection_sort(table_collection_t *self, size_t edge_start, int flags
 int table_collection_deduplicate_sites(table_collection_t *tables, int flags);
 int table_collection_compute_mutation_parents(table_collection_t *self, int flags);
 bool table_collection_equals(table_collection_t *self, table_collection_t *other);
+int table_collection_record_position(table_collection_t *self,
+        table_collection_position_t *position);
+int table_collection_reset_position(table_collection_t *self,
+        table_collection_position_t *position);
 
 int simplifier_alloc(simplifier_t *self, node_id_t *samples, size_t num_samples,
         table_collection_t *tables, int flags);
@@ -504,11 +515,6 @@ int simplifier_run(simplifier_t *self, node_id_t *node_map);
 void simplifier_print_state(simplifier_t *self, FILE *out);
 
 int squash_edges(edge_t *edges, size_t num_edges, size_t *num_output_edges);
-
-void table_collection_record_position(table_collection_t *tables,
-        table_collection_position_t *position);
-int table_collection_reset_position(table_collection_t *tables,
-        table_collection_position_t *position);
 
 #ifdef __cplusplus
 }

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -159,6 +159,18 @@ typedef struct {
     /* TODO Add in reserved space for future tables. */
 } table_collection_t;
 
+typedef struct {
+    table_collection_t *tables;
+    table_size_t individual_position;
+    table_size_t node_position;
+    table_size_t edge_position;
+    table_size_t migration_position;
+    table_size_t site_position;
+    table_size_t mutation_position;
+    table_size_t population_position;
+    table_size_t provenance_position;
+} table_collection_position_t;
+
 /* Definitions for the basic objects */
 
 typedef struct {
@@ -492,6 +504,11 @@ int simplifier_run(simplifier_t *self, node_id_t *node_map);
 void simplifier_print_state(simplifier_t *self, FILE *out);
 
 int squash_edges(edge_t *edges, size_t num_edges, size_t *num_output_edges);
+
+void table_collection_record_position(table_collection_t *tables,
+        table_collection_position_t *position);
+int table_collection_reset_position(table_collection_t *tables,
+        table_collection_position_t *position);
 
 #ifdef __cplusplus
 }

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6884,6 +6884,22 @@ test_node_table(void)
     node_table_print_state(&table, _devnull);
     node_table_dump_text(&table, _devnull);
 
+    /* Truncate back to the original number of rows. */
+    ret = node_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
+                (num_rows + 1) * sizeof(table_size_t)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
+
+    ret = node_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
+
     /* If population is NULL it should be set to -1. If metadata is NULL all metadatas
      * should be set to the empty string. If individual is NULL it should be set to -1. */
     num_rows = 10;
@@ -7009,6 +7025,18 @@ test_edge_table(void)
     CU_ASSERT_EQUAL(memcmp(table.child, child, num_rows * sizeof(node_id_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.child + num_rows, child, num_rows * sizeof(node_id_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
+
+    /* Truncate back to num_rows */
+    ret = edge_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.left, left, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.right, right, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.parent, parent, num_rows * sizeof(node_id_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.child, child, num_rows * sizeof(node_id_t)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+
+    ret = edge_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
 
     /* Inputs cannot be NULL */
     ret = edge_table_set_columns(&table, num_rows, NULL, right, parent, child);
@@ -7138,6 +7166,21 @@ test_site_table(void)
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
     CU_ASSERT_EQUAL(table.ancestral_state_length, 2 * num_rows);
+
+    /* truncate back to num_rows */
+    ret = site_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.position, position,
+                num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.ancestral_state, ancestral_state,
+                num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.ancestral_state_length, num_rows);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+
+    ret = site_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
 
     /* Inputs cannot be NULL */
     ret = site_table_set_columns(&table, num_rows, NULL, ancestral_state,
@@ -7319,6 +7362,22 @@ test_mutation_table(void)
                 num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.metadata_length, 2 * num_rows);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
+
+    /* Truncate back to num_rows */
+    ret = mutation_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.site, site, num_rows * sizeof(site_id_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.node, node, num_rows * sizeof(node_id_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.parent, parent, num_rows * sizeof(mutation_id_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.derived_state, derived_state,
+                num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+    CU_ASSERT_EQUAL(table.derived_state_length, num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
+
+    ret = mutation_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
 
     /* Check all this again, except with parent == NULL and metadata == NULL. */
     memset(parent, 0xff, num_rows * sizeof(mutation_id_t));
@@ -7505,6 +7564,20 @@ test_migration_table(void)
                 num_rows * sizeof(population_id_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
 
+    /* Truncate back to num_rows */
+    ret = migration_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.left, left, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.right, right, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.node, node, num_rows * sizeof(node_id_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.source, source, num_rows * sizeof(population_id_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.dest, dest, num_rows * sizeof(population_id_t)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+
+    ret = migration_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
+
     /* inputs cannot be NULL */
     ret = migration_table_set_columns(&table, num_rows, NULL, right, node, source,
             dest, time);
@@ -7639,6 +7712,25 @@ test_individual_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 2 * num_rows);
     individual_table_print_state(&table, _devnull);
     individual_table_dump_text(&table, _devnull);
+
+    /* Truncate back to num_rows */
+    ret = individual_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.location, location,
+                spatial_dimension * num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.location_offset, location_offset,
+                (num_rows + 1) * sizeof(table_size_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
+                (num_rows + 1) * sizeof(table_size_t)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+    CU_ASSERT_EQUAL(table.location_length, spatial_dimension * num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
+    individual_table_print_state(&table, _devnull);
+
+    ret = individual_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
 
     /* flags can't be NULL */
     ret = individual_table_set_columns(&table, num_rows, NULL,
@@ -7834,6 +7926,16 @@ test_population_table(void)
     CU_ASSERT_EQUAL(table.metadata_length, 2 * num_rows);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
 
+    /* Truncate back to num_rows */
+    ret = population_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+    CU_ASSERT_EQUAL(table.metadata_length, num_rows);
+
+    ret = population_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
+
     /* Metadata = NULL gives an error */
     ret = population_table_set_columns(&table, num_rows, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
@@ -7950,6 +8052,23 @@ test_provenance_table(void)
     CU_ASSERT_EQUAL(table.timestamp_length, 2 * num_rows);
     CU_ASSERT_EQUAL(table.record_length, 2 * num_rows);
     provenance_table_print_state(&table, _devnull);
+
+    /* Truncate back to num_rows */
+    ret = provenance_table_truncate(&table, num_rows);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL(memcmp(table.timestamp, timestamp, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.timestamp_offset, timestamp_offset,
+                (num_rows + 1) * sizeof(table_size_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.record, record, num_rows * sizeof(char)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.record_offset, record_offset,
+                (num_rows + 1) * sizeof(table_size_t)), 0);
+    CU_ASSERT_EQUAL(table.num_rows, num_rows);
+    CU_ASSERT_EQUAL(table.timestamp_length, num_rows);
+    CU_ASSERT_EQUAL(table.record_length, num_rows);
+    provenance_table_print_state(&table, _devnull);
+
+    ret = provenance_table_truncate(&table, num_rows + 1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TABLE_POSITION);
 
     /* No arguments can be null */
     ret = provenance_table_set_columns(&table, num_rows, NULL, timestamp_offset,

--- a/lib/util.c
+++ b/lib/util.c
@@ -260,6 +260,9 @@ msp_strerror_internal(int err)
             /* Temporary error to flag a limitation in current implementation. */
             ret = "Individuals are currently not supported in simplify.";
             break;
+        case MSP_ERR_BAD_TABLE_POSITION:
+            ret = "Bad table position provided to truncate/reset.";
+            break;
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);

--- a/lib/util.h
+++ b/lib/util.h
@@ -171,6 +171,7 @@
 
 /* REUSE: * -57 */
 
+#define MSP_ERR_BAD_TABLE_POSITION                                  -75
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -129,6 +129,14 @@ class BaseTable(object):
         # Deprecated alias for clear
         self.clear()
 
+    def truncate(self, num_rows):
+        """
+        Truncates this table so that the only the first ``num_rows`` are retained.
+
+        :param int num_rows: The number of rows to retain in this table.
+        """
+        return self.ll_table.truncate(num_rows)
+
     # Unpickle support
     def __setstate__(self, state):
         self.set_columns(**state)


### PR DESCRIPTION
There's two things here (in theory: untested! but running the idea by you):

1. Ability to record a position in a set of tables, which would be important for a number of things, including sorting only the last chunk of the tables or looking through the mutations recorded on a given individual.

2. Ability to "rewind" tables to a previously recorded position.  This is useful in use cases where a large number of possible offspring are generated, but are discarded before moving on to the next offspring.

If this looks good, I'll write some tests.