### PR TITLE
"clean tables" by removing duplicate sites

### DIFF
--- a/lib/tables.c
+++ b/lib/tables.c
@@ -4551,61 +4551,100 @@ out:
     return ret;
 }
 
-
-/*******************
- * Cleaning tables *
- ******************/
-
-typedef struct {
-    site_table_t *sites;
-    mutation_table_t *mutations;
-    /* Map of old site IDs to new site IDs. */
-    site_id_t *site_id_map;
-} table_cleaner_t;
-
-static int table_cleaner_run(table_cleaner_t *self)
+/*
+ * Remove any sites with duplicate positions, retaining only the *first*
+ * one. Assumes the tables have been sorted, throwing an error if not.
+ */
+int WARN_UNUSED
+table_collection_deduplicate_sites(table_collection_t *self, int flags)
 {
-    // Remove any sites with duplicate positions, retaining only the *first*
-    // one. Assumes the tables have been sorted, throwing an error if not.
-
     int ret = 0;
-    table_size_t j, k, site_j;
+    table_size_t j, site_j;
     table_size_t as_length, as_offset;
     table_size_t md_length, md_offset;
     table_size_t num_input_sites;
     double last_position, position;
+    site_id_t mutation_site;
+    /* Map of old site IDs to new site IDs. */
+    site_id_t *site_id_map = NULL;
 
-    num_input_sites = self->sites->num_rows;
-    site_j = 0; // the index of the next output row
-    // this will need to change if negative positions are allowed!
+    num_input_sites = self->sites.num_rows;
+    site_id_map = malloc(num_input_sites * sizeof(*site_id_map));
+    if (site_id_map == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    /* Check the input first. This avoids leaving the table in an indeterminate
+     * state after an error occurs, which could lead to nasty downstream bugs.
+     * The cost of the extra iterations is minimal. If the user is super-sure
+     * that their input is correct, then we could add a flag to skip these
+     * checks. */
     last_position = -1;
-    as_offset = 0;
-    md_offset = 0;
-
-    // self->site_id_map[0] = 0;
-    // last_position = self->sites->position[0];
-    // as_offset = self->sites->ancestral_state_offset[1];
-    // md_offset = self->sites->metadata_offset[1];
-    for (j = 0; j < self->sites->num_rows; j++) {
-        position = self->sites->position[j];
+    for (j = 0; j < self->sites.num_rows; j++) {
+        position = self->sites.position[j];
+        if (position < 0) {
+            ret = MSP_ERR_BAD_SITE_POSITION;
+            goto out;
+        }
         if (position < last_position) {
             ret = MSP_ERR_UNSORTED_SITES;
             goto out;
         }
+        /* Checking the offsets is arguably unnecessary, since these should
+         * be validated when calling add_row/or append_rows. However,
+         * we can't be sure that users won't edit tables directly and
+         * we'll end up with hard-to-debug memory access violations when
+         * doing the memcpy'ing below. */
+        if (self->sites.metadata_offset[j + 1] > self->sites.metadata_length) {
+            ret = MSP_ERR_BAD_OFFSET;
+            goto out;
+        }
+        if (self->sites.metadata_offset[j] > self->sites.metadata_offset[j + 1]) {
+            ret = MSP_ERR_BAD_OFFSET;
+            goto out;
+        }
+        if (self->sites.ancestral_state_offset[j + 1]
+                > self->sites.ancestral_state_length) {
+            ret = MSP_ERR_BAD_OFFSET;
+            goto out;
+        }
+        if (self->sites.ancestral_state_offset[j]
+                > self->sites.ancestral_state_offset[j + 1]) {
+            ret = MSP_ERR_BAD_OFFSET;
+            goto out;
+        }
+        last_position = position;
+    }
+    for (j = 0; j < self->mutations.num_rows; j++) {
+        mutation_site = self->mutations.site[j];
+        if (mutation_site < 0 || mutation_site >= (site_id_t) num_input_sites) {
+            ret = MSP_ERR_SITE_OUT_OF_BOUNDS;
+            goto out;
+        }
+    }
+
+    site_j = 0; // the index of the next output row
+    // NOTE: this will need to change if negative positions are allowed!
+    last_position = -1;
+    as_offset = 0;
+    md_offset = 0;
+
+    for (j = 0; j < self->sites.num_rows; j++) {
+        position = self->sites.position[j];
         if (position != last_position) {
-            as_length = (self->sites->ancestral_state_offset[j + 1] 
-                    - self->sites->ancestral_state_offset[j]);
-            md_length = self->sites->metadata_offset[j + 1] - self->sites->metadata_offset[j];
+            as_length = (self->sites.ancestral_state_offset[j + 1]
+                    - self->sites.ancestral_state_offset[j]);
+            md_length = self->sites.metadata_offset[j + 1] - self->sites.metadata_offset[j];
             if (site_j != j) {
                 assert(site_j < j);
-                self->sites->position[site_j] = self->sites->position[j];
-                self->sites->ancestral_state_offset[site_j] = as_offset;
-                memcpy(self->sites->ancestral_state + self->sites->ancestral_state_offset[site_j],
-                        self->sites->ancestral_state + self->sites->ancestral_state_offset[j],
+                self->sites.position[site_j] = self->sites.position[j];
+                self->sites.ancestral_state_offset[site_j] = as_offset;
+                memcpy(self->sites.ancestral_state + self->sites.ancestral_state_offset[site_j],
+                        self->sites.ancestral_state + self->sites.ancestral_state_offset[j],
                         as_length);
-                self->sites->metadata_offset[site_j] = md_offset;
-                memcpy(self->sites->metadata + self->sites->metadata_offset[site_j],
-                        self->sites->metadata + self->sites->metadata_offset[j],
+                self->sites.metadata_offset[site_j] = md_offset;
+                memcpy(self->sites.metadata + self->sites.metadata_offset[site_j],
+                        self->sites.metadata + self->sites.metadata_offset[j],
                         md_length);
             }
             as_offset += as_length;
@@ -4613,80 +4652,22 @@ static int table_cleaner_run(table_cleaner_t *self)
             last_position = position;
             site_j++;
         }
-        self->site_id_map[j] = site_j - 1;
+        site_id_map[j] = (site_id_t) site_j - 1;
     }
 
-    self->sites->num_rows = site_j;
-    self->sites->ancestral_state_length = self->sites->ancestral_state_offset[site_j];
-    self->sites->metadata_length = self->sites->metadata_offset[site_j];
+    self->sites.num_rows = site_j;
+    self->sites.ancestral_state_length = self->sites.ancestral_state_offset[site_j];
+    self->sites.metadata_length = self->sites.metadata_offset[site_j];
 
-    if (self->sites->num_rows < num_input_sites) {
+    if (self->sites.num_rows < num_input_sites) {
         // Remap sites in the mutation table
         // (but only if there's been any changed sites)
-        for (j = 0; j < self->mutations->num_rows; j++) {
-            k = self->mutations->site[j];
-            assert(k < num_input_sites);
-            self->mutations->site[j] = self->site_id_map[k];
+        for (j = 0; j < self->mutations.num_rows; j++) {
+            mutation_site = self->mutations.site[j];
+            self->mutations.site[j] = site_id_map[self->mutations.site[j]];
         }
     }
-
 out:
-    return ret;
-}
-
-static int 
-table_cleaner_alloc(table_cleaner_t *self, 
-        site_table_t *sites,
-        mutation_table_t *mutations) {
-    int ret = 0;
-
-    memset(self, 0, sizeof(table_cleaner_t));
-    if (sites == NULL || mutations == NULL) {
-        ret = MSP_ERR_BAD_PARAM_VALUE;
-        goto out;
-    }
-    self->sites = sites;
-    self->mutations = mutations;
-
-    self->site_id_map = malloc(sites->num_rows * sizeof(site_id_t));
-    if (self->site_id_map == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-
-out:
-    return ret;
-}
-
-static void
-table_cleaner_free(table_cleaner_t *self)
-{
-    msp_safe_free(self->site_id_map);
-}
-
-int
-clean_tables(site_table_t *sites, mutation_table_t *mutations)
-{
-    int ret = 0;
-    table_cleaner_t *cleaner = NULL;
-
-    cleaner = malloc(sizeof(table_cleaner_t));
-    if (cleaner == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-
-    ret = table_cleaner_alloc(cleaner, sites, mutations);
-    if (ret != 0) {
-        goto out;
-    }
-
-    ret = table_cleaner_run(cleaner);
-
-out:
-    if (cleaner != NULL) {
-        table_cleaner_free(cleaner);
-        free(cleaner);
-    }
+    msp_safe_free(site_id_map);
     return ret;
 }

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -375,6 +375,7 @@ int table_collection_copy(table_collection_t *self, table_collection_t *dest);
 int table_collection_free(table_collection_t *self);
 int table_collection_simplify(table_collection_t *self,
         node_id_t *samples, size_t num_samples, int flags, node_id_t *node_map);
+int table_collection_deduplicate_sites(table_collection_t *tables, int flags);
 
 int simplifier_alloc(simplifier_t *self, double sequence_length,
         node_id_t *samples, size_t num_samples,
@@ -388,7 +389,6 @@ int sort_tables(node_table_t *nodes, edge_table_t *edges, migration_table_t *mig
         site_table_t *sites, mutation_table_t *mutations, size_t edge_start);
 int squash_edges(edge_t *edges, size_t num_edges, size_t *num_output_edges);
 
-int clean_tables(site_table_t *sites, mutation_table_t *mutations);
 
 #ifdef __cplusplus
 }

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -259,13 +259,13 @@ typedef struct {
 } simplifier_t;
 
 int node_table_alloc(node_table_t *self, size_t max_rows_increment,
-        size_t max_name_length_increment);
+        size_t max_metadata_length_increment);
 node_id_t node_table_add_row(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, const char *name, size_t name_length);
+        population_id_t population, const char *metadata, size_t metadata_length);
 int node_table_set_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, char *name, table_size_t *name_length);
+        population_id_t *population, const char *metadata, table_size_t *metadata_length);
 int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, char *name, table_size_t *name_length);
+        population_id_t *population, const char *metadata, table_size_t *metadata_length);
 int node_table_clear(node_table_t *self);
 int node_table_free(node_table_t *self);
 int node_table_dump_text(node_table_t *self, FILE *out);
@@ -387,6 +387,8 @@ void simplifier_print_state(simplifier_t *self, FILE *out);
 int sort_tables(node_table_t *nodes, edge_table_t *edges, migration_table_t *migrations,
         site_table_t *sites, mutation_table_t *mutations, size_t edge_start);
 int squash_edges(edge_t *edges, size_t num_edges, size_t *num_output_edges);
+
+int clean_tables(site_table_t *sites, mutation_table_t *mutations);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is WIP - not tested - but I'm putting it here now for comments on the API, the structure, and whether we want it in tskit at all.

Note that it really should update the site table in place, as there's no reason it can't do that; but currently it makes a new table and copies it back over.

I'm calling it "clean tables" because (a) it's shorter than "remove_duplicate_sites_in_tables" or equivalent, and (b) we could potentially add other "cleaning" operations to this one thing (although maybe those should just all be separate).  Feel free to complain about this.