### PR TITLE
Add UUID to file format.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -11,7 +11,7 @@ LDFLAGS=-lgsl -lgslcblas -lm
 HEADERS=msprime.h util.h trees.h tables.h
 COMPILED=msprime.o fenwick.o tree_sequence.o object_heap.o newick.o \
     hapgen.o recomb_map.o mutgen.o vargen.o vcf.o ld.o avl.o tables.o util.o \
-    kastore.o
+    uuid.o kastore.o
 
 all: main simulation_tests tests table_example table_example_cpp
 
@@ -59,9 +59,9 @@ coverity:
 
 # Examples using just the tables API.
 table_example: table_example.c
-	gcc -Ikastore/c -o table_example table_example.c tables.c util.c kastore/c/kastore.c
+	gcc -Ikastore/c -o table_example table_example.c tables.c uuid.c util.c kastore/c/kastore.c
 
 # Make sure that all the files are compiled as C code.
 table_example_cpp: table_example_cpp.cc tables.o util.o
 	g++ -std=c++11 -Ikastore/c -o table_example_cpp table_example_cpp.cc tables.o util.o \
-		kastore.o
+		uuid.o kastore.o

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -21,6 +21,7 @@
  * Unit tests for the low-level msprime API.
  */
 #include "msprime.h"
+#include "uuid.h"
 
 #include <float.h>
 #include <limits.h>
@@ -8037,6 +8038,28 @@ test_load_node_table_errors(void)
 
 }
 
