### PR TITLE
Added C inteface for 16 bit genotypes.

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -570,10 +570,12 @@ make_variant(variant_t *variant, size_t num_samples)
     PyObject *alleles = make_alleles(variant);
     PyArrayObject *genotypes = (PyArrayObject *) PyArray_SimpleNew(1, &dims, NPY_UINT8);
 
+    /* TODO update this to account for 16 bit variants when we provide the
+     * high-level interface. */
     if (genotypes == NULL || alleles == NULL) {
         goto out;
     }
-    memcpy(PyArray_DATA(genotypes), variant->genotypes, num_samples * sizeof(uint8_t));
+    memcpy(PyArray_DATA(genotypes), variant->genotypes.u8, num_samples * sizeof(uint8_t));
     ret = Py_BuildValue("iOO", variant->site->id, genotypes, alleles);
 out:
     Py_XDECREF(genotypes);
@@ -4723,6 +4725,8 @@ TreeSequence_get_genotype_matrix(TreeSequence  *self)
     variant_t *variant;
     size_t j;
 
+    /* TODO add option for 16 bit genotypes */
+
     if (TreeSequence_check_tree_sequence(self) != 0) {
         goto out;
     }
@@ -4748,7 +4752,7 @@ TreeSequence_get_genotype_matrix(TreeSequence  *self)
     }
     j = 0;
     while ((err = vargen_next(vg, &variant)) == 1) {
-        memcpy(V + (j * num_samples), variant->genotypes, num_samples * sizeof(uint8_t));
+        memcpy(V + (j * num_samples), variant->genotypes.u8, num_samples * sizeof(uint8_t));
         j++;
     }
     if (err != 0) {
@@ -6324,6 +6328,7 @@ VariantGenerator_init(VariantGenerator *self, PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"tree_sequence", NULL};
     TreeSequence *tree_sequence = NULL;
 
+    /* TODO add option for 16 bit genotypes */
     self->variant_generator = NULL;
     self->tree_sequence = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist,

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -9,7 +9,7 @@ EXTRA_CFLAGS=-std=c99 -pedantic -Werror -Wall -W \
 CFLAGS=-g -O2 -DH5_NO_DEPRECATED_SYMBOLS
 LDFLAGS=-lgsl -lgslcblas -lhdf5 -lm
 
-HEADERS=msprime.h util.h
+HEADERS=msprime.h util.h trees.h tables.h
 COMPILED=msprime.o fenwick.o tree_sequence.o object_heap.o newick.o \
     hapgen.o recomb_map.o mutgen.o vargen.o vcf.o ld.o avl.o tables.o util.o
 

--- a/lib/main.c
+++ b/lib/main.c
@@ -614,7 +614,7 @@ print_variants(tree_sequence_t *ts)
         }
         printf("\t");
         for (k = 0; k < ts->num_samples; k++) {
-            printf("%d\t", var->genotypes[k]);
+            printf("%d\t", var->genotypes.u8[k]);
         }
         printf("\n");
     }

--- a/lib/trees.h
+++ b/lib/trees.h
@@ -15,6 +15,8 @@ extern "C" {
 #define MSP_SAMPLE_COUNTS  1
 #define MSP_SAMPLE_LISTS   2
 
+#define MSP_16_BIT_GENOTYPES    1
+
 #define MSP_DIR_FORWARD 1
 #define MSP_DIR_REVERSE -1
 
@@ -197,7 +199,10 @@ typedef struct {
     table_size_t *allele_lengths;
     table_size_t num_alleles;
     table_size_t max_alleles;
-    uint8_t *genotypes;
+    union {
+        uint8_t *u8;
+        uint16_t *u16;
+    } genotypes;
 } variant_t;
 
 typedef struct {

--- a/lib/util.h
+++ b/lib/util.h
@@ -27,6 +27,8 @@
     #define WARN_UNUSED __attribute__ ((warn_unused_result))
 #else
     #define WARN_UNUSED
+    /* Don't bother with restrict for MSVC */
+    #define restrict
 #endif
 
 #define MSP_NODE_IS_SAMPLE 1

--- a/lib/vcf.c
+++ b/lib/vcf.c
@@ -171,7 +171,7 @@ vcf_converter_write_record(vcf_converter_t *self, variant_t *variant)
     for (j = 0; j < self->num_vcf_samples; j++) {
         for (k = 0; k < p; k++) {
             self->vcf_genotypes[2 * p * j + 2 * k] =
-                (char) ('0' + variant->genotypes[j * p + k]);
+                (char) ('0' + variant->genotypes.u8[j * p + k]);
         }
     }
     assert(offset + self->vcf_genotypes_size < self->record_size);

--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ _msprime_module = Extension(
     sources=["_msprimemodule.c"] + [os.path.join(libdir, f) for f in source_files],
     # Enable asserts by default.
     undef_macros=["NDEBUG"],
+    extra_compile_args=["-std=c99"],
     define_macros=DefineMacros(),
     libraries=["gsl", "gslcblas", "hdf5"],
     include_dirs=[libdir] + configurator.include_dirs,


### PR DESCRIPTION
Allow for optional 16 bit genotypes in the C API by adding a flag to vargen_alloc, ``MSP_16BIT_GENOTYPES`` and making the ``genotypes`` field in the ``variant_t`` struct a union. Thus, client code must now use ``variant.genotypes.u8`` or ``variant.genotypes.u16`` to access the genotypes, depending on the size required.

This seems like a good compromise between efficiency in the (vastly) common case of 8 bit genotypes, but allowing for cases in which we can have more than 255 alleles.

Note that the algorithm for matching alleles will not be efficient for large numbers of alleles. If this becomes a problem, we'll need to use a hash table or something.

Closes #466. cc @bhaller.