### PR TITLE
Text input method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -184,6 +184,13 @@ instances to define special values of various variables.
     defined, or population information was not available in the underlying tree
     sequence.
 
+.. data:: msprime.NULL_INDIVIDUAL == -1
+
+    Special reserved value, representing the null individual ID. This value is
+    returned if the individual associated with a particular node is not
+    defined, or individual information was not available in the underlying tree
+    sequence.
+
 .. data:: msprime.NULL_MUTATION == -1
 
     Special reserved value, representing the null mutation ID. If there is a

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -2482,7 +2482,7 @@ msp_populate_tables(msp_t *self, recomb_map_t *recomb_map, node_table_t *nodes,
     for (j = 0; j < self->num_nodes; j++) {
         node = self->nodes + j;
         ret = node_table_add_row(nodes, node->flags, node->time, node->population,
-                NULL, 0);
+                MSP_NULL_INDIVIDUAL, NULL, 0);
         if (ret < 0) {
             goto out;
         }

--- a/lib/table_example.c
+++ b/lib/table_example.c
@@ -26,7 +26,8 @@ main(int argc, char **argv)
     for (j = 0; j < 10; j++) {
         /* node and edge_table_add_row return < 0 in the case of an error,
          * or the ID of the node/edge just added otherwise. */
-        ret = node_table_add_row(&tables.nodes, j == 0, j, 0, NULL, 0);
+        ret = node_table_add_row(&tables.nodes, j == 0, j, 0, MSP_NULL_INDIVIDUAL,
+                NULL, 0);
         if (ret < 0) {
             goto out;
         }

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -184,6 +184,69 @@ out:
     return ret;
 }
 
+/* ****
+ * Tab-separated parsing:
+ * These will be used on null-terminated strings, which are included,
+ * so `end`, if not NULL, will always be at least one before the end
+ * of the string.
+ *
+ * These return: 
+ *   1 if `sep` is found and delimits a nonzero-length token; 
+ *   0 if `sep` is found as the first character;
+ *   and -1 otherwise.
+ * ***/
+
+int
+get_sep_atoi(char **start, int *out, int sep)
+{
+    int ret;
+    char *next;
+    next = strchr(*start, sep);
+    if (next == NULL) {
+        ret = -1;
+    } else {
+        ret = (int) (next != *start);
+        *next = '\0';
+    }
+    *out = atoi(*start);
+    *start = (next == NULL) ? NULL : next + 1;
+    return ret;
+}
+
+int
+get_sep_atof(char **start, double *out, int sep)
+{
+    int ret;
+    char *next;
+    next = strchr(*start, sep);
+    if (next == NULL) {
+        ret = -1;
+    } else {
+        ret = (int) (next != *start);
+        *next = '\0';
+    }
+    *out = atof(*start);
+    *start = (next == NULL) ? NULL : next + 1;
+    return ret;
+}
+
+int
+get_sep_atoa(char **start, char **out, int sep)
+{
+    int ret;
+    char *next;
+    next = strchr(*start, sep);
+    if (next == NULL) {
+        ret = -1;
+    } else {
+        ret = (int) (next != *start);
+        *next = '\0';
+    }
+    *out = *start;
+    *start = (next == NULL) ? NULL : next + 1;
+    return ret;
+}
+
 
 /*************************
  * node table
@@ -458,7 +521,7 @@ node_table_print_state(node_table_t *self, FILE *out)
 int
 node_table_dump_text(node_table_t *self, FILE *out)
 {
-    int ret = 0;
+    int ret = MSP_ERR_IO;
     size_t j;
     table_size_t metadata_len;
     int err;
@@ -469,7 +532,7 @@ node_table_dump_text(node_table_t *self, FILE *out)
     }
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%d\t%f\t%d\t%d\t%.*s\n", (int) j,
+        err = fprintf(out, "%d\t%d\t%.17g\t%d\t%d\t%.*s\n", (int) j,
                 (int) (self->flags[j] & MSP_NODE_IS_SAMPLE),
                 self->time[j], self->population[j], self->individual[j],
                 metadata_len, self->metadata + self->metadata_offset[j]);
@@ -479,6 +542,75 @@ node_table_dump_text(node_table_t *self, FILE *out)
     }
     ret = 0;
 out:
+    return ret;
+}
+
+int
+node_table_load_text(node_table_t *node_table, FILE *file)
+{
+    int ret = MSP_ERR_FILE_FORMAT;
+    int err;
+    size_t k;
+    size_t MAX_LINE = 1024;
+    char *line = NULL;
+    double time;
+    int flags, population, individual, id, is_sample;
+    char *name;
+    const char *header = "id\tis_sample\ttime\tpopulation\tindividual\tmetadata\n";
+    char *start;
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = node_table_clear(node_table);
+    if (ret < 0) {
+        goto out;
+    }
+
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atoi(&start, &id, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &is_sample, '\t');
+        flags = (is_sample && MSP_NODE_IS_SAMPLE);
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atof(&start, &time, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &population, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &individual, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &name, '\n');
+        if (err < 0 || *start != '\0') {
+            goto out;
+        }
+        ret = node_table_add_row(node_table, flags, time, population, individual,
+                name, strlen(name));
+        assert(ret >= 0);
+    }
+    ret = 0;
+out:
+    free(line);
     return ret;
 }
 
@@ -702,7 +834,7 @@ edge_table_dump_text(edge_table_t *self, FILE *out)
         goto out;
     }
     for (j = 0; j < self->num_rows; j++) {
-        err = fprintf(out, "%.3f\t%.3f\t%d\t%d\n", self->left[j], self->right[j],
+        err = fprintf(out, "%.17g\t%.17g\t%d\t%d\n", self->left[j], self->right[j],
                 self->parent[j], self->child[j]);
         if (err < 0) {
             goto out;
@@ -712,6 +844,70 @@ edge_table_dump_text(edge_table_t *self, FILE *out)
 out:
     return ret;
 }
+
+int
+edge_table_load_text(edge_table_t *edge_table, FILE *file)
+{
+    int ret = MSP_ERR_FILE_FORMAT;
+    int err;
+    size_t k;
+    size_t MAX_LINE = 1024;
+    char *line = NULL;
+    double left, right;
+    node_id_t parent, child;
+    uint32_t num_children;
+    const char *header = "left\tright\tparent\tchild\n";
+    char *start, *childs;
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = edge_table_clear(edge_table);
+    if (ret < 0) {
+        goto out;
+    }
+    
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atof(&start, &left, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atof(&start, &right, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &parent, '\t');
+        if (err <= 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &childs, '\n');
+        if (err < 0) {
+            goto out;
+        }
+        do {
+            err = get_sep_atoi(&childs, &child, ',');
+            ret = edge_table_add_row(edge_table, left, right, parent, child);
+            assert(ret >= 0);
+        } while (err > 0);
+        assert(err == -1);
+    }
+    ret = 0;
+out:
+    free(line);
+    return ret;
+}
+
 
 bool
 edge_table_equal(edge_table_t *self, edge_table_t *other)
@@ -1067,7 +1263,7 @@ site_table_print_state(site_table_t *self, FILE *out)
             (int) self->ancestral_state_length,
             (int) self->max_ancestral_state_length,
             (int) self->max_ancestral_state_length_increment);
-    fprintf(out, "metadata_length = %d(\tmax= %d\tincrement = %d)\n",
+    fprintf(out, "metadata_length = %d\t(max= %d\tincrement = %d)\n",
             (int) self->metadata_length,
             (int) self->max_metadata_length,
             (int) self->max_metadata_length_increment);
@@ -1098,7 +1294,7 @@ site_table_dump_text(site_table_t *self, FILE *out)
         ancestral_state_len = self->ancestral_state_offset[j + 1] -
             self->ancestral_state_offset[j];
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%f\t%.*s\t%.*s\n", (int) j, self->position[j],
+        err = fprintf(out, "%d\t%.17g\t%.*s\t%.*s\n", (int) j, self->position[j],
                 ancestral_state_len, self->ancestral_state + self->ancestral_state_offset[j],
                 metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
@@ -1107,6 +1303,66 @@ site_table_dump_text(site_table_t *self, FILE *out)
     }
     ret = 0;
 out:
+    return ret;
+}
+
+int
+site_table_load_text(site_table_t *site_table, FILE *file)
+{
+    int ret = MSP_ERR_FILE_FORMAT;
+    int err;
+    size_t k;
+    size_t MAX_LINE = 1024;
+    char *line = NULL;
+    int id;
+    double position;
+    char *ancestral_state, *metadata;
+    const char *header = "id\tposition\tancestral_state\tmetadata\n";
+    char *start;
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = site_table_clear(site_table);
+    if (ret < 0) {
+        goto out;
+    }
+    
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atoi(&start, &id, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atof(&start, &position, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &ancestral_state, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &metadata, '\n');
+        if (err < 0 || *start != '\0') {
+            goto out;
+        }
+        ret = site_table_add_row(site_table, position, ancestral_state,
+                strlen(ancestral_state), metadata, strlen(metadata));
+        assert(ret >= 0);
+    }
+    ret = 0;
+out:
+    free(line);
     return ret;
 }
 
@@ -1527,6 +1783,79 @@ out:
     return ret;
 }
 
+int
+mutation_table_load_text(mutation_table_t *mutation_table, FILE *file)
+{
+    int ret = MSP_ERR_FILE_FORMAT;
+    int err;
+    size_t k;
+    size_t MAX_LINE = 1024;
+    char *line;
+    const char *tabsep = "\t\n";
+    int id;
+    node_id_t node;
+    site_id_t site;
+    mutation_id_t parent;
+    char *derived_state, *metadata;
+    const char *header = "id\tsite\tnode\tparent\tderived_state\tmetadata\n";
+    char *start;
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = mutation_table_clear(mutation_table);
+    if (ret < 0) {
+        goto out;
+    }
+    
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atoi(&start, &id, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &site, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &node, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &parent, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &derived_state, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &metadata, '\n');
+        if (err < 0 || *start != '\0') {
+            goto out;
+        }
+        ret = mutation_table_add_row(mutation_table, site, node, parent,
+                derived_state, strlen(derived_state), metadata, strlen(metadata));
+        if (ret < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    free(line);
+    return ret;
+}
+
 static int
 mutation_table_dump(mutation_table_t *self, kastore_t *store)
 {
@@ -1750,7 +2079,7 @@ migration_table_dump_text(migration_table_t *self, FILE *out)
         goto out;
     }
     for (j = 0; j < self->num_rows; j++) {
-        err = fprintf(out, "%.3f\t%.3f\t%d\t%d\t%d\t%f\n", self->left[j],
+        err = fprintf(out, "%.17g\t%.17g\t%d\t%d\t%d\t%.17g\n", self->left[j],
                 self->right[j], (int) self->node[j], (int) self->source[j],
                 (int) self->dest[j], self->time[j]);
         if (err < 0) {
@@ -1759,6 +2088,73 @@ migration_table_dump_text(migration_table_t *self, FILE *out)
     }
     ret = 0;
 out:
+    return ret;
+}
+
+int
+migration_table_load_text(migration_table_t *migration_table, FILE *file)
+{
+    int ret = MSP_ERR_FILE_FORMAT;
+    int err;
+    size_t k;
+    size_t MAX_LINE = 1024;
+    char *line = NULL;
+    double left, right, time;
+    int node, source, dest;
+    const char *header = "left\tright\tnode\tsource\tdest\ttime\n";
+    char *start;
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = migration_table_clear(migration_table);
+    if (ret < 0) {
+        goto out;
+    }
+
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atof(&start, &left, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atof(&start, &right, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &node, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &source, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &dest, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atof(&start, &time, '\n');
+        if (err < 0) {
+            goto out;
+        }
+        ret = migration_table_add_row(migration_table, left, right, node,
+                source, dest, time);
+        assert(ret >= 0);
+    }
+    ret = 0;
+out:
+    free(line);
     return ret;
 }
 
@@ -2104,7 +2500,7 @@ individual_table_print_state(individual_table_t *self, FILE *out)
 int
 individual_table_dump_text(individual_table_t *self, FILE *out)
 {
-    int ret = 0;
+    int ret = MSP_ERR_IO;
     size_t j, k;
     table_size_t metadata_len;
     int err;
@@ -2120,7 +2516,7 @@ individual_table_dump_text(individual_table_t *self, FILE *out)
             goto out;
         }
         for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
-            fprintf(out, "%f", self->location[k]);
+            fprintf(out, "%.17g", self->location[k]);
             if (k + 1 < self->location_offset[j + 1]) {
                 fprintf(out, ",");
             }
@@ -2134,6 +2530,75 @@ individual_table_dump_text(individual_table_t *self, FILE *out)
     }
     ret = 0;
 out:
+    return ret;
+}
+
+int
+individual_table_load_text(individual_table_t *individual_table, FILE *file)
+{
+    int ret = MSP_ERR_FILE_FORMAT;
+    int err;
+    size_t j, k;
+    size_t MAX_LINE = 1024;
+    char *line, *start, *loc;
+    const char *tabsep = "\t\n";
+    double location[MAX_LINE];
+    int flags, id;
+    char *metadata;
+    const char *header = "id\tflags\tlocation\tmetadata\n";
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = individual_table_clear(individual_table);
+    if (ret < 0) {
+        goto out;
+    }
+    
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atoi(&start, &id, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoi(&start, &flags, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        j = 0;
+        err = get_sep_atoa(&start, &loc, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        if (err > 0) {
+            while ((err = get_sep_atof(&loc, location + j, ',')) > 0) {
+                j++;
+            }
+            if (err < 0) {
+                goto out;
+            }
+        }
+        err = get_sep_atoa(&start, &metadata, '\n');
+        if (err < 0 || *start != '\0') {
+            goto out;
+        }
+        ret = individual_table_add_row(individual_table, flags, location, j,
+                metadata, strlen(metadata));
+        assert(ret >= 0);
+    }
+    ret = 0;
+out:
+    free(line);
     return ret;
 }
 
@@ -2484,6 +2949,83 @@ provenance_table_print_state(provenance_table_t *self, FILE *out)
     assert(self->timestamp_offset[self->num_rows] == self->timestamp_length);
     assert(self->record_offset[0] == 0);
     assert(self->record_offset[self->num_rows] == self->record_length);
+}
+
+int
+provenance_table_dump_text(provenance_table_t *self, FILE *out)
+{
+    int ret = MSP_ERR_IO;
+    int err;
+    size_t j;
+    table_size_t timestamp_len, record_len;
+
+    err = fprintf(out, "record\ttimestamp\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        record_len = self->record_offset[j + 1] -
+            self->record_offset[j];
+        timestamp_len = self->timestamp_offset[j + 1] - self->timestamp_offset[j];
+        err = fprintf(out, "%.*s\t%.*s\n", record_len, self->record + self->record_offset[j],
+                timestamp_len, self->timestamp + self->timestamp_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+int
+provenance_table_load_text(provenance_table_t *provenance_table, FILE *file)
+{
+    int ret = MSP_ERR_IO;
+    int err;
+    size_t c, k;
+    size_t MAX_LINE = 1024;
+    char *line = NULL;
+    char *record, *timestamp;
+    char *start;
+    const char *header = "record\ttimestamp\n";
+
+    line = malloc(MAX_LINE);
+    k = MAX_LINE;
+
+    ret = provenance_table_clear(provenance_table);
+    if (ret < 0) {
+        goto out;
+    }
+    
+    // check the header
+    err = getline(&line, &k, file);
+    if (err < 0) {
+        goto out;
+    }
+    err = strcmp(line, header);
+    if (err != 0) {
+        goto out;
+    }
+
+    while ((err = getline(&line, &k, file)) != -1) {
+        start = line;
+        err = get_sep_atoa(&start, &record, '\t');
+        if (err < 0) {
+            goto out;
+        }
+        err = get_sep_atoa(&start, &timestamp, '\n');
+        if (err < 0 || *start != '\0') {
+            goto out;
+        }
+        ret = provenance_table_add_row(provenance_table, timestamp, strlen(timestamp), 
+                record, strlen(record));
+        assert(ret >= 0);
+    }
+    ret = 0;
+out:
+    free(line);
+    return ret;
 }
 
 bool
@@ -4820,5 +5362,75 @@ table_collection_compute_mutation_parents(table_collection_t *self, int flags)
 out:
     msp_safe_free(parent);
     msp_safe_free(bottom_mutation);
+    return ret;
+}
+
+
+/*************************
+ * load_text
+ *************************/
+
+
+/****
+ * Simple utilities to parse text, mostly for debugging purposes.
+ * General assumptions:
+ *  files are strictly tab-separated (columns separated by exactly one tab)
+ *  columns are in the expected order
+ *  only the last column (metadata) is optional
+ ****/
+
+
+int
+table_collection_load_text(table_collection_t *tables, FILE *nodes, FILE *edges,
+        FILE *sites, FILE *mutations, FILE *migrations, FILE *individuals, 
+        FILE *provenances)
+{
+    int ret;
+    int j;
+    double sequence_length;
+
+    ret = node_table_load_text(&tables->nodes, nodes);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = edge_table_load_text(&tables->edges, edges);
+    if (ret != 0) {
+        goto out;
+    }
+    if (sites != NULL) {
+        ret = site_table_load_text(&tables->sites, sites);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (mutations != NULL) {
+        ret = mutation_table_load_text(&tables->mutations, mutations);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (individuals != NULL) {
+        ret = individual_table_load_text(&tables->individuals, individuals);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    if (provenances != NULL) {
+        ret = provenance_table_load_text(&tables->provenances, provenances);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+    /* infer sequence length from the edges */
+    sequence_length = 0.0;
+    for (j = 0; j < tables->edges.num_rows; j++) {
+        sequence_length = MSP_MAX(sequence_length, tables->edges.right[j]);
+    }
+    if (sequence_length <= 0.0) {
+        ret = MSP_ERR_BAD_SEQUENCE_LENGTH;
+        goto out;
+    }
+    tables->sequence_length = sequence_length;
+out :
     return ret;
 }

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -1220,7 +1220,7 @@ mutation_table_expand_metadata(mutation_table_t *self, size_t additional_length)
         if (ret != 0) {
             goto out;
         }
-        self->max_metadata_length = (table_size_t) new_size;
+        self->max_metadata_length = new_size;
     }
 out:
     return ret;
@@ -1809,8 +1809,8 @@ individual_table_expand_main_columns(individual_table_t *self, table_size_t addi
         if (ret != 0) {
             goto out;
         }
-        ret = expand_column((void **) &self->location, new_size,
-                self->spatial_dimension * sizeof(double));
+        ret = expand_column((void **) &self->location_offset, new_size + 1,
+                sizeof(table_size_t));
         if (ret != 0) {
             goto out;
         }
@@ -1826,6 +1826,25 @@ out:
 }
 
 static int
+individual_table_expand_location(individual_table_t *self, table_size_t additional_length)
+{
+    int ret = 0;
+    table_size_t increment = MSP_MAX(additional_length,
+            self->max_location_length_increment);
+    table_size_t new_size = self->max_location_length + increment;
+
+    if ((self->location_length + additional_length) > self->max_location_length) {
+        ret = expand_column((void **) &self->location, new_size, sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_location_length = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
 individual_table_expand_metadata(individual_table_t *self, table_size_t additional_length)
 {
     int ret = 0;
@@ -1834,7 +1853,7 @@ individual_table_expand_metadata(individual_table_t *self, table_size_t addition
     table_size_t new_size = self->max_metadata_length + increment;
 
     if ((self->metadata_length + additional_length) > self->max_metadata_length) {
-        ret = expand_column((void **) &self->metadata, new_size, sizeof(char *));
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char));
         if (ret != 0) {
             goto out;
         }
@@ -1845,24 +1864,8 @@ out:
 }
 
 int
-individual_table_set_spatial_dimension(individual_table_t *self, table_size_t spatial_dimension)
-{
-    int ret = 0;
-
-    if (spatial_dimension < 0) {
-        ret = MSP_ERR_BAD_PARAM_VALUE;
-        goto out;
-    }
-    self->spatial_dimension = spatial_dimension;
-    ret = expand_column((void **) &self->location, self->max_rows,
-            spatial_dimension * sizeof(double));
-out:
-    return ret;
-}
-
-int
 individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
-        size_t max_metadata_length_increment)
+        size_t max_location_length_increment, size_t max_metadata_length_increment)
 {
     int ret = 0;
 
@@ -1870,23 +1873,30 @@ individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
     if (max_rows_increment == 0) {
        max_rows_increment = DEFAULT_SIZE_INCREMENT;
     }
+    if (max_location_length_increment == 0) {
+        max_location_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
     if (max_metadata_length_increment == 0) {
         max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
     }
     self->max_rows_increment = (table_size_t) max_rows_increment;
+    self->max_location_length_increment = (table_size_t) max_location_length_increment;
     self->max_metadata_length_increment = (table_size_t) max_metadata_length_increment;
     self->max_rows = 0;
     self->num_rows = 0;
+    self->max_location_length = 0;
+    self->location_length = 0;
     self->max_metadata_length = 0;
     self->metadata_length = 0;
-    ret = individual_table_set_spatial_dimension(self, 0);
-    if (ret != 0) {
-        goto out;
-    }
     ret = individual_table_expand_main_columns(self, 1);
     if (ret != 0) {
         goto out;
     }
+    ret = individual_table_expand_location(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->location_offset[0] = 0;
     ret = individual_table_expand_metadata(self, 1);
     if (ret != 0) {
         goto out;
@@ -1900,13 +1910,12 @@ int WARN_UNUSED
 individual_table_copy(individual_table_t *self, individual_table_t *dest)
 {
     return individual_table_set_columns(dest, self->num_rows, self->flags,
-            self->spatial_dimension, self->location,
-            self->metadata, self->metadata_offset);
+            self->location, self->location_offset, self->metadata, self->metadata_offset);
 }
 
 int WARN_UNUSED
 individual_table_set_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
-        table_size_t spatial_dimension, double *location,
+        double *location, uint32_t *location_offset,
         const char *metadata, uint32_t *metadata_offset)
 {
     int ret;
@@ -1915,29 +1924,24 @@ individual_table_set_columns(individual_table_t *self, size_t num_rows, uint32_t
     if (ret != 0) {
         goto out;
     }
-    ret = individual_table_set_spatial_dimension(self, spatial_dimension);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = individual_table_append_columns(self, num_rows, flags, location, metadata,
-            metadata_offset);
+    ret = individual_table_append_columns(self, num_rows, flags, location, location_offset,
+            metadata, metadata_offset);
 out:
     return ret;
 }
 
 int
 individual_table_append_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
-        double *location, const char *metadata, uint32_t *metadata_offset)
+        double *location, uint32_t *location_offset, const char *metadata, uint32_t *metadata_offset)
 {
     int ret;
-    table_size_t j, metadata_length;
+    table_size_t j, metadata_length, location_length;
 
     if (flags == NULL) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    if ((self->spatial_dimension < 0) ||
-            ((location == NULL) && (self->spatial_dimension != 0))) {
+    if ((location == NULL) != (location_offset == NULL)) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
@@ -1950,9 +1954,26 @@ individual_table_append_columns(individual_table_t *self, size_t num_rows, uint3
         goto out;
     }
     memcpy(self->flags + self->num_rows, flags, num_rows * sizeof(uint32_t));
-    if (self->spatial_dimension > 0) {
-        memcpy(self->location + self->spatial_dimension * self->num_rows, location,
-                num_rows * self->spatial_dimension * sizeof(double));
+    if (location == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->location_offset[self->num_rows + j + 1] = (table_size_t) self->location_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, location_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_rows; j++) {
+            self->location_offset[self->num_rows + j] =
+                (table_size_t) self->location_length + location_offset[j];
+        }
+        location_length = location_offset[num_rows];
+        ret = individual_table_expand_location(self, location_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->location + self->location_length, location, location_length * sizeof(double));
+        self->location_length += location_length;
     }
     if (metadata == NULL) {
         for (j = 0; j < num_rows; j++) {
@@ -1976,6 +1997,7 @@ individual_table_append_columns(individual_table_t *self, size_t num_rows, uint3
         self->metadata_length += metadata_length;
     }
     self->num_rows += (table_size_t) num_rows;
+    self->location_offset[self->num_rows] = self->location_length;
     self->metadata_offset[self->num_rows] = self->metadata_length;
 out:
     return ret;
@@ -1983,16 +2005,17 @@ out:
 
 static individual_id_t
 individual_table_add_row_internal(individual_table_t *self, uint32_t flags, double *location,
-        const char *metadata, table_size_t metadata_length)
+        table_size_t location_length, const char *metadata, table_size_t metadata_length)
 {
     int k;
     assert(self->num_rows < self->max_rows);
     assert(self->metadata_length + metadata_length <= self->max_metadata_length);
-    memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
+    assert(self->location_length + location_length <= self->max_location_length);
     self->flags[self->num_rows] = flags;
-    for (k = 0; k < self->spatial_dimension; k++) {
-        self->location[self->spatial_dimension * self->num_rows + k] = location[k];
-    }
+    memcpy(self->location + self->location_length, location, location_length * sizeof(double));
+    self->location_offset[self->num_rows + 1] = self->location_length + location_length;
+    self->location_length += location_length;
+    memcpy(self->metadata + self->metadata_length, metadata, metadata_length * sizeof(char));
     self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
     self->metadata_length += metadata_length;
     self->num_rows++;
@@ -2001,7 +2024,7 @@ individual_table_add_row_internal(individual_table_t *self, uint32_t flags, doub
 
 individual_id_t
 individual_table_add_row(individual_table_t *self, uint32_t flags, double *location,
-        const char *metadata, size_t metadata_length)
+        size_t location_length, const char *metadata, size_t metadata_length)
 {
     int ret = 0;
 
@@ -2009,12 +2032,16 @@ individual_table_add_row(individual_table_t *self, uint32_t flags, double *locat
     if (ret != 0) {
         goto out;
     }
+    ret = individual_table_expand_location(self, (table_size_t) location_length);
+    if (ret != 0) {
+        goto out;
+    }
     ret = individual_table_expand_metadata(self, (table_size_t) metadata_length);
     if (ret != 0) {
         goto out;
     }
-    ret = individual_table_add_row_internal(self, flags, location, metadata,
-            (table_size_t) metadata_length);
+    ret = individual_table_add_row_internal(self, flags, location,
+            (table_size_t) location_length, metadata, (table_size_t) metadata_length);
 out:
     return ret;
 }
@@ -2025,7 +2052,7 @@ individual_table_clear(individual_table_t *self)
     int ret = 0;
     self->num_rows = 0;
     self->metadata_length = 0;
-    ret = individual_table_set_spatial_dimension(self, 0);
+    self->location_length = 0;
     return ret;
 }
 
@@ -2035,6 +2062,7 @@ individual_table_free(individual_table_t *self)
     if (self->max_rows > 0) {
         msp_safe_free(self->flags);
         msp_safe_free(self->location);
+        msp_safe_free(self->location_offset);
         msp_safe_free(self->metadata);
         msp_safe_free(self->metadata_offset);
     }
@@ -2048,7 +2076,6 @@ individual_table_print_state(individual_table_t *self, FILE *out)
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "individual_table: %p:\n", (void *) self);
-    fprintf(out, "spatial_dimension = %d\n", self->spatial_dimension);
     fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
             (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
     fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
@@ -2057,46 +2084,36 @@ individual_table_print_state(individual_table_t *self, FILE *out)
             (int) self->max_metadata_length_increment);
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here because we want to output
-     * the metadata offset column. */
-    fprintf(out, "id\tflags\t");
-    for (i = 0; i < self->spatial_dimension; i++) {
-        fprintf(out, "location_%d\t", i);
-    }
+     * the offset columns. */
+    fprintf(out, "id\tflags\tlocation_offset\tlocation\t");
     fprintf(out, "metadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
         fprintf(out, "%d\t%d\t", (int) j, self->flags[j]);
-        for (i = 0; i < self->spatial_dimension; i++) {
-            fprintf(out, "%f\t", self->location[j * self->spatial_dimension + i]);
+        fprintf(out, "%d\t", self->location_offset[j]);
+        for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
+            fprintf(out, "%f", self->location[k]);
+            if (k + 1 < self->location_offset[j + 1]) {
+                fprintf(out, ",");
+            }
         }
+        fprintf(out, "\t");
         fprintf(out, "%d\t", self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }
         fprintf(out, "\n");
     }
-    assert(self->metadata_offset[0] == 0);
-    assert(self->metadata_offset[self->num_rows] == self->metadata_length);
 }
 
 int
 individual_table_dump_text(individual_table_t *self, FILE *out)
 {
     int ret = 0;
-    size_t i, j;
+    size_t j, k;
     table_size_t metadata_len;
     int err;
 
-    err = fprintf(out, "id\tflags\t");
-    if (err < 0) {
-        goto out;
-    }
-    for (i = 0; i < self->spatial_dimension; i++) {
-        err = fprintf(out, "location_%d\t", i);
-        if (err < 0) {
-            goto out;
-        }
-    }
-    err = fprintf(out, "metadata\n");
+    err = fprintf(out, "id\tflags\tlocation\tmetadata\n");
     if (err < 0) {
         goto out;
     }
@@ -2106,12 +2123,13 @@ individual_table_dump_text(individual_table_t *self, FILE *out)
         if (err < 0) {
             goto out;
         }
-        for (i = 0; i < self->spatial_dimension; i++) {
-            err = fprintf(out, "%f\t", self->location[j * self->spatial_dimension + i]);
-            if (err < 0) {
-                goto out;
+        for (k = self->location_offset[j]; k < self->location_offset[j + 1]; k++) {
+            fprintf(out, "%f", self->location[k]);
+            if (k + 1 < self->location_offset[j + 1]) {
+                fprintf(out, ",");
             }
         }
+        fprintf(out, "\t");
         err = fprintf(out, "%.*s\n",
                 metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
@@ -2131,8 +2149,10 @@ individual_table_equal(individual_table_t *self, individual_table_t *other)
             && self->metadata_length == other->metadata_length) {
         ret = memcmp(self->flags, other->flags,
                     self->num_rows * sizeof(uint32_t)) == 0
+            && memcmp(self->location_offset, other->location_offset,
+                    (self->num_rows + 1) * sizeof(table_size_t)) == 0
             && memcmp(self->location, other->location,
-                    self->num_rows * self->spatial_dimension * sizeof(double)) == 0
+                    self->location_length * sizeof(double)) == 0
             && memcmp(self->metadata_offset, other->metadata_offset,
                     (self->num_rows + 1) * sizeof(table_size_t)) == 0
             && memcmp(self->metadata, other->metadata,
@@ -2145,10 +2165,10 @@ static int
 individual_table_dump(individual_table_t *self, kastore_t *store)
 {
     write_table_col_t write_cols[] = {
-        {"individuals/spatial_dimension", (void *) &(self->spatial_dimension), 1, KAS_UINT32},
         {"individuals/flags", (void *) self->flags, self->num_rows, KAS_UINT32},
-        {"individuals/location", (void *) self->location,
-            self->num_rows * self->spatial_dimension, KAS_FLOAT64},
+        {"individuals/location", (void *) self->location, self->location_length, KAS_FLOAT64},
+        {"individuals/location_offset", (void *) self->location_offset, self->num_rows + 1,
+            KAS_UINT32},
         {"individuals/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8},
         {"individuals/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
             KAS_UINT32},
@@ -2160,25 +2180,14 @@ static int
 individual_table_load(individual_table_t *self, kastore_t *store)
 {
     int ret;
-    uint32_t *spatial_dimension;
     size_t len;
-
-    ret = kastore_gets_uint32(store, "individuals/spatial_dimension",
-            &spatial_dimension, &len);
-    if (ret != 0) {
-        ret = msp_set_kas_error(ret);
-        goto out;
-    }
-    if (len != 1) {
-        ret = MSP_ERR_FILE_FORMAT;
-        goto out;
-    }
-    self->spatial_dimension = (table_size_t) *spatial_dimension;
 
     read_table_col_t read_cols[] = {
         {"individuals/flags", (void **) &self->flags, &self->num_rows, 0, 1, KAS_UINT32},
-        {"individuals/location", (void **) &self->location, &self->num_rows, 0,
-            self->spatial_dimension, KAS_FLOAT64},
+        {"individuals/location", (void **) &self->location, &self->location_length, 0,
+            1, KAS_FLOAT64},
+        {"individuals/location_offset", (void **) &self->location_offset, &self->num_rows,
+            1, 1, KAS_UINT32},
         {"individuals/metadata", (void **) &self->metadata, &self->metadata_length, 0, 1,
             KAS_UINT8},
         {"individuals/metadata_offset", (void **) &self->metadata_offset, &self->num_rows,
@@ -2228,7 +2237,7 @@ provenance_table_expand_timestamp(provenance_table_t *self, table_size_t additio
     table_size_t new_size = self->max_timestamp_length + increment;
 
     if ((self->timestamp_length + additional_length) > self->max_timestamp_length) {
-        ret = expand_column((void **) &self->timestamp, new_size, sizeof(char *));
+        ret = expand_column((void **) &self->timestamp, new_size, sizeof(char));
         if (ret != 0) {
             goto out;
         }
@@ -2247,7 +2256,7 @@ provenance_table_expand_provenance(provenance_table_t *self, table_size_t additi
     table_size_t new_size = self->max_record_length + increment;
 
     if ((self->record_length + additional_length) > self->max_record_length) {
-        ret = expand_column((void **) &self->record, new_size, sizeof(char *));
+        ret = expand_column((void **) &self->record, new_size, sizeof(char));
         if (ret != 0) {
             goto out;
         }
@@ -4134,7 +4143,7 @@ table_collection_alloc(table_collection_t *self, int flags)
         if (ret != 0) {
             goto out;
         }
-        ret = individual_table_alloc(&self->individuals, 0, 0);
+        ret = individual_table_alloc(&self->individuals, 0, 0, 0);
         if (ret != 0) {
             goto out;
         }

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -548,7 +548,7 @@ out:
 int
 node_table_load_text(node_table_t *node_table, FILE *file)
 {
-    int ret = MSP_ERR_FILE_FORMAT;
+    int ret;
     int err;
     size_t k;
     size_t MAX_LINE = 1024;
@@ -560,6 +560,10 @@ node_table_load_text(node_table_t *node_table, FILE *file)
     char *start;
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = node_table_clear(node_table);
@@ -568,6 +572,7 @@ node_table_load_text(node_table_t *node_table, FILE *file)
     }
 
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -606,7 +611,9 @@ node_table_load_text(node_table_t *node_table, FILE *file)
         }
         ret = node_table_add_row(node_table, flags, time, population, individual,
                 name, strlen(name));
-        assert(ret >= 0);
+        if (ret < 0) {
+            goto out;
+        }
     }
     ret = 0;
 out:
@@ -848,7 +855,7 @@ out:
 int
 edge_table_load_text(edge_table_t *edge_table, FILE *file)
 {
-    int ret = MSP_ERR_FILE_FORMAT;
+    int ret;
     int err;
     size_t k;
     size_t MAX_LINE = 1024;
@@ -860,6 +867,10 @@ edge_table_load_text(edge_table_t *edge_table, FILE *file)
     char *start, *childs;
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = edge_table_clear(edge_table);
@@ -868,6 +879,7 @@ edge_table_load_text(edge_table_t *edge_table, FILE *file)
     }
     
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -898,7 +910,9 @@ edge_table_load_text(edge_table_t *edge_table, FILE *file)
         do {
             err = get_sep_atoi(&childs, &child, ',');
             ret = edge_table_add_row(edge_table, left, right, parent, child);
-            assert(ret >= 0);
+            if (ret < 0) {
+                goto out;
+            }
         } while (err > 0);
         assert(err == -1);
     }
@@ -1309,7 +1323,7 @@ out:
 int
 site_table_load_text(site_table_t *site_table, FILE *file)
 {
-    int ret = MSP_ERR_FILE_FORMAT;
+    int ret;
     int err;
     size_t k;
     size_t MAX_LINE = 1024;
@@ -1321,6 +1335,10 @@ site_table_load_text(site_table_t *site_table, FILE *file)
     char *start;
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = site_table_clear(site_table);
@@ -1329,6 +1347,7 @@ site_table_load_text(site_table_t *site_table, FILE *file)
     }
     
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -1358,7 +1377,9 @@ site_table_load_text(site_table_t *site_table, FILE *file)
         }
         ret = site_table_add_row(site_table, position, ancestral_state,
                 strlen(ancestral_state), metadata, strlen(metadata));
-        assert(ret >= 0);
+        if (ret < 0) {
+            goto out;
+        }
     }
     ret = 0;
 out:
@@ -1786,7 +1807,7 @@ out:
 int
 mutation_table_load_text(mutation_table_t *mutation_table, FILE *file)
 {
-    int ret = MSP_ERR_FILE_FORMAT;
+    int ret;
     int err;
     size_t k;
     size_t MAX_LINE = 1024;
@@ -1801,6 +1822,10 @@ mutation_table_load_text(mutation_table_t *mutation_table, FILE *file)
     char *start;
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = mutation_table_clear(mutation_table);
@@ -1809,6 +1834,7 @@ mutation_table_load_text(mutation_table_t *mutation_table, FILE *file)
     }
     
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -2094,7 +2120,7 @@ out:
 int
 migration_table_load_text(migration_table_t *migration_table, FILE *file)
 {
-    int ret = MSP_ERR_FILE_FORMAT;
+    int ret;
     int err;
     size_t k;
     size_t MAX_LINE = 1024;
@@ -2105,6 +2131,10 @@ migration_table_load_text(migration_table_t *migration_table, FILE *file)
     char *start;
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = migration_table_clear(migration_table);
@@ -2113,6 +2143,7 @@ migration_table_load_text(migration_table_t *migration_table, FILE *file)
     }
 
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -2150,7 +2181,9 @@ migration_table_load_text(migration_table_t *migration_table, FILE *file)
         }
         ret = migration_table_add_row(migration_table, left, right, node,
                 source, dest, time);
-        assert(ret >= 0);
+        if (ret < 0) {
+            goto out;
+        }
     }
     ret = 0;
 out:
@@ -2536,7 +2569,7 @@ out:
 int
 individual_table_load_text(individual_table_t *individual_table, FILE *file)
 {
-    int ret = MSP_ERR_FILE_FORMAT;
+    int ret;
     int err;
     size_t j, k;
     size_t MAX_LINE = 1024;
@@ -2548,6 +2581,10 @@ individual_table_load_text(individual_table_t *individual_table, FILE *file)
     const char *header = "id\tflags\tlocation\tmetadata\n";
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = individual_table_clear(individual_table);
@@ -2556,6 +2593,7 @@ individual_table_load_text(individual_table_t *individual_table, FILE *file)
     }
     
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -2594,7 +2632,9 @@ individual_table_load_text(individual_table_t *individual_table, FILE *file)
         }
         ret = individual_table_add_row(individual_table, flags, location, j,
                 metadata, strlen(metadata));
-        assert(ret >= 0);
+        if (ret < 0) {
+            goto out;
+        }
     }
     ret = 0;
 out:
@@ -2981,7 +3021,7 @@ out:
 int
 provenance_table_load_text(provenance_table_t *provenance_table, FILE *file)
 {
-    int ret = MSP_ERR_IO;
+    int ret;
     int err;
     size_t c, k;
     size_t MAX_LINE = 1024;
@@ -2991,6 +3031,10 @@ provenance_table_load_text(provenance_table_t *provenance_table, FILE *file)
     const char *header = "record\ttimestamp\n";
 
     line = malloc(MAX_LINE);
+    if (line == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     k = MAX_LINE;
 
     ret = provenance_table_clear(provenance_table);
@@ -2999,6 +3043,7 @@ provenance_table_load_text(provenance_table_t *provenance_table, FILE *file)
     }
     
     // check the header
+    ret = MSP_ERR_FILE_FORMAT;
     err = getline(&line, &k, file);
     if (err < 0) {
         goto out;
@@ -3020,7 +3065,9 @@ provenance_table_load_text(provenance_table_t *provenance_table, FILE *file)
         }
         ret = provenance_table_add_row(provenance_table, timestamp, strlen(timestamp), 
                 record, strlen(record));
-        assert(ret >= 0);
+        if (ret < 0) {
+            goto out;
+        }
     }
     ret = 0;
 out:
@@ -5409,6 +5456,12 @@ table_collection_load_text(table_collection_t *tables, FILE *nodes, FILE *edges,
             goto out;
         }
     }
+    if (migrations != NULL) {
+        ret = migration_table_load_text(&tables->migrations, migrations);
+        if (ret != 0) {
+            goto out;
+        }
+    }
     if (individuals != NULL) {
         ret = individual_table_load_text(&tables->individuals, individuals);
         if (ret != 0) {
@@ -5421,10 +5474,13 @@ table_collection_load_text(table_collection_t *tables, FILE *nodes, FILE *edges,
             goto out;
         }
     }
-    /* infer sequence length from the edges */
+    /* infer sequence length from the edges and/or sites */
     sequence_length = 0.0;
     for (j = 0; j < tables->edges.num_rows; j++) {
         sequence_length = MSP_MAX(sequence_length, tables->edges.right[j]);
+    }
+    for (j = 0; j < tables->sites.num_rows; j++) {
+        sequence_length = MSP_MAX(sequence_length, tables->sites.position[j]);
     }
     if (sequence_length <= 0.0) {
         ret = MSP_ERR_BAD_SEQUENCE_LENGTH;

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -103,7 +103,7 @@ expand_column(void **column, size_t new_max_rows, size_t element_size)
     void *tmp;
 
     tmp = realloc((void **) *column, new_max_rows * element_size);
-    if (tmp == NULL && (new_max_rows * element_size > 0)) {
+    if (tmp == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
@@ -117,7 +117,6 @@ typedef struct {
     void **array_dest;
     table_size_t *len_dest;
     table_size_t len_offset;
-    table_size_t len_multiplier;
     int type;
 } read_table_col_t;
 
@@ -146,10 +145,8 @@ read_table_cols(kastore_t *store, read_table_col_t *read_cols, size_t num_cols)
         }
         last_len = *read_cols[j].len_dest;
         if (last_len == (table_size_t) -1) {
-            *read_cols[j].len_dest = (table_size_t) ((len - read_cols[j].len_offset)
-                    / read_cols[j].len_multiplier);
-        } else if ((last_len + read_cols[j].len_offset) * read_cols[j].len_multiplier
-                   != (table_size_t) len) {
+            *read_cols[j].len_dest = (table_size_t) (len - read_cols[j].len_offset);
+        } else if ((last_len + read_cols[j].len_offset) != (table_size_t) len) {
             ret = MSP_ERR_FILE_FORMAT;
             goto out;
         }
@@ -526,16 +523,16 @@ static int
 node_table_load(node_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"nodes/time", (void **) &self->time, &self->num_rows, 0, 1, KAS_FLOAT64},
-        {"nodes/flags", (void **) &self->flags, &self->num_rows, 0, 1, KAS_UINT32},
+        {"nodes/time", (void **) &self->time, &self->num_rows, 0, KAS_FLOAT64},
+        {"nodes/flags", (void **) &self->flags, &self->num_rows, 0, KAS_UINT32},
         {"nodes/population", (void **) &self->population, &self->num_rows, 0,
-            1, KAS_INT32},
+            KAS_INT32},
         {"nodes/individual", (void **) &self->individual, &self->num_rows, 0,
-            1, KAS_INT32},
+            KAS_INT32},
         {"nodes/metadata", (void **) &self->metadata, &self->metadata_length, 0,
-            1, KAS_UINT8},
+            KAS_UINT8},
         {"nodes/metadata_offset", (void **) &self->metadata_offset, &self->num_rows,
-            1, 1, KAS_UINT32},
+            1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -749,10 +746,10 @@ static int
 edge_table_load(edge_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"edges/left", (void **) &self->left, &self->num_rows, 0, 1, KAS_FLOAT64},
-        {"edges/right", (void **) &self->right, &self->num_rows, 0, 1, KAS_FLOAT64},
-        {"edges/parent", (void **) &self->parent, &self->num_rows, 0, 1, KAS_INT32},
-        {"edges/child", (void **) &self->child, &self->num_rows, 0, 1, KAS_INT32},
+        {"edges/left", (void **) &self->left, &self->num_rows, 0, KAS_FLOAT64},
+        {"edges/right", (void **) &self->right, &self->num_rows, 0, KAS_FLOAT64},
+        {"edges/parent", (void **) &self->parent, &self->num_rows, 0, KAS_INT32},
+        {"edges/child", (void **) &self->child, &self->num_rows, 0, KAS_INT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -1133,15 +1130,15 @@ static int
 site_table_load(site_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"sites/position", (void **) &self->position, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"sites/position", (void **) &self->position, &self->num_rows, 0, KAS_FLOAT64},
         {"sites/ancestral_state", (void **) &self->ancestral_state,
-            &self->ancestral_state_length, 0, 1, KAS_UINT8},
+            &self->ancestral_state_length, 0, KAS_UINT8},
         {"sites/ancestral_state_offset", (void **) &self->ancestral_state_offset,
-            &self->num_rows, 1, 1, KAS_UINT32},
+            &self->num_rows, 1, KAS_UINT32},
         {"sites/metadata", (void **) &self->metadata,
-            &self->metadata_length, 0, 1, KAS_UINT8},
+            &self->metadata_length, 0, KAS_UINT8},
         {"sites/metadata_offset", (void **) &self->metadata_offset,
-            &self->num_rows, 1, 1, KAS_UINT32},
+            &self->num_rows, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -1554,17 +1551,17 @@ static int
 mutation_table_load(mutation_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"mutations/site", (void **) &self->site, &self->num_rows, 0, 1, KAS_INT32},
-        {"mutations/node", (void **) &self->node, &self->num_rows, 0, 1, KAS_INT32},
-        {"mutations/parent", (void **) &self->parent, &self->num_rows, 0, 1, KAS_INT32},
+        {"mutations/site", (void **) &self->site, &self->num_rows, 0, KAS_INT32},
+        {"mutations/node", (void **) &self->node, &self->num_rows, 0, KAS_INT32},
+        {"mutations/parent", (void **) &self->parent, &self->num_rows, 0, KAS_INT32},
         {"mutations/derived_state", (void **) &self->derived_state,
-            &self->derived_state_length, 0, 1, KAS_UINT8},
+            &self->derived_state_length, 0, KAS_UINT8},
         {"mutations/derived_state_offset", (void **) &self->derived_state_offset,
-            &self->num_rows, 1, 1, KAS_UINT32},
+            &self->num_rows, 1, KAS_UINT32},
         {"mutations/metadata", (void **) &self->metadata,
-            &self->metadata_length, 0, 1, KAS_UINT8},
+            &self->metadata_length, 0, KAS_UINT8},
         {"mutations/metadata_offset", (void **) &self->metadata_offset,
-            &self->num_rows, 1, 1, KAS_UINT32},
+            &self->num_rows, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -1783,12 +1780,12 @@ static int
 migration_table_load(migration_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"migrations/left", (void **) &self->left, &self->num_rows, 0, 1, KAS_FLOAT64},
-        {"migrations/right", (void **) &self->right, &self->num_rows, 0, 1, KAS_FLOAT64},
-        {"migrations/node", (void **) &self->node, &self->num_rows, 0, 1, KAS_INT32},
-        {"migrations/source", (void **) &self->source, &self->num_rows, 0, 1, KAS_INT32},
-        {"migrations/dest", (void **) &self->dest, &self->num_rows, 0, 1, KAS_INT32},
-        {"migrations/time", (void **) &self->time, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"migrations/left", (void **) &self->left, &self->num_rows, 0, KAS_FLOAT64},
+        {"migrations/right", (void **) &self->right, &self->num_rows, 0, KAS_FLOAT64},
+        {"migrations/node", (void **) &self->node, &self->num_rows, 0, KAS_INT32},
+        {"migrations/source", (void **) &self->source, &self->num_rows, 0, KAS_INT32},
+        {"migrations/dest", (void **) &self->dest, &self->num_rows, 0, KAS_INT32},
+        {"migrations/time", (void **) &self->time, &self->num_rows, 0, KAS_FLOAT64},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -2007,7 +2004,6 @@ static individual_id_t
 individual_table_add_row_internal(individual_table_t *self, uint32_t flags, double *location,
         table_size_t location_length, const char *metadata, table_size_t metadata_length)
 {
-    int k;
     assert(self->num_rows < self->max_rows);
     assert(self->metadata_length + metadata_length <= self->max_metadata_length);
     assert(self->location_length + location_length <= self->max_location_length);
@@ -2072,7 +2068,7 @@ individual_table_free(individual_table_t *self)
 void
 individual_table_print_state(individual_table_t *self, FILE *out)
 {
-    size_t i, j, k;
+    size_t j, k;
 
     fprintf(out, TABLE_SEP);
     fprintf(out, "individual_table: %p:\n", (void *) self);
@@ -2179,24 +2175,18 @@ individual_table_dump(individual_table_t *self, kastore_t *store)
 static int
 individual_table_load(individual_table_t *self, kastore_t *store)
 {
-    int ret;
-    size_t len;
-
     read_table_col_t read_cols[] = {
-        {"individuals/flags", (void **) &self->flags, &self->num_rows, 0, 1, KAS_UINT32},
+        {"individuals/flags", (void **) &self->flags, &self->num_rows, 0, KAS_UINT32},
         {"individuals/location", (void **) &self->location, &self->location_length, 0,
-            1, KAS_FLOAT64},
+            KAS_FLOAT64},
         {"individuals/location_offset", (void **) &self->location_offset, &self->num_rows,
-            1, 1, KAS_UINT32},
-        {"individuals/metadata", (void **) &self->metadata, &self->metadata_length, 0, 1,
+            1, KAS_UINT32},
+        {"individuals/metadata", (void **) &self->metadata, &self->metadata_length, 0, 
             KAS_UINT8},
         {"individuals/metadata_offset", (void **) &self->metadata_offset, &self->num_rows,
-            1, 1, KAS_UINT32},
+            1, KAS_UINT32},
     };
-    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
-
-out:
-    return ret;
+    return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
 
 
@@ -2535,13 +2525,13 @@ provenance_table_load(provenance_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
         {"provenances/timestamp", (void **) &self->timestamp,
-            &self->timestamp_length, 0, 1, KAS_UINT8},
+            &self->timestamp_length, 0, KAS_UINT8},
         {"provenances/timestamp_offset", (void **) &self->timestamp_offset,
-            &self->num_rows, 1, 1, KAS_UINT32},
+            &self->num_rows, 1, KAS_UINT32},
         {"provenances/record", (void **) &self->record,
-            &self->record_length, 0, 1, KAS_UINT8},
+            &self->record_length, 0, KAS_UINT8},
         {"provenances/record_offset", (void **) &self->record_offset,
-            &self->num_rows, 1, 1, KAS_UINT32},
+            &self->num_rows, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -4414,9 +4404,9 @@ table_collection_load_indexes(table_collection_t *self)
 {
     read_table_col_t read_cols[] = {
         {"indexes/edge_insertion_order", (void **) &self->indexes.edge_insertion_order,
-            &self->edges.num_rows, 0, 1, KAS_INT32},
+            &self->edges.num_rows, 0, KAS_INT32},
         {"indexes/edge_removal_order", (void **) &self->indexes.edge_removal_order,
-            &self->edges.num_rows, 0, 1, KAS_INT32},
+            &self->edges.num_rows, 0, KAS_INT32},
     };
     self->indexes.malloced_locally = false;
     return read_table_cols(&self->store, read_cols, sizeof(read_cols) / sizeof(*read_cols));

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -212,6 +212,10 @@ node_table_expand_main_columns(node_table_t *self, table_size_t additional_rows)
         if (ret != 0) {
             goto out;
         }
+        ret = expand_column((void **) &self->individual, new_size, sizeof(individual_id_t));
+        if (ret != 0) {
+            goto out;
+        }
         ret = expand_column((void **) &self->metadata_offset, new_size + 1,
                 sizeof(table_size_t));
         if (ret != 0) {
@@ -278,12 +282,14 @@ int WARN_UNUSED
 node_table_copy(node_table_t *self, node_table_t *dest)
 {
     return node_table_set_columns(dest, self->num_rows, self->flags,
-            self->time, self->population, self->metadata, self->metadata_offset);
+            self->time, self->population, self->individual,
+            self->metadata, self->metadata_offset);
 }
 
 int WARN_UNUSED
 node_table_set_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, const char *metadata, uint32_t *metadata_offset)
+        population_id_t *population, individual_id_t *individual, const char *metadata,
+        uint32_t *metadata_offset)
 {
     int ret;
 
@@ -291,15 +297,16 @@ node_table_set_columns(node_table_t *self, size_t num_rows, uint32_t *flags, dou
     if (ret != 0) {
         goto out;
     }
-    ret = node_table_append_columns(self, num_rows, flags, time, population, metadata,
-            metadata_offset);
+    ret = node_table_append_columns(self, num_rows, flags, time, population, individual,
+            metadata, metadata_offset);
 out:
     return ret;
 }
 
 int
 node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, const char *metadata, uint32_t *metadata_offset)
+        population_id_t *population, individual_id_t *individual, const char *metadata,
+        uint32_t *metadata_offset)
 {
     int ret;
     table_size_t j, metadata_length;
@@ -347,6 +354,14 @@ node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, 
         memcpy(self->population + self->num_rows, population,
                 num_rows * sizeof(population_id_t));
     }
+    if (individual == NULL) {
+        /* Set individual to NULL_INDIVIDUAL (-1) if not specified */
+        memset(self->individual + self->num_rows, 0xff,
+                num_rows * sizeof(individual_id_t));
+    } else {
+        memcpy(self->individual + self->num_rows, individual,
+                num_rows * sizeof(individual_id_t));
+    }
     self->num_rows += (table_size_t) num_rows;
     self->metadata_offset[self->num_rows] = self->metadata_length;
 out:
@@ -355,7 +370,8 @@ out:
 
 static node_id_t
 node_table_add_row_internal(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, const char *metadata, table_size_t metadata_length)
+        population_id_t population, individual_id_t individual,
+        const char *metadata, table_size_t metadata_length)
 {
     assert(self->num_rows < self->max_rows);
     assert(self->metadata_length + metadata_length <= self->max_metadata_length);
@@ -363,6 +379,7 @@ node_table_add_row_internal(node_table_t *self, uint32_t flags, double time,
     self->flags[self->num_rows] = flags;
     self->time[self->num_rows] = time;
     self->population[self->num_rows] = population;
+    self->individual[self->num_rows] = individual;
     self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
     self->metadata_length += metadata_length;
     self->num_rows++;
@@ -371,7 +388,8 @@ node_table_add_row_internal(node_table_t *self, uint32_t flags, double time,
 
 node_id_t
 node_table_add_row(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, const char *metadata, size_t metadata_length)
+        population_id_t population, individual_id_t individual,
+        const char *metadata, size_t metadata_length)
 {
     int ret = 0;
 
@@ -383,8 +401,8 @@ node_table_add_row(node_table_t *self, uint32_t flags, double time,
     if (ret != 0) {
         goto out;
     }
-    ret = node_table_add_row_internal(self, flags, time, population, metadata,
-            (table_size_t) metadata_length);
+    ret = node_table_add_row_internal(self, flags, time, population, individual,
+            metadata, (table_size_t) metadata_length);
 out:
     return ret;
 }
@@ -404,6 +422,7 @@ node_table_free(node_table_t *self)
         msp_safe_free(self->flags);
         msp_safe_free(self->time);
         msp_safe_free(self->population);
+        msp_safe_free(self->individual);
         msp_safe_free(self->metadata);
         msp_safe_free(self->metadata_offset);
     }
@@ -426,10 +445,10 @@ node_table_print_state(node_table_t *self, FILE *out)
     fprintf(out, TABLE_SEP);
     /* We duplicate the dump_text code here for simplicity because we want to output
      * the flags column directly. */
-    fprintf(out, "id\tflags\ttime\tpopulation\tmetadata_offset\tmetadata\n");
+    fprintf(out, "id\tflags\ttime\tpopulation\tindividual\tmetadata_offset\tmetadata\n");
     for (j = 0; j < self->num_rows; j++) {
-        fprintf(out, "%d\t%d\t%f\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
-                (int) self->population[j], self->metadata_offset[j]);
+        fprintf(out, "%d\t%d\t%f\t%d\t%d\t%d\t", (int) j, self->flags[j], self->time[j],
+                (int) self->population[j], self->individual[j], self->metadata_offset[j]);
         for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
             fprintf(out, "%c", self->metadata[k]);
         }
@@ -447,15 +466,15 @@ node_table_dump_text(node_table_t *self, FILE *out)
     table_size_t metadata_len;
     int err;
 
-    err = fprintf(out, "id\tis_sample\ttime\tpopulation\tmetadata\n");
+    err = fprintf(out, "id\tis_sample\ttime\tpopulation\tindividual\tmetadata\n");
     if (err < 0) {
         goto out;
     }
     for (j = 0; j < self->num_rows; j++) {
         metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
-        err = fprintf(out, "%d\t%d\t%f\t%d\t%.*s\n", (int) j,
+        err = fprintf(out, "%d\t%d\t%f\t%d\t%d\t%.*s\n", (int) j,
                 (int) (self->flags[j] & MSP_NODE_IS_SAMPLE),
-                self->time[j], self->population[j],
+                self->time[j], self->population[j], self->individual[j],
                 metadata_len, self->metadata + self->metadata_offset[j]);
         if (err < 0) {
             goto out;
@@ -478,6 +497,8 @@ node_table_equal(node_table_t *self, node_table_t *other)
                     self->num_rows * sizeof(uint32_t)) == 0
             && memcmp(self->population, other->population,
                     self->num_rows * sizeof(population_id_t)) == 0
+            && memcmp(self->individual, other->individual,
+                    self->num_rows * sizeof(individual_id_t)) == 0
             && memcmp(self->metadata_offset, other->metadata_offset,
                     (self->num_rows + 1) * sizeof(table_size_t)) == 0
             && memcmp(self->metadata, other->metadata,
@@ -493,6 +514,7 @@ node_table_dump(node_table_t *self, kastore_t *store)
         {"nodes/time", (void *) self->time, self->num_rows, KAS_FLOAT64},
         {"nodes/flags", (void *) self->flags, self->num_rows, KAS_UINT32},
         {"nodes/population", (void *) self->population, self->num_rows, KAS_INT32},
+        {"nodes/individual", (void *) self->individual, self->num_rows, KAS_INT32},
         {"nodes/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8},
         {"nodes/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
             KAS_UINT32},
@@ -507,6 +529,8 @@ node_table_load(node_table_t *self, kastore_t *store)
         {"nodes/time", (void **) &self->time, &self->num_rows, 0, 1, KAS_FLOAT64},
         {"nodes/flags", (void **) &self->flags, &self->num_rows, 0, 1, KAS_UINT32},
         {"nodes/population", (void **) &self->population, &self->num_rows, 0,
+            1, KAS_INT32},
+        {"nodes/individual", (void **) &self->individual, &self->num_rows, 0,
             1, KAS_INT32},
         {"nodes/metadata", (void **) &self->metadata, &self->metadata_length, 0,
             1, KAS_UINT8},
@@ -3117,6 +3141,7 @@ simplifier_record_node(simplifier_t *self, node_id_t input_id, bool is_sample)
     self->node_id_map[input_id] = (node_id_t) self->nodes->num_rows;
     ret = node_table_add_row_internal(self->nodes, flags,
             self->input_nodes.time[input_id], self->input_nodes.population[input_id],
+            self->input_nodes.individual[input_id],
             self->input_nodes.metadata + offset, length);
     return ret;
 }
@@ -3447,7 +3472,7 @@ simplifier_alloc(simplifier_t *self, double sequence_length,
     }
     ret = node_table_set_columns(&self->input_nodes, nodes->num_rows,
             nodes->flags, nodes->time, nodes->population,
-            nodes->metadata, nodes->metadata_offset);
+            nodes->individual, nodes->metadata, nodes->metadata_offset);
     if (ret != 0) {
         goto out;
     }
@@ -3845,15 +3870,6 @@ simplifier_map_mutation_nodes(simplifier_t *self)
     return ret;
 }
 
-
-static int WARN_UNUSED
-simplifier_map_individual_nodes(simplifier_t *self)
-{
-    int ret = 0;
-    // TODO something here
-    return ret;
-}
-
 static int WARN_UNUSED
 simplifier_output_sites(simplifier_t *self)
 {
@@ -3981,10 +3997,6 @@ simplifier_run(simplifier_t *self, node_id_t *node_map)
         }
     }
     ret = simplifier_map_mutation_nodes(self);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = simplifier_map_individual_nodes(self);
     if (ret != 0) {
         goto out;
     }

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -103,7 +103,7 @@ expand_column(void **column, size_t new_max_rows, size_t element_size)
     void *tmp;
 
     tmp = realloc((void **) *column, new_max_rows * element_size);
-    if (tmp == NULL) {
+    if (tmp == NULL && (new_max_rows * element_size > 0)) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
@@ -117,6 +117,7 @@ typedef struct {
     void **array_dest;
     table_size_t *len_dest;
     table_size_t len_offset;
+    table_size_t len_multiplier;
     int type;
 } read_table_col_t;
 
@@ -145,8 +146,10 @@ read_table_cols(kastore_t *store, read_table_col_t *read_cols, size_t num_cols)
         }
         last_len = *read_cols[j].len_dest;
         if (last_len == (table_size_t) -1) {
-            *read_cols[j].len_dest = (table_size_t) len - read_cols[j].len_offset;
-        } else if (last_len + read_cols[j].len_offset != (table_size_t) len) {
+            *read_cols[j].len_dest = (table_size_t) ((len - read_cols[j].len_offset)
+                    / read_cols[j].len_multiplier);
+        } else if ((last_len + read_cols[j].len_offset) * read_cols[j].len_multiplier
+                   != (table_size_t) len) {
             ret = MSP_ERR_FILE_FORMAT;
             goto out;
         }
@@ -501,14 +504,14 @@ static int
 node_table_load(node_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"nodes/time", (void **) &self->time, &self->num_rows, 0, KAS_FLOAT64},
-        {"nodes/flags", (void **) &self->flags, &self->num_rows, 0, KAS_UINT32},
+        {"nodes/time", (void **) &self->time, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"nodes/flags", (void **) &self->flags, &self->num_rows, 0, 1, KAS_UINT32},
         {"nodes/population", (void **) &self->population, &self->num_rows, 0,
-            KAS_INT32},
+            1, KAS_INT32},
         {"nodes/metadata", (void **) &self->metadata, &self->metadata_length, 0,
-            KAS_UINT8},
+            1, KAS_UINT8},
         {"nodes/metadata_offset", (void **) &self->metadata_offset, &self->num_rows,
-            1, KAS_UINT32},
+            1, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -722,10 +725,10 @@ static int
 edge_table_load(edge_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"edges/left", (void **) &self->left, &self->num_rows, 0, KAS_FLOAT64},
-        {"edges/right", (void **) &self->right, &self->num_rows, 0, KAS_FLOAT64},
-        {"edges/parent", (void **) &self->parent, &self->num_rows, 0, KAS_INT32},
-        {"edges/child", (void **) &self->child, &self->num_rows, 0, KAS_INT32},
+        {"edges/left", (void **) &self->left, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"edges/right", (void **) &self->right, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"edges/parent", (void **) &self->parent, &self->num_rows, 0, 1, KAS_INT32},
+        {"edges/child", (void **) &self->child, &self->num_rows, 0, 1, KAS_INT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -1106,15 +1109,15 @@ static int
 site_table_load(site_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"sites/position", (void **) &self->position, &self->num_rows, 0, KAS_FLOAT64},
+        {"sites/position", (void **) &self->position, &self->num_rows, 0, 1, KAS_FLOAT64},
         {"sites/ancestral_state", (void **) &self->ancestral_state,
-            &self->ancestral_state_length, 0, KAS_UINT8},
+            &self->ancestral_state_length, 0, 1, KAS_UINT8},
         {"sites/ancestral_state_offset", (void **) &self->ancestral_state_offset,
-            &self->num_rows, 1, KAS_UINT32},
+            &self->num_rows, 1, 1, KAS_UINT32},
         {"sites/metadata", (void **) &self->metadata,
-            &self->metadata_length, 0, KAS_UINT8},
+            &self->metadata_length, 0, 1, KAS_UINT8},
         {"sites/metadata_offset", (void **) &self->metadata_offset,
-            &self->num_rows, 1, KAS_UINT32},
+            &self->num_rows, 1, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -1527,17 +1530,17 @@ static int
 mutation_table_load(mutation_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"mutations/site", (void **) &self->site, &self->num_rows, 0, KAS_INT32},