+void
+test_generate_uuid(void)
+{
+    size_t uuid_size = 36;
+    char uuid[uuid_size + 1];
+    char other_uuid[uuid_size + 1];
+    int ret;
+
+    ret = tsk_generate_uuid(uuid, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(strlen(uuid), uuid_size);
+    CU_ASSERT_EQUAL(uuid[8], '-');
+    CU_ASSERT_EQUAL(uuid[13], '-');
+    CU_ASSERT_EQUAL(uuid[18], '-');
+    CU_ASSERT_EQUAL(uuid[23], '-');
+
+    ret = tsk_generate_uuid(other_uuid, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(strlen(other_uuid), uuid_size);
+    CU_ASSERT_STRING_NOT_EQUAL(uuid, other_uuid);
+}
+
 static int
 msprime_suite_init(void)
 {
@@ -8202,6 +8225,7 @@ main(int argc, char **argv)
         {"test_table_collection_dump_errors", test_table_collection_dump_errors},
         {"test_table_collection_set_tables", test_table_collection_set_tables},
         {"test_load_node_table_errors", test_load_node_table_errors},
+        {"test_generate_uuid", test_generate_uuid},
         CU_TEST_INFO_NULL,
     };
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -250,6 +250,9 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_INDIVIDUAL:
             ret = "Individual ID not in individual table.";
             break;
+        case MSP_ERR_GENERATE_UUID:
+            ret = "Error generating UUID";
+            break;
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);

--- a/lib/util.h
+++ b/lib/util.h
@@ -151,6 +151,7 @@
 #define MSP_ERR_MUTATION_PARENT_EQUAL                               -70
 #define MSP_ERR_MUTATION_PARENT_AFTER_CHILD                         -71
 #define MSP_ERR_BAD_INDIVIDUAL                                      -72
+#define MSP_ERR_GENERATE_UUID                                       -73
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -1,0 +1,77 @@
+/*
+** Copyright (C) 2018 University of Oxford
+**
+** This file is part of msprime.
+**
+** msprime is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** msprime is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with msprime.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "util.h"
+#include "uuid.h"
+
+
+#define NUM_BYTES 16
+
+static int WARN_UNUSED
+get_random_bytes(uint8_t *buf)
+{
+    int ret = MSP_ERR_GENERATE_UUID;
+    FILE *f = fopen("/dev/urandom", "r");
+
+    if (f == NULL) {
+        goto out;
+    }
+    if (fread(buf, NUM_BYTES, 1, f) != 1) {
+        goto out;
+    }
+    if (fclose(f) != 0) {
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+/* Generate a new UUID4 using a system-generated source of randomness.
+ * Note that this function writes a NULL terminator to the end of this
+ * string, so that the total length of the buffer must be 37 bytes.
+ */
+int
+tsk_generate_uuid(char *dest, int MSP_UNUSED(flags))
+{
+    int ret = 0;
+    uint8_t buf[NUM_BYTES];
+    const char *pattern =
+        "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x";
+
+    ret = get_random_bytes(buf);
+    if (ret != 0) {
+        goto out;
+    }
+    if (snprintf(dest, TSK_UUID_SIZE + 1, pattern,
+            buf[0], buf[1], buf[2], buf[3],
+            buf[4], buf[5], buf[6], buf[7],
+            buf[8], buf[9], buf[10], buf[11],
+            buf[12], buf[13], buf[14], buf[15]) < 0) {
+        ret = MSP_ERR_GENERATE_UUID;
+        goto out;
+    }
+out:
+    return ret;
+}

--- a/lib/uuid.h
+++ b/lib/uuid.h
@@ -1,0 +1,15 @@
+#ifndef TSK_UUID_H
+#define TSK_UUID_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TSK_UUID_SIZE 36
+
+int tsk_generate_uuid(char *dest, int flags);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* TSK_UUID_H */

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ configurator = PathConfigurator()
 source_files = [
     "msprime.c", "fenwick.c", "avl.c", "tree_sequence.c",
     "object_heap.c", "newick.c", "hapgen.c", "recomb_map.c", "mutgen.c",
-    "vargen.c", "vcf.c", "ld.c", "tables.c", "util.c",
+    "vargen.c", "vcf.c", "ld.c", "tables.c", "util.c", "uuid.c",
     os.path.join(kastore_dir, "kastore.c")]
 
 

--- a/setup.py
+++ b/setup.py
@@ -126,14 +126,19 @@ class DefineMacros(object):
         return defines[index]
 
 
+libraries = ["gsl", "gslcblas"]
+if IS_WINDOWS:
+    # Needed for generating UUIDs
+    libraries.append("Advapi32")
+
 _msprime_module = Extension(
     '_msprime',
     sources=["_msprimemodule.c"] + [os.path.join(libdir, f) for f in source_files],
     # Enable asserts by default.
     undef_macros=["NDEBUG"],
     extra_compile_args=["-std=c99"],
+    libraries=libraries,
     define_macros=DefineMacros(),
-    libraries=["gsl", "gslcblas"],
     include_dirs=includes + [
         os.path.join(libdir, kastore_dir)] + configurator.include_dirs,
     library_dirs=configurator.library_dirs,

--- a/tests/test_file_format.py
+++ b/tests/test_file_format.py
@@ -592,6 +592,20 @@ class TestDumpFormat(TestFileFormat):
         self.verify_dump_format(multichar_mutation_example())
 
 
+class TestUuid(TestFileFormat):
+    """
+    Basic tests for the UUID generation.
+    """
+    def test_different_files_same_ts(self):
+        ts = msprime.simulate(10)
+        uuids = []
+        for _ in range(10):
+            ts.dump(self.temp_file)
+            with kastore.load(self.temp_file, use_mmap=False) as store:
+                uuids.append(store["uuid"].tobytes().decode())
+        self.assertEqual(len(uuids), len(set(uuids)))
+
+
 class TestFileFormatErrors(TestFileFormat):
     """
     Tests for errors in the HDF5 format.


### PR DESCRIPTION
Closes #479 . 

This should do fine for the unix implementation. Will need to do something else to get random bytes for Windows, but it shouldn't be too hard.

The protocol is to just generate a new UUID for every time we dump. I think this is probably fine --- we can worry about the how to store the provenance of UUIDs we're generating from later. Basically, the UUID is a property of the **file** not the tree sequence/tables.

What do you think @petrelharp?