-        {"mutations/node", (void **) &self->node, &self->num_rows, 0, KAS_INT32},
-        {"mutations/parent", (void **) &self->parent, &self->num_rows, 0, KAS_INT32},
+        {"mutations/site", (void **) &self->site, &self->num_rows, 0, 1, KAS_INT32},
+        {"mutations/node", (void **) &self->node, &self->num_rows, 0, 1, KAS_INT32},
+        {"mutations/parent", (void **) &self->parent, &self->num_rows, 0, 1, KAS_INT32},
         {"mutations/derived_state", (void **) &self->derived_state,
-            &self->derived_state_length, 0, KAS_UINT8},
+            &self->derived_state_length, 0, 1, KAS_UINT8},
         {"mutations/derived_state_offset", (void **) &self->derived_state_offset,
-            &self->num_rows, 1, KAS_UINT32},
+            &self->num_rows, 1, 1, KAS_UINT32},
         {"mutations/metadata", (void **) &self->metadata,
-            &self->metadata_length, 0, KAS_UINT8},
+            &self->metadata_length, 0, 1, KAS_UINT8},
         {"mutations/metadata_offset", (void **) &self->metadata_offset,
-            &self->num_rows, 1, KAS_UINT32},
+            &self->num_rows, 1, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -1756,15 +1759,413 @@ static int
 migration_table_load(migration_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
-        {"migrations/left", (void **) &self->left, &self->num_rows, 0, KAS_FLOAT64},
-        {"migrations/right", (void **) &self->right, &self->num_rows, 0, KAS_FLOAT64},
-        {"migrations/node", (void **) &self->node, &self->num_rows, 0, KAS_INT32},
-        {"migrations/source", (void **) &self->source, &self->num_rows, 0, KAS_INT32},
-        {"migrations/dest", (void **) &self->dest, &self->num_rows, 0, KAS_INT32},
-        {"migrations/time", (void **) &self->time, &self->num_rows, 0, KAS_FLOAT64},
+        {"migrations/left", (void **) &self->left, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"migrations/right", (void **) &self->right, &self->num_rows, 0, 1, KAS_FLOAT64},
+        {"migrations/node", (void **) &self->node, &self->num_rows, 0, 1, KAS_INT32},
+        {"migrations/source", (void **) &self->source, &self->num_rows, 0, 1, KAS_INT32},
+        {"migrations/dest", (void **) &self->dest, &self->num_rows, 0, 1, KAS_INT32},
+        {"migrations/time", (void **) &self->time, &self->num_rows, 0, 1, KAS_FLOAT64},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
+
+/*************************
+ * individual table
+ *************************/
+
+static int
+individual_table_expand_main_columns(individual_table_t *self, table_size_t additional_rows)
+{
+    int ret = 0;
+    table_size_t increment = MSP_MAX(additional_rows, self->max_rows_increment);
+    table_size_t new_size = self->max_rows + increment;
+
+    if ((self->num_rows + additional_rows) > self->max_rows) {
+        ret = expand_column((void **) &self->flags, new_size, sizeof(uint32_t));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->location, new_size,
+                self->spatial_dimension * sizeof(double));
+        if (ret != 0) {
+            goto out;
+        }
+        ret = expand_column((void **) &self->metadata_offset, new_size + 1,
+                sizeof(table_size_t));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_rows = new_size;
+    }
+out:
+    return ret;
+}
+
+static int
+individual_table_expand_metadata(individual_table_t *self, table_size_t additional_length)
+{
+    int ret = 0;
+    table_size_t increment = MSP_MAX(additional_length,
+            self->max_metadata_length_increment);
+    table_size_t new_size = self->max_metadata_length + increment;
+
+    if ((self->metadata_length + additional_length) > self->max_metadata_length) {
+        ret = expand_column((void **) &self->metadata, new_size, sizeof(char *));
+        if (ret != 0) {
+            goto out;
+        }
+        self->max_metadata_length = new_size;
+    }
+out:
+    return ret;
+}
+
+int
+individual_table_set_spatial_dimension(individual_table_t *self, table_size_t spatial_dimension)
+{
+    int ret = 0;
+
+    if (spatial_dimension < 0) {
+        ret = MSP_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    self->spatial_dimension = spatial_dimension;
+    ret = expand_column((void **) &self->location, self->max_rows,
+            spatial_dimension * sizeof(double));
+out:
+    return ret;
+}
+
+int
+individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
+        size_t max_metadata_length_increment)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(individual_table_t));
+    if (max_rows_increment == 0) {
+       max_rows_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    if (max_metadata_length_increment == 0) {
+        max_metadata_length_increment = DEFAULT_SIZE_INCREMENT;
+    }
+    self->max_rows_increment = (table_size_t) max_rows_increment;
+    self->max_metadata_length_increment = (table_size_t) max_metadata_length_increment;
+    self->max_rows = 0;
+    self->num_rows = 0;
+    self->max_metadata_length = 0;
+    self->metadata_length = 0;
+    ret = individual_table_set_spatial_dimension(self, 0);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_expand_metadata(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    self->metadata_offset[0] = 0;
+out:
+    return ret;
+}
+
+int WARN_UNUSED
+individual_table_copy(individual_table_t *self, individual_table_t *dest)
+{
+    return individual_table_set_columns(dest, self->num_rows, self->flags,
+            self->spatial_dimension, self->location,
+            self->metadata, self->metadata_offset);
+}
+
+int WARN_UNUSED
+individual_table_set_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
+        table_size_t spatial_dimension, double *location,
+        const char *metadata, uint32_t *metadata_offset)
+{
+    int ret;
+
+    ret = individual_table_clear(self);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_set_spatial_dimension(self, spatial_dimension);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_append_columns(self, num_rows, flags, location, metadata,
+            metadata_offset);
+out:
+    return ret;
+}
+
+int
+individual_table_append_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
+        double *location, const char *metadata, uint32_t *metadata_offset)
+{
+    int ret;
+    table_size_t j, metadata_length;
+
+    if (flags == NULL) {
+        ret = MSP_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((self->spatial_dimension < 0) ||
+            ((location == NULL) && (self->spatial_dimension != 0))) {
+        ret = MSP_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    if ((metadata == NULL) != (metadata_offset == NULL)) {
+        ret = MSP_ERR_BAD_PARAM_VALUE;
+        goto out;
+    }
+    ret = individual_table_expand_main_columns(self, (table_size_t) num_rows);
+    if (ret != 0) {
+        goto out;
+    }
+    memcpy(self->flags + self->num_rows, flags, num_rows * sizeof(uint32_t));
+    if (self->spatial_dimension > 0) {
+        memcpy(self->location + self->spatial_dimension * self->num_rows, location,
+                num_rows * self->spatial_dimension * sizeof(double));
+    }
+    if (metadata == NULL) {
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j + 1] = (table_size_t) self->metadata_length;
+        }
+    } else {
+        ret = check_offsets(num_rows, metadata_offset, 0, false);
+        if (ret != 0) {
+            goto out;
+        }
+        for (j = 0; j < num_rows; j++) {
+            self->metadata_offset[self->num_rows + j] =
+                (table_size_t) self->metadata_length + metadata_offset[j];
+        }
+        metadata_length = metadata_offset[num_rows];
+        ret = individual_table_expand_metadata(self, metadata_length);
+        if (ret != 0) {
+            goto out;
+        }
+        memcpy(self->metadata + self->metadata_length, metadata, metadata_length * sizeof(char));
+        self->metadata_length += metadata_length;
+    }
+    self->num_rows += (table_size_t) num_rows;
+    self->metadata_offset[self->num_rows] = self->metadata_length;
+out:
+    return ret;
+}
+
+static individual_id_t
+individual_table_add_row_internal(individual_table_t *self, uint32_t flags, double *location,
+        const char *metadata, table_size_t metadata_length)
+{
+    int k;
+    assert(self->num_rows < self->max_rows);
+    assert(self->metadata_length + metadata_length <= self->max_metadata_length);
+    memcpy(self->metadata + self->metadata_length, metadata, metadata_length);
+    self->flags[self->num_rows] = flags;
+    for (k = 0; k < self->spatial_dimension; k++) {
+        self->location[self->spatial_dimension * self->num_rows + k] = location[k];
+    }
+    self->metadata_offset[self->num_rows + 1] = self->metadata_length + metadata_length;
+    self->metadata_length += metadata_length;
+    self->num_rows++;
+    return (individual_id_t) self->num_rows - 1;
+}
+
+individual_id_t
+individual_table_add_row(individual_table_t *self, uint32_t flags, double *location,
+        const char *metadata, size_t metadata_length)
+{
+    int ret = 0;
+
+    ret = individual_table_expand_main_columns(self, 1);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_expand_metadata(self, (table_size_t) metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_add_row_internal(self, flags, location, metadata,
+            (table_size_t) metadata_length);
+out:
+    return ret;
+}
+
+int
+individual_table_clear(individual_table_t *self)
+{
+    int ret = 0;
+    self->num_rows = 0;
+    self->metadata_length = 0;
+    ret = individual_table_set_spatial_dimension(self, 0);
+    return ret;
+}
+
+int
+individual_table_free(individual_table_t *self)
+{
+    if (self->max_rows > 0) {
+        msp_safe_free(self->flags);
+        msp_safe_free(self->location);
+        msp_safe_free(self->metadata);
+        msp_safe_free(self->metadata_offset);
+    }
+    return 0;
+}
+
+void
+individual_table_print_state(individual_table_t *self, FILE *out)
+{
+    size_t i, j, k;
+
+    fprintf(out, TABLE_SEP);
+    fprintf(out, "individual_table: %p:\n", (void *) self);
+    fprintf(out, "spatial_dimension = %d\n", self->spatial_dimension);
+    fprintf(out, "num_rows          = %d\tmax= %d\tincrement = %d)\n",
+            (int) self->num_rows, (int) self->max_rows, (int) self->max_rows_increment);
+    fprintf(out, "metadata_length = %d\tmax= %d\tincrement = %d)\n",
+            (int) self->metadata_length,
+            (int) self->max_metadata_length,
+            (int) self->max_metadata_length_increment);
+    fprintf(out, TABLE_SEP);
+    /* We duplicate the dump_text code here because we want to output
+     * the metadata offset column. */
+    fprintf(out, "id\tflags\t");
+    for (i = 0; i < self->spatial_dimension; i++) {
+        fprintf(out, "location_%d\t", i);
+    }
+    fprintf(out, "metadata_offset\tmetadata\n");
+    for (j = 0; j < self->num_rows; j++) {
+        fprintf(out, "%d\t%d\t", (int) j, self->flags[j]);
+        for (i = 0; i < self->spatial_dimension; i++) {
+            fprintf(out, "%f\t", self->location[j * self->spatial_dimension + i]);
+        }
+        fprintf(out, "%d\t", self->metadata_offset[j]);
+        for (k = self->metadata_offset[j]; k < self->metadata_offset[j + 1]; k++) {
+            fprintf(out, "%c", self->metadata[k]);
+        }
+        fprintf(out, "\n");
+    }
+    assert(self->metadata_offset[0] == 0);
+    assert(self->metadata_offset[self->num_rows] == self->metadata_length);
+}
+
+int
+individual_table_dump_text(individual_table_t *self, FILE *out)
+{
+    int ret = 0;
+    size_t i, j;
+    table_size_t metadata_len;
+    int err;
+
+    err = fprintf(out, "id\tflags\t");
+    if (err < 0) {
+        goto out;
+    }
+    for (i = 0; i < self->spatial_dimension; i++) {
+        err = fprintf(out, "location_%d\t", i);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    err = fprintf(out, "metadata\n");
+    if (err < 0) {
+        goto out;
+    }
+    for (j = 0; j < self->num_rows; j++) {
+        metadata_len = self->metadata_offset[j + 1] - self->metadata_offset[j];
+        err = fprintf(out, "%d\t%d\t", (int) j, (int) self->flags[j]);
+        if (err < 0) {
+            goto out;
+        }
+        for (i = 0; i < self->spatial_dimension; i++) {
+            err = fprintf(out, "%f\t", self->location[j * self->spatial_dimension + i]);
+            if (err < 0) {
+                goto out;
+            }
+        }
+        err = fprintf(out, "%.*s\n",
+                metadata_len, self->metadata + self->metadata_offset[j]);
+        if (err < 0) {
+            goto out;
+        }
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+bool
+individual_table_equal(individual_table_t *self, individual_table_t *other)
+{
+    bool ret = false;
+    if (self->num_rows == other->num_rows
+            && self->metadata_length == other->metadata_length) {
+        ret = memcmp(self->flags, other->flags,
+                    self->num_rows * sizeof(uint32_t)) == 0
+            && memcmp(self->location, other->location,
+                    self->num_rows * self->spatial_dimension * sizeof(double)) == 0
+            && memcmp(self->metadata_offset, other->metadata_offset,
+                    (self->num_rows + 1) * sizeof(table_size_t)) == 0
+            && memcmp(self->metadata, other->metadata,
+                    self->metadata_length * sizeof(char)) == 0;
+    }
+    return ret;
+}
+
+static int
+individual_table_dump(individual_table_t *self, kastore_t *store)
+{
+    write_table_col_t write_cols[] = {
+        {"individuals/spatial_dimension", (void *) &(self->spatial_dimension), 1, KAS_UINT32},
+        {"individuals/flags", (void *) self->flags, self->num_rows, KAS_UINT32},
+        {"individuals/location", (void *) self->location,
+            self->num_rows * self->spatial_dimension, KAS_FLOAT64},
+        {"individuals/metadata", (void *) self->metadata, self->metadata_length, KAS_UINT8},
+        {"individuals/metadata_offset", (void *) self->metadata_offset, self->num_rows + 1,
+            KAS_UINT32},
+    };
+    return write_table_cols(store, write_cols, sizeof(write_cols) / sizeof(*write_cols));
+}
+
+static int
+individual_table_load(individual_table_t *self, kastore_t *store)
+{
+    int ret;
+    uint32_t *spatial_dimension;
+    size_t len;
+
+    ret = kastore_gets_uint32(store, "individuals/spatial_dimension",
+            &spatial_dimension, &len);
+    if (ret != 0) {
+        ret = msp_set_kas_error(ret);
+        goto out;
+    }
+    if (len != 1) {
+        ret = MSP_ERR_FILE_FORMAT;
+        goto out;
+    }
+    self->spatial_dimension = (table_size_t) *spatial_dimension;
+
+    read_table_col_t read_cols[] = {
+        {"individuals/flags", (void **) &self->flags, &self->num_rows, 0, 1, KAS_UINT32},
+        {"individuals/location", (void **) &self->location, &self->num_rows, 0,
+            self->spatial_dimension, KAS_FLOAT64},
+        {"individuals/metadata", (void **) &self->metadata, &self->metadata_length, 0, 1,
+            KAS_UINT8},
+        {"individuals/metadata_offset", (void **) &self->metadata_offset, &self->num_rows,
+            1, 1, KAS_UINT32},
+    };
+    ret = read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
+
+out:
+    return ret;
+}
+
 
 /*************************
  * provenance table
@@ -2101,13 +2502,13 @@ provenance_table_load(provenance_table_t *self, kastore_t *store)
 {
     read_table_col_t read_cols[] = {
         {"provenances/timestamp", (void **) &self->timestamp,
-            &self->timestamp_length, 0, KAS_UINT8},
+            &self->timestamp_length, 0, 1, KAS_UINT8},
         {"provenances/timestamp_offset", (void **) &self->timestamp_offset,
-            &self->num_rows, 1, KAS_UINT32},
+            &self->num_rows, 1, 1, KAS_UINT32},
         {"provenances/record", (void **) &self->record,
-            &self->record_length, 0, KAS_UINT8},
+            &self->record_length, 0, 1, KAS_UINT8},
         {"provenances/record_offset", (void **) &self->record_offset,
-            &self->num_rows, 1, KAS_UINT32},
+            &self->num_rows, 1, 1, KAS_UINT32},
     };
     return read_table_cols(store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
 }
@@ -3444,6 +3845,15 @@ simplifier_map_mutation_nodes(simplifier_t *self)
     return ret;
 }
 
+
+static int WARN_UNUSED
+simplifier_map_individual_nodes(simplifier_t *self)
+{
+    int ret = 0;
+    // TODO something here
+    return ret;
+}
+
 static int WARN_UNUSED
 simplifier_output_sites(simplifier_t *self)
 {
@@ -3574,6 +3984,10 @@ simplifier_run(simplifier_t *self, node_id_t *node_map)
     if (ret != 0) {
         goto out;
     }
+    ret = simplifier_map_individual_nodes(self);
+    if (ret != 0) {
+        goto out;
+    }
     ret = simplifier_output_sites(self);
     if (ret != 0) {
         goto out;
@@ -3646,6 +4060,11 @@ table_collection_check_offsets(table_collection_t *self)
     if (ret != 0) {
         goto out;
     }
+    ret = check_offsets(self->individuals.num_rows, self->individuals.metadata_offset,
+            self->individuals.metadata_length, true);
+    if (ret != 0) {
+        goto out;
+    }
     ret = check_offsets(self->provenances.num_rows, self->provenances.timestamp_offset,
             self->provenances.timestamp_length, true);
     if (ret != 0) {
@@ -3671,6 +4090,7 @@ table_collection_print_state(table_collection_t *self, FILE *out)
     migration_table_print_state(&self->migrations, out);
     site_table_print_state(&self->sites, out);
     mutation_table_print_state(&self->mutations, out);
+    individual_table_print_state(&self->individuals, out);
     provenance_table_print_state(&self->provenances, out);
     return 0;
 }
@@ -3702,6 +4122,10 @@ table_collection_alloc(table_collection_t *self, int flags)
         if (ret != 0) {
             goto out;
         }
+        ret = individual_table_alloc(&self->individuals, 0, 0);
+        if (ret != 0) {
+            goto out;
+        }
         ret = provenance_table_alloc(&self->provenances, 0, 0, 0);
         if (ret != 0) {
             goto out;
@@ -3721,6 +4145,7 @@ table_collection_free(table_collection_t *self)
     migration_table_free(&self->migrations);
     site_table_free(&self->sites);
     mutation_table_free(&self->mutations);
+    individual_table_free(&self->individuals);
     provenance_table_free(&self->provenances);
     if (self->indexes.malloced_locally) {
         msp_safe_free(self->indexes.edge_insertion_order);
@@ -3753,6 +4178,10 @@ table_collection_copy(table_collection_t *self, table_collection_t *dest)
         goto out;
     }
     ret = mutation_table_copy(&self->mutations, &dest->mutations);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_copy(&self->individuals, &dest->individuals);
     if (ret != 0) {
         goto out;
     }
@@ -3964,9 +4393,9 @@ table_collection_load_indexes(table_collection_t *self)
 {
     read_table_col_t read_cols[] = {
         {"indexes/edge_insertion_order", (void **) &self->indexes.edge_insertion_order,
-            &self->edges.num_rows, 0, KAS_INT32},
+            &self->edges.num_rows, 0, 1, KAS_INT32},
         {"indexes/edge_removal_order", (void **) &self->indexes.edge_removal_order,
-            &self->edges.num_rows, 0, KAS_INT32},
+            &self->edges.num_rows, 0, 1, KAS_INT32},
     };
     self->indexes.malloced_locally = false;
     return read_table_cols(&self->store, read_cols, sizeof(read_cols) / sizeof(*read_cols));
@@ -4008,6 +4437,10 @@ table_collection_load(table_collection_t *self, const char *filename, int flags)
         goto out;
     }
     ret = migration_table_load(&self->migrations, &self->store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_load(&self->individuals, &self->store);
     if (ret != 0) {
         goto out;
     }
@@ -4073,6 +4506,10 @@ table_collection_dump(table_collection_t *self, const char *filename, int flags)
         goto out;
     }
     ret = mutation_table_dump(&self->mutations, &store);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = individual_table_dump(&self->individuals, &store);
     if (ret != 0) {
         goto out;
     }

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -62,12 +62,15 @@ typedef struct {
     table_size_t num_rows;
     table_size_t max_rows;
     table_size_t max_rows_increment;
+    table_size_t location_length;
+    table_size_t max_location_length;
+    table_size_t max_location_length_increment;
     table_size_t metadata_length;
     table_size_t max_metadata_length;
     table_size_t max_metadata_length_increment;
-    table_size_t spatial_dimension;
     uint32_t *flags;
     double *location;
+    table_size_t *location_offset;
     char *metadata;
     table_size_t *metadata_offset;
 } individual_table_t;
@@ -370,16 +373,16 @@ int migration_table_dump_text(migration_table_t *self, FILE *out);
 void migration_table_print_state(migration_table_t *self, FILE *out);
 
 int individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
-        size_t max_metadata_length_increment);
-int individual_table_set_spatial_dimension(individual_table_t *self,
-        table_size_t spatial_dimension);
+        size_t max_location_length_increment, size_t max_metadata_length_increment);
 individual_id_t individual_table_add_row(individual_table_t *self, uint32_t flags,
-        double *location, const char *metadata, size_t metadata_length);
+        double *location, size_t location_length, 
+        const char *metadata, size_t metadata_length);
 int individual_table_set_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
-        table_size_t spatial_dimension, double *location,
+        double *location, table_size_t *location_length,
         const char *metadata, table_size_t *metadata_length);
-int individual_table_append_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
-        double *location, const char *metadata, table_size_t *metadata_length);
+int individual_table_append_columns(individual_table_t *self, size_t num_rows, uint32_t *flags, 
+        double *location, table_size_t *location_length,
+        const char *metadata, table_size_t *metadata_length);
 int individual_table_clear(individual_table_t *self);
 int individual_table_free(individual_table_t *self);
 int individual_table_dump_text(individual_table_t *self, FILE *out);

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -82,6 +82,7 @@ typedef struct {
     uint32_t *flags;
     double *time;
     population_id_t *population;
+    individual_id_t *individual;
     char *metadata;
     table_size_t *metadata_offset;
 } node_table_t;
@@ -280,11 +281,14 @@ typedef struct {
 int node_table_alloc(node_table_t *self, size_t max_rows_increment,
         size_t max_metadata_length_increment);
 node_id_t node_table_add_row(node_table_t *self, uint32_t flags, double time,
-        population_id_t population, const char *metadata, size_t metadata_length);
+        population_id_t population, individual_id_t individual,
+        const char *metadata, size_t metadata_length);
 int node_table_set_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, const char *metadata, table_size_t *metadata_length);
+        population_id_t *population, individual_id_t *individual,
+        const char *metadata, table_size_t *metadata_length);
 int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *flags, double *time,
-        population_id_t *population, const char *metadata, table_size_t *metadata_length);
+        population_id_t *population, individual_id_t *individual,
+        const char *metadata, table_size_t *metadata_length);
 int node_table_clear(node_table_t *self);
 int node_table_free(node_table_t *self);
 int node_table_dump_text(node_table_t *self, FILE *out);

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -296,6 +296,7 @@ int node_table_append_columns(node_table_t *self, size_t num_rows, uint32_t *fla
 int node_table_clear(node_table_t *self);
 int node_table_free(node_table_t *self);
 int node_table_dump_text(node_table_t *self, FILE *out);
+int node_table_load_text(node_table_t *self, FILE *file);
 int node_table_copy(node_table_t *self, node_table_t *dest);
 void node_table_print_state(node_table_t *self, FILE *out);
 bool node_table_equal(node_table_t *self, node_table_t *other);
@@ -310,6 +311,7 @@ int edge_table_append_columns(edge_table_t *self, size_t num_rows, double *left,
 int edge_table_clear(edge_table_t *self);
 int edge_table_free(edge_table_t *self);
 int edge_table_dump_text(edge_table_t *self, FILE *out);
+int edge_table_load_text(edge_table_t *self, FILE *file);
 int edge_table_copy(edge_table_t *self, edge_table_t *dest);
 void edge_table_print_state(edge_table_t *self, FILE *out);
 bool edge_table_equal(edge_table_t *self, edge_table_t *other);
@@ -332,6 +334,7 @@ int site_table_clear(site_table_t *self);
 int site_table_copy(site_table_t *self, site_table_t *dest);
 int site_table_free(site_table_t *self);
 int site_table_dump_text(site_table_t *self, FILE *out);
+int site_table_load_text(site_table_t *self, FILE *file);
 void site_table_print_state(site_table_t *self, FILE *out);
 
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
@@ -355,6 +358,7 @@ int mutation_table_clear(mutation_table_t *self);
 int mutation_table_copy(mutation_table_t *self, mutation_table_t *dest);
 int mutation_table_free(mutation_table_t *self);
 int mutation_table_dump_text(mutation_table_t *self, FILE *out);
+int mutation_table_load_text(mutation_table_t *self, FILE *file);
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
 
 int migration_table_alloc(migration_table_t *self, size_t max_rows_increment);
@@ -371,6 +375,7 @@ int migration_table_clear(migration_table_t *self);
 int migration_table_free(migration_table_t *self);
 int migration_table_copy(migration_table_t *self, migration_table_t *dest);
 int migration_table_dump_text(migration_table_t *self, FILE *out);
+int migration_table_load_text(migration_table_t *self, FILE *file);
 void migration_table_print_state(migration_table_t *self, FILE *out);
 
 int individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
@@ -387,6 +392,7 @@ int individual_table_append_columns(individual_table_t *self, size_t num_rows, u
 int individual_table_clear(individual_table_t *self);
 int individual_table_free(individual_table_t *self);
 int individual_table_dump_text(individual_table_t *self, FILE *out);
+int individual_table_load_text(individual_table_t *self, FILE *file);
 int individual_table_copy(individual_table_t *self, individual_table_t *dest);
 void individual_table_print_state(individual_table_t *self, FILE *out);
 bool individual_table_equal(individual_table_t *self, individual_table_t *other);
@@ -406,6 +412,8 @@ int provenance_table_append_columns(provenance_table_t *self, size_t num_rows,
 int provenance_table_clear(provenance_table_t *self);
 int provenance_table_copy(provenance_table_t *self, provenance_table_t *dest);
 int provenance_table_free(provenance_table_t *self);
+int provenance_table_dump_text(provenance_table_t *self, FILE *out);
+int provenance_table_load_text(provenance_table_t *self, FILE *file);
 void provenance_table_print_state(provenance_table_t *self, FILE *out);
 bool provenance_table_equal(provenance_table_t *self, provenance_table_t *other);
 

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -151,6 +151,7 @@ typedef struct {
     uint32_t flags;
     double time;
     population_id_t population;
+    individual_id_t individual;
     const char *metadata;
     table_size_t metadata_length;
 } node_t;

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -18,6 +18,7 @@ typedef int32_t population_id_t;
 typedef int32_t site_id_t;
 typedef int32_t mutation_id_t;
 typedef int32_t migration_id_t;
+typedef int32_t individual_id_t;
 typedef int32_t provenance_id_t;
 typedef uint32_t table_size_t;
 
@@ -56,6 +57,20 @@ typedef struct {
     char *metadata;
     table_size_t *metadata_offset;
 } mutation_table_t;
+
+typedef struct {
+    table_size_t num_rows;
+    table_size_t max_rows;
+    table_size_t max_rows_increment;
+    table_size_t metadata_length;
+    table_size_t max_metadata_length;
+    table_size_t max_metadata_length_increment;
+    table_size_t spatial_dimension;
+    uint32_t *flags;
+    double *location;
+    char *metadata;
+    table_size_t *metadata_offset;
+} individual_table_t;
 
 typedef struct {
     table_size_t num_rows;
@@ -116,6 +131,7 @@ typedef struct {
     migration_table_t migrations;
     site_table_t sites;
     mutation_table_t mutations;
+    individual_table_t individuals;
     provenance_table_t provenances;
     struct {
         edge_id_t *edge_insertion_order;
@@ -348,6 +364,24 @@ int migration_table_free(migration_table_t *self);
 int migration_table_copy(migration_table_t *self, migration_table_t *dest);
 int migration_table_dump_text(migration_table_t *self, FILE *out);
 void migration_table_print_state(migration_table_t *self, FILE *out);
+
+int individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
+        size_t max_metadata_length_increment);
+int individual_table_set_spatial_dimension(individual_table_t *self,
+        table_size_t spatial_dimension);
+individual_id_t individual_table_add_row(individual_table_t *self, uint32_t flags,
+        double *location, const char *metadata, size_t metadata_length);
+int individual_table_set_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
+        table_size_t spatial_dimension, double *location,
+        const char *metadata, table_size_t *metadata_length);
+int individual_table_append_columns(individual_table_t *self, size_t num_rows, uint32_t *flags,
+        double *location, const char *metadata, table_size_t *metadata_length);
+int individual_table_clear(individual_table_t *self);
+int individual_table_free(individual_table_t *self);
+int individual_table_dump_text(individual_table_t *self, FILE *out);
+int individual_table_copy(individual_table_t *self, individual_table_t *dest);
+void individual_table_print_state(individual_table_t *self, FILE *out);
+bool individual_table_equal(individual_table_t *self, individual_table_t *other);
 
 int provenance_table_alloc(provenance_table_t *self, size_t max_rows_increment,
         size_t max_timestamp_length_increment,

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -430,6 +430,9 @@ int table_collection_simplify(table_collection_t *self,
         node_id_t *samples, size_t num_samples, int flags, node_id_t *node_map);
 int table_collection_deduplicate_sites(table_collection_t *tables, int flags);
 int table_collection_compute_mutation_parents(table_collection_t *self, int flags);
+int table_collection_load_text(table_collection_t *tables, FILE *nodes, FILE *edges,
+        FILE *sites, FILE *mutations, FILE *migrations, FILE *individuals, 
+        FILE *provenances);
 
 int simplifier_alloc(simplifier_t *self, double sequence_length,
         node_id_t *samples, size_t num_samples,

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -56,13 +56,13 @@ typedef struct {
 
 /* Simple single tree example. */
 const char *single_tree_ex_nodes =/*          6          */
-    "1  0   0\n"                  /*         / \         */
-    "1  0   0\n"                  /*        /   \        */
-    "1  0   0\n"                  /*       /     \       */
-    "1  0   0\n"                  /*      /       5      */
-    "0  1   0\n"                  /*     4       / \     */
-    "0  2   0\n"                  /*    / \     /   \    */
-    "0  3   0\n";                 /*   0   1   2     3   */
+    "1  0   0   -1\n"             /*         / \         */
+    "1  0   0   -1\n"             /*        /   \        */
+    "1  0   0   -1\n"             /*       /     \       */
+    "1  0   0   -1\n"             /*      /       5      */
+    "0  1   0   -1\n"             /*     4       / \     */
+    "0  2   0   -1\n"             /*    / \     /   \    */
+    "0  3   0   -1\n";            /*   0   1   2     3   */
 const char *single_tree_ex_edges =
     "0  1   4   0,1\n"
     "0  1   5   2,3\n"
@@ -82,15 +82,15 @@ const char *single_tree_ex_mutations =
 
 /* Example from the PLOS paper */
 const char *paper_ex_nodes =
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "0  0.071   0\n"
-    "0  0.090   0\n"
-    "0  0.170   0\n"
-    "0  0.202   0\n"
-    "0  0.253   0\n";
+    "1  0       0   0\n"
+    "1  0       0   0\n"
+    "1  0       0   1\n"
+    "1  0       0   1\n"
+    "0  0.071   0   -1\n"
+    "0  0.090   0   -1\n"
+    "0  0.170   0   -1\n"
+    "0  0.202   0   -1\n"
+    "0  0.253   0   -1\n";
 const char *paper_ex_edges =
     "2 10 4 2\n"
     "2 10 4 3\n"
@@ -116,19 +116,19 @@ const char *paper_ex_individuals =
 
 /* An example of a nonbinary tree sequence */
 const char *nonbinary_ex_nodes =
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "0  0.01    0\n"
-    "0  0.068   0\n"
-    "0  0.130   0\n"
-    "0  0.279   0\n"
-    "0  0.405   0\n";
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "1  0       0   -1\n"
+    "0  0.01    0   -1\n"
+    "0  0.068   0   -1\n"
+    "0  0.130   0   -1\n"
+    "0  0.279   0   -1\n"
+    "0  0.405   0   -1\n";
 const char *nonbinary_ex_edges =
     "0	100	8	0,1,2,3\n"
     "0	100	9	6,8\n"
@@ -149,15 +149,15 @@ const char *nonbinary_ex_mutations =
 /* An example of a tree sequence with unary nodes. */
 
 const char *unary_ex_nodes =
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "1  0   0\n"
-    "0  0.071   0\n"
-    "0  0.090   0\n"
-    "0  0.170   0\n"
-    "0  0.202   0\n"
-    "0  0.253   0\n";
+    "1  0       0  -1\n"
+    "1  0       0  -1\n"
+    "1  0       0  -1\n"
+    "1  0       0  -1\n"
+    "0  0.071   0  -1\n"
+    "0  0.090   0  -1\n"
+    "0  0.170   0  -1\n"
+    "0  0.202   0  -1\n"
+    "0  0.253   0  -1\n";
 const char *unary_ex_edges =
     "2 10 4 2,3\n"
     "0 10 5 1\n"
@@ -222,15 +222,15 @@ const char *unary_ex_mutations =
 */
 
 const char *internal_sample_ex_nodes =
-    "1  0.0   0\n"
-    "1  0.1   0\n"
-    "1  0.1   0\n"
-    "1  0.2   0\n"
-    "0  0.4   0\n"
-    "1  0.5   0\n"
-    "0  0.7   0\n"
-    "0  1.0   0\n"
-    "0  1.2   0\n";
+    "1  0.0   0   -1\n"
+    "1  0.1   0   -1\n"
+    "1  0.1   0   -1\n"
+    "1  0.2   0   -1\n"
+    "0  0.4   0   -1\n"
+    "1  0.5   0   -1\n"
+    "0  0.7   0   -1\n"
+    "0  1.0   0   -1\n"
+    "0  1.2   0   -1\n";
 const char *internal_sample_ex_edges =
     "2 8  4 0\n"
     "0 10 4 2\n"
@@ -265,7 +265,7 @@ parse_nodes(const char *text, node_table_t *node_table)
     const char *whitespace = " \t";
     char *p;
     double time;
-    int flags, population;
+    int flags, population, individual;
     char *name;
 
     c = 0;
@@ -293,12 +293,18 @@ parse_nodes(const char *text, node_table_t *node_table)
         population = atoi(p);
         p = strtok(NULL, whitespace);
         if (p == NULL) {
+            individual = -1;
+        } else {
+            individual = atoi(p);
+            p = strtok(NULL, whitespace);
+        }
+        if (p == NULL) {
             name = "";
         } else {
             name = p;
         }
-        ret = node_table_add_row(node_table, flags, time, population, name,
-                strlen(name));
+        ret = node_table_add_row(node_table, flags, time, population,
+                individual, name, strlen(name));
         CU_ASSERT_FATAL(ret >= 0);
     }
 }
@@ -1873,11 +1879,11 @@ static void
 test_node_metadata(void)
 {
     const char *nodes =
-        "1  0   0   n1\n"
-        "1  0   0   n2\n"
-        "0  1   0   A_much_longer_name\n"
-        "0  1   0\n"
-        "0  1   0   n4";
+        "1  0   0   -1   n1\n"
+        "1  0   0   -1   n2\n"
+        "0  1   0   -1   A_much_longer_name\n"
+        "0  1   0   -1\n"
+        "0  1   0   -1   n4";
     const char *edges =
         "0  1   2   0,1\n";
     tree_sequence_t ts;
@@ -6354,6 +6360,7 @@ test_node_table(void)
     uint32_t *flags;
     population_id_t *population;
     double *time;
+    individual_id_t *individual;
     char *metadata;
     uint32_t *metadata_offset;
     const char *test_metadata = "test";
@@ -6367,11 +6374,12 @@ test_node_table(void)
     node_table_dump_text(&table, _devnull);
 
     for (j = 0; j < num_rows; j++) {
-        ret = node_table_add_row(&table, j, j, j, test_metadata, test_metadata_length);
+        ret = node_table_add_row(&table, j, j, j, j, test_metadata, test_metadata_length);
         CU_ASSERT_EQUAL_FATAL(ret, j);
         CU_ASSERT_EQUAL(table.flags[j], j);
         CU_ASSERT_EQUAL(table.time[j], j);
         CU_ASSERT_EQUAL(table.population[j], j);
+        CU_ASSERT_EQUAL(table.individual[j], j);
         CU_ASSERT_EQUAL(table.num_rows, j + 1);
         CU_ASSERT_EQUAL(table.metadata_length, (j + 1) * test_metadata_length);
         CU_ASSERT_EQUAL(table.metadata_offset[j + 1], table.metadata_length);
@@ -6396,6 +6404,9 @@ test_node_table(void)
     time = malloc(num_rows * sizeof(double));
     CU_ASSERT_FATAL(time != NULL);
     memset(time, 0, num_rows * sizeof(double));
+    individual = malloc(num_rows * sizeof(uint32_t));
+    CU_ASSERT_FATAL(individual != NULL);
+    memset(individual, 3, num_rows * sizeof(uint32_t));
     metadata = malloc(num_rows * sizeof(char));
     memset(metadata, 'a', num_rows * sizeof(char));
     CU_ASSERT_FATAL(metadata != NULL);
@@ -6405,11 +6416,12 @@ test_node_table(void)
         metadata_offset[j] = j;
     }
     ret = node_table_set_columns(&table, num_rows, flags, time, population,
-            metadata, metadata_offset);
+            individual, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset,
                 (num_rows + 1) * sizeof(table_size_t)), 0);
@@ -6420,7 +6432,7 @@ test_node_table(void)
 
     /* Append another num_rows onto the end */
     ret = node_table_append_columns(&table, num_rows, flags, time, population,
-            metadata, metadata_offset);
+            individual, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
@@ -6429,6 +6441,9 @@ test_node_table(void)
                 num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time + num_rows, time, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.individual + num_rows, individual,
+                num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata + num_rows, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(table.num_rows, 2 * num_rows);
@@ -6437,37 +6452,39 @@ test_node_table(void)
     node_table_dump_text(&table, _devnull);
 
     /* If population is NULL it should be set to -1. If metadata is NULL all metadatas
-     * should be set to the empty string. */
+     * should be set to the empty string. If individual is NULL it should be set to -1. */
     num_rows = 10;
     memset(population, 0xff, num_rows * sizeof(uint32_t));
-    ret = node_table_set_columns(&table, num_rows, flags, time, NULL, metadata, metadata_offset);
+    memset(individual, 0xff, num_rows * sizeof(uint32_t));
+    ret = node_table_set_columns(&table, num_rows, flags, time, NULL, NULL, metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.population, population, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
+    CU_ASSERT_EQUAL(memcmp(table.individual, individual, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata, metadata, num_rows * sizeof(char)), 0);
     CU_ASSERT_EQUAL(memcmp(table.metadata_offset, metadata_offset, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, num_rows);
 
     /* flags and time cannot be NULL */
-    ret = node_table_set_columns(&table, num_rows, NULL, time, population, metadata,
-            metadata_offset);
+    ret = node_table_set_columns(&table, num_rows, NULL, time, population, individual,
+            metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = node_table_set_columns(&table, num_rows, flags, NULL, population, metadata,
-            metadata_offset);
+    ret = node_table_set_columns(&table, num_rows, flags, NULL, population, individual,
+            metadata, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = node_table_set_columns(&table, num_rows, flags, time, population, NULL,
-            metadata_offset);
+    ret = node_table_set_columns(&table, num_rows, flags, time, population, individual,
+            NULL, metadata_offset);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = node_table_set_columns(&table, num_rows, flags, time, population, metadata,
-            NULL);
+    ret = node_table_set_columns(&table, num_rows, flags, time, population, individual,
+            metadata, NULL);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
     /* if metadata and metadata_offset are both null, all metadatas are zero length */
     num_rows = 10;
     memset(metadata_offset, 0, (num_rows + 1) * sizeof(table_size_t));
-    ret = node_table_set_columns(&table, num_rows, flags, time, NULL, NULL, NULL);
+    ret = node_table_set_columns(&table, num_rows, flags, time, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.time, time, num_rows * sizeof(double)), 0);
@@ -6475,7 +6492,7 @@ test_node_table(void)
                 (num_rows + 1) * sizeof(table_size_t)), 0);
     CU_ASSERT_EQUAL(table.num_rows, num_rows);
     CU_ASSERT_EQUAL(table.metadata_length, 0);
-    ret = node_table_append_columns(&table, num_rows, flags, time, NULL, NULL, NULL);
+    ret = node_table_append_columns(&table, num_rows, flags, time, NULL, NULL, NULL, NULL);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(memcmp(table.flags, flags, num_rows * sizeof(uint32_t)), 0);
     CU_ASSERT_EQUAL(memcmp(table.flags + num_rows, flags, num_rows * sizeof(uint32_t)), 0);
@@ -7632,6 +7649,7 @@ test_load_node_table_errors(void)
     double time = 0;
     double flags = 0;
     int32_t population = 0;
+    int32_t individual = 0;
     int8_t metadata = 0;
     uint32_t metadata_offset[] = {0, 1};
     uint32_t version[2] = {
@@ -7640,6 +7658,7 @@ test_load_node_table_errors(void)
         {"nodes/time", (void *) &time, 1, KAS_FLOAT64},
         {"nodes/flags", (void *) &flags, 1, KAS_UINT32},
         {"nodes/population", (void *) &population, 1, KAS_INT32},
+        {"nodes/individual", (void *) &individual, 1, KAS_INT32},
         {"nodes/metadata", (void *) &metadata, 1, KAS_UINT8},
         {"nodes/metadata_offset", (void *) metadata_offset, 2, KAS_UINT32},
         {"format/name", (void *) format_name, sizeof(format_name), KAS_INT8},
@@ -7704,7 +7723,7 @@ test_load_node_table_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Wrong length for metadata offset */
-    write_cols[4].len = 1;
+    write_cols[5].len = 1;
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     write_table_cols(&store, write_cols, sizeof(write_cols) / sizeof(*write_cols));

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6329,7 +6329,38 @@ test_load_text(void)
     tree_sequence_t *ts1;
     size_t j;
     table_collection_t tables, tables2;
-    FILE *tmpfile;
+    FILE *node_file, *edge_file, *site_file, *muta_file;
+    FILE *migr_file, *indi_file, *prov_file;
+    char *node_file_name, *edge_file_name, *site_file_name, *muta_file_name;
+    char *migr_file_name, *indi_file_name, *prov_file_name;
+
+    node_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(node_file_name, _tmp_file_name);
+    strcat(node_file_name, "node");
+
+    edge_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(edge_file_name, _tmp_file_name);
+    strcat(edge_file_name, "edge");
+
+    site_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(site_file_name, _tmp_file_name);
+    strcat(site_file_name, "site");
+
+    muta_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(muta_file_name, _tmp_file_name);
+    strcat(muta_file_name, "muta");
+
+    migr_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(migr_file_name, _tmp_file_name);
+    strcat(migr_file_name, "migr");
+
+    indi_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(indi_file_name, _tmp_file_name);
+    strcat(indi_file_name, "indi");
+
+    prov_file_name = malloc(strlen(_tmp_file_name) + 4);
+    strcpy(prov_file_name, _tmp_file_name);
+    strcat(prov_file_name, "prov");
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6342,86 +6373,93 @@ test_load_text(void)
         ret = tree_sequence_dump_tables(ts1, &tables, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-fprintf(stdout, "BEGIN example %d  ::::::::::::::::::::::::::::::::::::::\n", (int) j); fflush(stdout);
-table_collection_print_state(&tables, stdout);
-fprintf(stdout, "::::::::::::::::::::::::::::::::::::::\n"); fflush(stdout);
+        node_file = fopen(node_file_name, "w");
+        ret = node_table_dump_text(&tables.nodes, node_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(node_file);
+        node_file = fopen(node_file_name, "r");
+        /* ret = node_table_load_text(&tables2.nodes, node_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = node_table_dump_text(&tables.nodes, tmpfile);
+        edge_file = fopen(edge_file_name, "w");
+        ret = edge_table_dump_text(&tables.edges, edge_file);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = node_table_load_text(&tables2.nodes, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
+        fclose(edge_file);
+        edge_file = fopen(edge_file_name, "r");
+        /* ret = edge_table_load_text(&tables2.edges, edge_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = edge_table_dump_text(&tables.edges, tmpfile);
+        site_file = fopen(site_file_name, "w");
+        ret = site_table_dump_text(&tables.sites, site_file);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = edge_table_load_text(&tables2.edges, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
+        fclose(site_file);
+        site_file = fopen(site_file_name, "r");
+        /* ret = site_table_load_text(&tables2.sites, site_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = site_table_dump_text(&tables.sites, tmpfile);
+        muta_file = fopen(muta_file_name, "w");
+        ret = mutation_table_dump_text(&tables.mutations, muta_file);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = site_table_load_text(&tables2.sites, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
+        fclose(muta_file);
+        muta_file = fopen(muta_file_name, "r");
+        /* ret = mutation_table_load_text(&tables2.mutations, muta_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = mutation_table_dump_text(&tables.mutations, tmpfile);
+        migr_file = fopen(migr_file_name, "w");
+        ret = migration_table_dump_text(&tables.migrations, migr_file);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = mutation_table_load_text(&tables2.mutations, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
+        fclose(migr_file);
+        migr_file = fopen(migr_file_name, "r");
+        /* ret = migration_table_load_text(&tables2.migrations, migr_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = migration_table_dump_text(&tables.migrations, tmpfile);
+        indi_file = fopen(indi_file_name, "w");
+        ret = individual_table_dump_text(&tables.individuals, indi_file);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = migration_table_load_text(&tables2.migrations, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
+        fclose(indi_file);
+        indi_file = fopen(indi_file_name, "r");
+        /* ret = individual_table_load_text(&tables2.individuals, indi_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = individual_table_dump_text(&tables.individuals, tmpfile);
+        prov_file = fopen(prov_file_name, "w");
+        ret = provenance_table_dump_text(&tables.provenances, prov_file);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = individual_table_load_text(&tables2.individuals, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
+        fclose(prov_file);
+        prov_file = fopen(prov_file_name, "r");
+        /* ret = provenance_table_load_text(&tables2.provenances, prov_file);
+        CU_ASSERT_EQUAL_FATAL(ret, 0); */
 
-        tmpfile = fopen(_tmp_file_name, "w");
-        ret = provenance_table_dump_text(&tables.provenances, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-        tmpfile = fopen(_tmp_file_name, "r");
-        ret = provenance_table_load_text(&tables2.provenances, tmpfile);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-        fclose(tmpfile);
-
-table_collection_print_state(&tables2, stdout);
-fprintf(stdout, "END example %d  ::::::::::::::::::::::::::::::::::::::\n", (int) j); fflush(stdout);
-
-        ret = tree_sequence_load_tables(&ts2, &tables2, 0);
-fprintf(stdout, "XX ret = %s\n", msp_strerror(ret)); fflush(stdout);
+        ret = table_collection_load_text(&tables2, node_file, edge_file,
+                site_file, muta_file, migr_file, indi_file, prov_file);
+        /* fprintf(stdout, "\ntesting (%d)::::::::::::::::::\n", (int) j); fflush(stdout); */
+        /* table_collection_print_state(&tables, stdout); */
+        /* fprintf(stdout, "\n(%d) ::::::::::::::::::::::::::::::\n", (int) j); fflush(stdout); */
+        /* table_collection_print_state(&tables2, stdout); */
+        /* fprintf(stdout, "\n(%d) ::::::::::::::::::::::::::::::\n", (int) j); fflush(stdout); */
+        /* ret = tree_sequence_load_tables(&ts2, &tables2, 0); */
+        /* fprintf(stdout, "\nret = %s\n", msp_strerror(ret)); fflush(stdout); */
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
+        fclose(prov_file);
+        fclose(indi_file);
+        fclose(migr_file);
+        fclose(muta_file);
+        fclose(site_file);
+        fclose(edge_file);
+        fclose(node_file);
 
         tree_sequence_free(&ts2);
         tree_sequence_free(ts1);
         free(ts1);
     }
 
+    free(prov_file_name);
+    free(indi_file_name);
+    free(migr_file_name);
+    free(muta_file_name);
+    free(site_file_name);
+    free(edge_file_name);
+    free(node_file_name);
     free(examples);
     table_collection_free(&tables);
     table_collection_free(&tables2);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6320,6 +6320,112 @@ test_dump_tables_kas(void)
     table_collection_free(&tables);
 }
 
+static void
+test_load_text(void)
+{
+    int ret;
+    tree_sequence_t **examples = get_example_tree_sequences(1);
+    tree_sequence_t ts2;
+    tree_sequence_t *ts1;
+    size_t j;
+    table_collection_t tables, tables2;
+    FILE *tmpfile;
+
+    ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = table_collection_alloc(&tables2, MSP_ALLOC_TABLES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_FATAL(examples != NULL);
+
+    for (j = 0; examples[j] != NULL; j++) {
+        ts1 = examples[j];
+        ret = tree_sequence_dump_tables(ts1, &tables, 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+fprintf(stdout, "BEGIN example %d  ::::::::::::::::::::::::::::::::::::::\n", (int) j); fflush(stdout);
+table_collection_print_state(&tables, stdout);
+fprintf(stdout, "::::::::::::::::::::::::::::::::::::::\n"); fflush(stdout);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = node_table_dump_text(&tables.nodes, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = node_table_load_text(&tables2.nodes, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = edge_table_dump_text(&tables.edges, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = edge_table_load_text(&tables2.edges, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = site_table_dump_text(&tables.sites, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = site_table_load_text(&tables2.sites, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = mutation_table_dump_text(&tables.mutations, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = mutation_table_load_text(&tables2.mutations, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = migration_table_dump_text(&tables.migrations, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = migration_table_load_text(&tables2.migrations, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = individual_table_dump_text(&tables.individuals, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = individual_table_load_text(&tables2.individuals, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+        tmpfile = fopen(_tmp_file_name, "w");
+        ret = provenance_table_dump_text(&tables.provenances, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+        tmpfile = fopen(_tmp_file_name, "r");
+        ret = provenance_table_load_text(&tables2.provenances, tmpfile);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        fclose(tmpfile);
+
+table_collection_print_state(&tables2, stdout);
+fprintf(stdout, "END example %d  ::::::::::::::::::::::::::::::::::::::\n", (int) j); fflush(stdout);
+
+        ret = tree_sequence_load_tables(&ts2, &tables2, 0);
+fprintf(stdout, "XX ret = %s\n", msp_strerror(ret)); fflush(stdout);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        verify_tree_sequences_equal(ts1, &ts2, true, true, true);
+
+        tree_sequence_free(&ts2);
+        tree_sequence_free(ts1);
+        free(ts1);
+    }
+
+    free(examples);
+    table_collection_free(&tables);
+    table_collection_free(&tables2);
+}
 
 static void
 test_strerror(void)
@@ -7912,6 +8018,7 @@ main(int argc, char **argv)
         {"test_deduplicate_sites", test_deduplicate_sites},
         {"test_deduplicate_sites_errors", test_deduplicate_sites_errors},
         {"test_dump_tables_kas", test_dump_tables_kas},
+        {"test_load_text", test_load_text},
         {"test_strerror", test_strerror},
         {"test_node_table", test_node_table},
         {"test_edge_table", test_edge_table},

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -290,6 +290,7 @@ tree_sequence_check(tree_sequence_t *self)
     for (j = 0; j < self->sites.num_records; j++) {
         if (self->sites.position[j] < 0
                 || self->sites.position[j] >= self->sequence_length) {
+fprintf(stdout, "A: %d : pos = %.17g but len = %.17g\n", j, self->sites.position[j], self->sequence_length); fflush(stdout);
             ret = MSP_ERR_BAD_SITE_POSITION;
             goto out;
         }
@@ -380,6 +381,7 @@ tree_sequence_init_sites(tree_sequence_t *self)
     for (j = 0; j < (site_id_t) self->sites.num_records; j++) {
         if (self->sites.position[j] < 0
                 || self->sites.position[j] >= self->sequence_length) {
+fprintf(stdout, "B: %d : pos = %.17g but len = %.17g\n", j, self->sites.position[j], self->sequence_length); fflush(stdout);
             ret = MSP_ERR_BAD_SITE_POSITION;
             goto out;
         }

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -84,9 +84,10 @@ tree_sequence_print_state(tree_sequence_t *self, FILE *out)
     }
     fprintf(out, "nodes (%d)\n", (int) self->nodes.num_records);
     for (j = 0; j < self->nodes.num_records; j++) {
-        fprintf(out, "\t%d\t%d\t%d\t%f\t%d\t", (int) j,
+        fprintf(out, "\t%d\t%d\t%d\t%d\t%f\t%d\t", (int) j,
                 self->nodes.flags[j],
                 (int) self->nodes.population[j],
+                (int) self->nodes.individual[j],
                 self->nodes.time[j],
                 self->nodes.sample_index_map[j]);
         for (k = self->nodes.metadata_offset[j]; k < self->nodes.metadata_offset[j + 1]; k++) {
@@ -575,6 +576,7 @@ tree_sequence_load_tables(tree_sequence_t *self, table_collection_t *tables,
     self->nodes.flags = self->tables->nodes.flags;
     self->nodes.time = self->tables->nodes.time;
     self->nodes.population = self->tables->nodes.population;
+    self->nodes.individual = self->tables->nodes.individual;
     self->nodes.metadata = self->tables->nodes.metadata;
     self->nodes.metadata_offset = self->tables->nodes.metadata_offset;
 
@@ -829,6 +831,7 @@ tree_sequence_get_node(tree_sequence_t *self, node_id_t index, node_t *node)
     }
     node->time = self->nodes.time[index];
     node->population = self->nodes.population[index];
+    node->individual = self->nodes.individual[index];
     node->flags = self->nodes.flags[index];
     offset = self->nodes.metadata_offset[index];
     length = self->nodes.metadata_offset[index + 1] - offset;

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -289,8 +289,7 @@ tree_sequence_check(tree_sequence_t *self)
     /* Check the sites */
     for (j = 0; j < self->sites.num_records; j++) {
         if (self->sites.position[j] < 0
-                || self->sites.position[j] >= self->sequence_length) {
-fprintf(stdout, "A: %d : pos = %.17g but len = %.17g\n", j, self->sites.position[j], self->sequence_length); fflush(stdout);
+                || self->sites.position[j] > self->sequence_length) {
             ret = MSP_ERR_BAD_SITE_POSITION;
             goto out;
         }
@@ -380,8 +379,7 @@ tree_sequence_init_sites(tree_sequence_t *self)
     k = 0;
     for (j = 0; j < (site_id_t) self->sites.num_records; j++) {
         if (self->sites.position[j] < 0
-                || self->sites.position[j] >= self->sequence_length) {
-fprintf(stdout, "B: %d : pos = %.17g but len = %.17g\n", j, self->sites.position[j], self->sequence_length); fflush(stdout);
+                || self->sites.position[j] > self->sequence_length) {
             ret = MSP_ERR_BAD_SITE_POSITION;
             goto out;
         }
@@ -571,7 +569,7 @@ tree_sequence_load_tables(tree_sequence_t *self, table_collection_t *tables,
         ret = MSP_ERR_BAD_SEQUENCE_LENGTH;
         goto out;
     }
-    /* TODO It's messy having two copyies of this value. Should be in one place. */
+    /* TODO It's messy having two copies of this value. Should be in one place. */
     self->tables->sequence_length = self->sequence_length;
 
     self->nodes.num_records = self->tables->nodes.num_rows;

--- a/lib/trees.h
+++ b/lib/trees.h
@@ -39,6 +39,7 @@ typedef struct {
         double *time;
         uint32_t *flags;
         population_id_t *population;
+        individual_id_t *individual;
         char *metadata;
         table_size_t *metadata_offset;
         node_id_t *sample_index_map;

--- a/lib/util.h
+++ b/lib/util.h
@@ -41,6 +41,8 @@
 #define MSP_NULL_POPULATION_ID (-1)
 /* There is no parent for a given mutation */
 #define MSP_NULL_MUTATION (-1)
+/* Indicates that no individual has been set */
+#define MSP_NULL_INDIVIDUAL (-1)
 
 /* Flags for simplify() */
 #define MSP_FILTER_ZERO_MUTATION_SITES 1

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1523,14 +1523,15 @@ class TestTreeSequenceTextIO(HighLevelTestCase):
         self.assertEqual(len(output_nodes) - 1, ts.num_nodes)
         self.assertEqual(
             list(output_nodes[0].split()),
-            ["id", "is_sample", "time", "population", "metadata"])
+            ["id", "is_sample", "time", "population", "individual", "metadata"])
         for node, line in zip(ts.nodes(), output_nodes[1:]):
             splits = line.split("\t")
             self.assertEqual(str(node.id), splits[0])
             self.assertEqual(str(node.is_sample()), splits[1])
             self.assertEqual(convert(node.time), splits[2])
             self.assertEqual(str(node.population), splits[3])
-            self.assertEqual(tests.base64_encode(node.metadata), splits[4])
+            self.assertEqual(str(node.individual), splits[4])
+            self.assertEqual(tests.base64_encode(node.metadata), splits[5])
 
     def verify_edges_format(self, ts, edges_file, precision):
         """

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -569,7 +569,7 @@ class TestSimulationState(LowLevelTestCase):
         self.assertEqual(breakpoints, sorted(breakpoints))
         nodes = sim.get_nodes()
         self.assertEqual(len(nodes), sim.get_num_nodes())
-        for j, (flags, t, pop, metadata) in enumerate(nodes):
+        for j, (flags, t, pop, ind, metadata) in enumerate(nodes):
             if j < sim.get_num_samples():
                 self.assertEqual(t, 0.0)
                 self.assertEqual(flags, 1)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -502,14 +502,15 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
 
     def test_simple_example(self):
         t = msprime.NodeTable()
-        t.add_row(flags=0, time=1, population=2, metadata=b"123")
-        t.add_row(flags=1, time=2, population=3, metadata=b"456")
+        t.add_row(flags=0, time=1, population=2, individual=0, metadata=b"123")
+        t.add_row(flags=1, time=2, population=3, individual=1, metadata=b"456")
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0], (0, 1, 2, b"123"))
-        self.assertEqual(t[1], (1, 2, 3, b"456"))
+        self.assertEqual(t[0], (0, 1, 2, 0, b"123"))
+        self.assertEqual(t[1], (1, 2, 3, 1, b"456"))
         self.assertEqual(t[0].flags, 0)
         self.assertEqual(t[0].time, 1)
         self.assertEqual(t[0].population, 2)
+        self.assertEqual(t[0].individual, 0)
         self.assertEqual(t[0].metadata, b"123")
         self.assertEqual(t[0], t[-2])
         self.assertEqual(t[1], t[-1])
@@ -521,6 +522,7 @@ class TestNodeTable(unittest.TestCase, CommonTestsMixin, MetadataTestsMixin):
         self.assertEqual(t.time[0], 0)
         self.assertEqual(t.flags[0], 0)
         self.assertEqual(t.population[0], msprime.NULL_POPULATION)
+        self.assertEqual(t.individual[0], msprime.NULL_INDIVIDUAL)
         self.assertEqual(len(t.metadata), 0)
         self.assertEqual(t.metadata_offset[0], 0)
 


### PR DESCRIPTION
This would be a handy thing to have.  But, maybe it should be kept separate?  And, it should really be against #472.

This does not do population tables yet.

I believe it is working; but, it fails on the "gappy" test tree sequence, because that one puts a site to the right of all the edges; and this method has no way to record sequence_length other than inferring it from the edges.  I can just skip that tests, unless there's a compelling reason not to. 

This is not supposed to be a completely robust input method: it assumes that all columns are present, and that columns are separated by exactly one tab.

Also, there were (predictably) issues with floating point precision. I've changed all the precisions in `_dump_text` to be larger to fix this problem.  How do you feel about this, @jeromekelleher?