### PR TITLE
Added root argument to Tree.newick().

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -6748,17 +6748,16 @@ static PyObject *
 SparseTree_get_newick(SparseTree *self, PyObject *args, PyObject *kwds)
 {
     PyObject *ret = NULL;
-    static char *kwlist[] = {"precision", "time_scale", NULL};
+    static char *kwlist[] = {"root", "precision", NULL};
     int precision = 14;
-    double time_scale = 1.0;
-    int err;
+    int root, err;
     size_t buffer_size;
     char *buffer = NULL;
 
     if (SparseTree_check_sparse_tree(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|id", kwlist, &precision, &time_scale)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "i|i", kwlist, &root, &precision)) {
         goto out;
     }
     if (precision < 0 || precision > 16) {
@@ -6775,7 +6774,7 @@ SparseTree_get_newick(SparseTree *self, PyObject *args, PyObject *kwds)
     if (buffer == NULL) {
         PyErr_NoMemory();
     }
-    err = sparse_tree_get_newick(self->sparse_tree, precision, time_scale, 0,
+    err = sparse_tree_get_newick(self->sparse_tree, (node_id_t) root, precision, 0,
             buffer_size, buffer);
     if (err != 0) {
         handle_library_error(err);

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -499,10 +499,6 @@ this script using:
 
     $ python verification.py
 
-.. warning::
-
-    The ``verification.py`` currently does not support Python 3 because of odd
-    behaviour from dendropy.
 
 The statistical tests depend on compiled programs in the ``data`` directory.
 This includes a customised version of ``ms`` and a locally compiled version of

--- a/lib/main.c
+++ b/lib/main.c
@@ -764,7 +764,8 @@ print_newick_trees(tree_sequence_t *ts)
         fatal_error("ERROR: %d: %s\n", ret, msp_strerror(ret));
     }
     for (ret = sparse_tree_first(&tree); ret == 1; ret = sparse_tree_next(&tree)) {
-        ret = sparse_tree_get_newick(&tree, precision, 1, 0, newick_buffer_size, newick);
+        ret = sparse_tree_get_newick(&tree, tree.left_root, precision,
+                0, newick_buffer_size, newick);
         if (ret != 0) {
             fatal_library_error(ret ,"newick");
         }

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -1805,17 +1805,17 @@ sparse_tree_get_sites(sparse_tree_t *self, site_t **sites, table_size_t *sites_l
 }
 
 int WARN_UNUSED
-sparse_tree_get_newick(sparse_tree_t *self, size_t precision, double time_scale,
+sparse_tree_get_newick(sparse_tree_t *self, node_id_t root, size_t precision,
         int flags, size_t buffer_size, char *newick_buffer)
 {
     int ret = 0;
     newick_converter_t nc;
 
-    ret = newick_converter_alloc(&nc, self, precision, time_scale, flags);
+    ret = newick_converter_alloc(&nc, self, precision, flags);
     if (ret != 0) {
         goto out;
     }
-    ret = newick_converter_run(&nc, buffer_size, newick_buffer);
+    ret = newick_converter_run(&nc, root, buffer_size, newick_buffer);
 out:
     newick_converter_free(&nc);
     return ret;

--- a/lib/trees.h
+++ b/lib/trees.h
@@ -195,7 +195,6 @@ typedef struct {
 
 typedef struct {
     size_t precision;
-    double time_scale;
     int flags;
     char *newick;
     sparse_tree_t *tree;
@@ -334,8 +333,8 @@ int sparse_tree_get_num_tracked_samples(sparse_tree_t *self, node_id_t u,
 int sparse_tree_get_sample_list(sparse_tree_t *self, node_id_t u,
         node_list_t **head, node_list_t **tail);
 int sparse_tree_get_sites(sparse_tree_t *self, site_t **sites, table_size_t *sites_length);
-int sparse_tree_get_newick(sparse_tree_t *self, size_t precision, double time_scale,
-        int flags, size_t buffer_size, char *newick_buffer);
+int sparse_tree_get_newick(sparse_tree_t *self, node_id_t root,
+        size_t precision, int flags, size_t buffer_size, char *newick_buffer);
 
 void sparse_tree_print_state(sparse_tree_t *self, FILE *out);
 /* Method for positioning the tree in the sequence. */
@@ -346,8 +345,9 @@ int sparse_tree_prev(sparse_tree_t *self);
 
 /* TODO remove this from the public API. */
 int newick_converter_alloc(newick_converter_t *self,
-        sparse_tree_t *tree, size_t precision, double time_scale, int flags);
-int newick_converter_run(newick_converter_t *self, size_t buffer_size, char *buffer);
+        sparse_tree_t *tree, size_t precision, int flags);
+int newick_converter_run(newick_converter_t *self, node_id_t root,
+        size_t buffer_size, char *buffer);
 int newick_converter_free(newick_converter_t *self);
 
 int vcf_converter_alloc(vcf_converter_t *self,

--- a/lib/util.c
+++ b/lib/util.c
@@ -220,9 +220,6 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_EDGESET_OVERLAPPING_PARENT:
             ret = "Bad edges: multiple definitions of a given parent over an interval";
             break;
-        case MSP_ERR_MULTIROOT_NEWICK:
-            ret = "Newick output not supported for trees with > 1 roots.";
-            break;
         case MSP_ERR_BAD_SEQUENCE_LENGTH:
             ret = "Sequence length must be > 0.";
             break;

--- a/lib/util.h
+++ b/lib/util.h
@@ -122,7 +122,7 @@
 #define MSP_ERR_BAD_RECOMBINATION_MAP                               -26
 #define MSP_ERR_BAD_POPULATION_SIZE                                 -27
 #define MSP_ERR_BAD_SAMPLES                                         -28
-#define MSP_ERR_MULTIROOT_NEWICK                                    -29
+
 #define MSP_ERR_FILE_VERSION_TOO_OLD                                -30
 #define MSP_ERR_FILE_VERSION_TOO_NEW                                -31
 #define MSP_ERR_CANNOT_SIMPLIFY                                     -32
@@ -167,6 +167,9 @@
 #define MSP_ERR_MUTATION_PARENT_AFTER_CHILD                         -71
 #define MSP_ERR_BAD_INDIVIDUAL                                      -72
 #define MSP_ERR_GENERATE_UUID                                       -73
+
+/* REUSE: * -29, -57 */
+
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -124,11 +124,8 @@ class SimulationRunner(object):
         self._sample_size = sample_size
         self._num_loci = num_loci
         self._num_replicates = num_replicates
-        # We use unscaled per-generation rates. By setting Ne = 1 we
-        # don't need to rescale, but we still need to divide by 4 to
-        # cancel the factor introduced when calculated the scaled rates.
-        self._recombination_rate = scaled_recombination_rate / 4
-        self._mutation_rate = scaled_mutation_rate / 4
+        self._recombination_rate = scaled_recombination_rate
+        self._mutation_rate = scaled_mutation_rate
         # For strict ms-compability we want to have m non-recombining loci
         recomb_map = msprime.RecombinationMap.uniform_map(
             num_loci, self._recombination_rate, num_loci)
@@ -138,6 +135,7 @@ class SimulationRunner(object):
         if population_configurations is not None:
             sample_size = None
         self._simulator = msprime.simulator_factory(
+            Ne=0.25,
             sample_size=sample_size,
             recombination_map=recomb_map,
             population_configurations=population_configurations,
@@ -183,15 +181,14 @@ class SimulationRunner(object):
         simulation and write out a tree for each one.
         """
         breakpoints = self._simulator.breakpoints + [self._num_loci]
-        time_scale = 0.25
         if self._num_loci == 1:
             tree = next(tree_sequence.trees())
-            newick = tree.newick(precision=self._precision, time_scale=time_scale)
+            newick = tree.newick(precision=self._precision)
             print(newick, file=output)
         else:
             j = 0
             for tree in tree_sequence.trees():
-                newick = tree.newick(precision=self._precision, time_scale=time_scale)
+                newick = tree.newick(precision=self._precision)
                 left, right = tree.interval
                 while j < len(breakpoints) and breakpoints[j] <= right:
                     length = breakpoints[j] - left

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2016 University of Oxford
+# Copyright (C) 2015-2018 University of Oxford
 #
 # This file is part of msprime.
 #
@@ -134,6 +134,9 @@ class SimulationRunner(object):
         sample_size = self._sample_size
         if population_configurations is not None:
             sample_size = None
+        # msprime measure's time in units of generations, given a specific
+        # Ne value whereas ms uses coalescent time. To be compatible with ms,
+        # we therefore need to use an Ne value of 1/4.
         self._simulator = msprime.simulator_factory(
             Ne=0.25,
             sample_size=sample_size,
@@ -341,8 +344,7 @@ def create_simulation_runner(parser, arg_list):
     # Check the structure format.
     symmetric_migration_rate = 0.0
     num_populations = 1
-    population_configurations = [
-        msprime.PopulationConfiguration(args.sample_size)]
+    population_configurations = [msprime.PopulationConfiguration(args.sample_size)]
     migration_matrix = [[0.0]]
     if args.structure is not None:
         num_populations = convert_int(args.structure[0], parser)
@@ -511,19 +513,16 @@ def create_simulation_runner(parser, arg_list):
                         t, matrix[j][k], (j, k))
                     demographic_events.append((index, msp_event))
 
-    # We've created all the events, now we need to rescale the migration rates
-    # We assume Ne = 1 here.
+    # We've created all the events and PopulationConfiguration objects. Because
+    # msprime uses absolute population sizes we need to rescale these relative
+    # to Ne, since this is what ms does.
     for _, msp_event in demographic_events:
-        msp_event.time *= 4
         if isinstance(msp_event, msprime.PopulationParametersChange):
-            msp_event.growth_rate /= 4
-        if isinstance(msp_event, msprime.MigrationRateChange):
-            # Divide by 4 to get a per-generation rate, assuming Ne=1
-            msp_event.rate /= 4
-    # We also need to rescale the migration matrix and growth rates.
-    migration_matrix = [[m / 4 for m in row] for row in migration_matrix]
+            if msp_event.initial_size is not None:
+                msp_event.initial_size /= 4
     for config in population_configurations:
-        config.growth_rate /= 4
+        if config.initial_size is not None:
+            config.initial_size /= 4
 
     demographic_events.sort(key=lambda x: (x[0], x[1].time))
     time_sorted = sorted(demographic_events, key=lambda x: x[1].time)

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1072,18 +1072,46 @@ class SparseTree(object):
             for v in iterator(u):
                 yield v
 
-    def newick(self, precision=14, root=None):
+    # TODO make this a bit less embarrassing by using an iterative method.
+    def __build_newick(self, node, precision, node_labels):
+        """
+        Simple recursive version of the newick generator used when non-default
+        node labels are needed.
+        """
+        label = node_labels.get(node, "")
+        if self.is_leaf(node):
+            s = "{0}".format(label)
+        else:
+            s = "("
+            for child in self.children(node):
+                branch_length = self.branch_length(child)
+                subtree = self.__build_newick(child, precision, node_labels)
+                s += subtree + ":{0:.{1}f},".format(branch_length, precision)
+            s = s[:-1] + "){}".format(label)
+        return s
+
+    def newick(self, precision=14, root=None, node_labels=None):
         """
         Returns a `newick encoding <https://en.wikipedia.org/wiki/Newick_format>`_
-        of this tree. Leaf nodes are labelled with their numerical ID + 1,
-        and internal nodes are not labelled.
+        of this tree. If the ``root`` argument is specified, return a representation
+        of the specified subtree, otherwise the full tree is returned. If the tree
+        has multiple roots then seperate newick strings for each rooted subtree
+        must be found (i.e., we do not attempt to concatenate the different trees).
 
-        This method is currently primarily for ms-compatibility and
-        is not intended as a consistent means of data interchange.
+        By default, leaf nodes are labelled with their numerical ID + 1,
+        and internal nodes are not labelled. Arbitrary node labels can be specified
+        using the ``node_labels`` argument, which maps node IDs to the desired
+        labels.
+
+        .. warning:: Node labels are **not** Newick escaped, so care must be taken
+            to provide labels that will not break the encoding.
 
         :param int precision: The numerical precision with which branch lengths are
             printed.
-        :param float time_scale: A value which all branch lengths are multiplied by.
+        :param int root: If specified, return the tree rooted at this node.
+        :param map node_labels: If specified, show custom labels for the nodes
+            that are present in the map. Any nodes not specified in the map will
+            not have a node label.
         :return: A newick representation of this tree.
         :rtype: str
         """
@@ -1094,9 +1122,12 @@ class SparseTree(object):
                     "[t.newick(root) for root in t.roots] to get a list of "
                     "newick trees, one for each root.")
             root = self.root
-        s = self._ll_sparse_tree.get_newick(precision=precision, root=root)
-        if not IS_PY2:
-            s = s.decode()
+        if node_labels is None:
+            s = self._ll_sparse_tree.get_newick(precision=precision, root=root)
+            if not IS_PY2:
+                s = s.decode()
+        else:
+            return self.__build_newick(root, precision, node_labels) + ";"
         return s
 
     @property

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -1072,7 +1072,7 @@ class SparseTree(object):
             for v in iterator(u):
                 yield v
 
-    def newick(self, precision=14, time_scale=1):
+    def newick(self, precision=14, root=None):
         """
         Returns a `newick encoding <https://en.wikipedia.org/wiki/Newick_format>`_
         of this tree. Leaf nodes are labelled with their numerical ID + 1,
@@ -1087,7 +1087,14 @@ class SparseTree(object):
         :return: A newick representation of this tree.
         :rtype: str
         """
-        s = self._ll_sparse_tree.get_newick(precision=precision, time_scale=time_scale)
+        if root is None:
+            if self.num_roots > 1:
+                raise ValueError(
+                    "Cannot get newick for multiroot trees. Try "
+                    "[t.newick(root) for root in t.roots] to get a list of "
+                    "newick trees, one for each root.")
+            root = self.root
+        s = self._ll_sparse_tree.get_newick(precision=precision, root=root)
         if not IS_PY2:
             s = s.decode()
         return s

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -74,6 +74,7 @@ class PythonSparseTree(object):
         ret.site_list = list(sparse_tree.sites())
         ret.index = sparse_tree.get_index()
         ret.left_root = sparse_tree.left_root
+        ret.sparse_tree = sparse_tree
         for u in range(ret.num_nodes):
             ret.parent[u] = sparse_tree.parent(u)
             ret.left_child[u] = sparse_tree.left_child(u)
@@ -181,12 +182,10 @@ class PythonSparseTree(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def newick(self, precision=0, time_scale=0):
-        # We only support 0 branch lengths here because this information isn't
-        # immediately available.
-        assert time_scale == 0 and precision == 0
-        assert len(self.roots) == 1
-        return self._build_newick(self.left_root) + ";"
+    def newick(self, root=None):
+        if root is None:
+            root = self.left_root
+        return self._build_newick(root) + ";"
 
     def _build_newick(self, node):
         if self.left_child[node] == msprime.NULL_NODE:
@@ -194,7 +193,8 @@ class PythonSparseTree(object):
         else:
             s = "("
             for child in self.children(node):
-                s += self._build_newick(child) + ":0,"
+                branch_length = self.sparse_tree.branch_length(child)
+                s += self._build_newick(child) + ":{:0.16f},".format(branch_length)
             s = s[:-1] + ")"
         return s
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -182,20 +182,24 @@ class PythonSparseTree(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def newick(self, root=None):
+    def newick(self, root=None, precision=16, node_labels=None):
+        if node_labels is None:
+            node_labels = {u: str(u + 1) for u in self.sparse_tree.leaves()}
         if root is None:
             root = self.left_root
-        return self._build_newick(root) + ";"
+        return self._build_newick(root, precision, node_labels) + ";"
 
-    def _build_newick(self, node):
+    def _build_newick(self, node, precision, node_labels):
+        label = node_labels.get(node, "")
         if self.left_child[node] == msprime.NULL_NODE:
-            s = "{0}".format(node + 1)
+            s = label
         else:
             s = "("
             for child in self.children(node):
                 branch_length = self.sparse_tree.branch_length(child)
-                s += self._build_newick(child) + ":{:0.16f},".format(branch_length)
-            s = s[:-1] + ")"
+                subtree = self._build_newick(child, precision, node_labels)
+                s += subtree + ":{0:.{1}f},".format(branch_length, precision)
+            s = s[:-1] + label + ")"
         return s
 
 

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1840,6 +1840,13 @@ class TestSparseTree(HighLevelTestCase):
             newick1 = tree.newick(root=0, precision=16)
             newick2 = py_tree.newick(root=0)
             self.assertEqual(newick1, newick2)
+
+            # When we specify the node_labels we should get precisely the
+            # same result as we are using Python code now.
+            for precision in [0, 3, 19]:
+                newick1 = tree.newick(precision=precision, node_labels={})
+                newick2 = py_tree.newick(precision=precision, node_labels={})
+                self.assertEqual(newick1, newick2)
         else:
             self.assertRaises(ValueError, tree.newick)
             for root in tree.roots:

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1827,13 +1827,26 @@ class TestSparseTree(HighLevelTestCase):
         """
         Verifies that we output the newick tree as expected.
         """
+        # TODO to make this work we may need to clamp the precision of node
+        # times because Python and C float printing algorithms work slightly
+        # differently. Seems to work OK now, so leaving alone.
         if tree.num_roots == 1:
             py_tree = tests.PythonSparseTree.from_sparse_tree(tree)
-            newick1 = tree.newick(precision=0, time_scale=0)
-            newick2 = py_tree.newick(precision=0, time_scale=0)
+            newick1 = tree.newick(precision=16)
+            newick2 = py_tree.newick()
+            self.assertEqual(newick1, newick2)
+
+            # Make sure we get the same results for a leaf root.
+            newick1 = tree.newick(root=0, precision=16)
+            newick2 = py_tree.newick(root=0)
             self.assertEqual(newick1, newick2)
         else:
-            self.assertRaises(_msprime.LibraryError, tree.newick)
+            self.assertRaises(ValueError, tree.newick)
+            for root in tree.roots:
+                py_tree = tests.PythonSparseTree.from_sparse_tree(tree)
+                newick1 = tree.newick(precision=16, root=root)
+                newick2 = py_tree.newick(root=root)
+                self.assertEqual(newick1, newick2)
 
     def test_newick(self):
         for ts in get_example_tree_sequences():

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 University of Oxford
+# Copyright (C) 2015-2018 University of Oxford
 #
 # This file is part of msprime.
 #
@@ -2592,11 +2592,12 @@ class TestSparseTree(LowLevelTestCase):
         ts = self.get_tree_sequence(num_samples=10, num_loci=5)
         st = _msprime.SparseTree(ts)
         for st in _msprime.SparseTreeIterator(st):
-            self.assertRaises(ValueError, st.get_newick, precision=-1)
-            self.assertRaises(ValueError, st.get_newick, precision=17)
-            self.assertRaises(ValueError, st.get_newick, precision=100)
+            self.assertRaises(ValueError, st.get_newick, root=0, precision=-1)
+            self.assertRaises(ValueError, st.get_newick, root=0, precision=17)
+            self.assertRaises(ValueError, st.get_newick, root=0, precision=100)
             for precision in range(17):
-                tree = st.get_newick(precision=precision).decode()
+                tree = st.get_newick(
+                    root=st.get_left_root(), precision=precision).decode()
                 times = get_times(tree)
                 self.assertGreater(len(times), ts.get_num_samples())
                 for t in times:

--- a/verification.py
+++ b/verification.py
@@ -18,11 +18,11 @@ import pandas as pd
 import numpy as np
 import numpy.random
 import statsmodels.api as sm
-import seaborn as sns
 import matplotlib
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use('Agg')
 from matplotlib import pyplot
+import seaborn as sns
 
 import dendropy
 import msprime.cli as cli
@@ -126,7 +126,7 @@ class SimulationVerifier(object):
             sim.reset()
             sim.run()
             num_trees[j] = sim.num_breakpoints + 1
-            time[j] = sim.time / 4  # Convert to coalescent units
+            time[j] = sim.time
             ca_events[j] = sim.num_common_ancestor_events
             re_events[j] = sim.num_recombination_events
             mig_events[j] = [r for row in sim.num_migration_events for r in row]
@@ -192,7 +192,7 @@ class SimulationVerifier(object):
         j = 0
         for line in output.splitlines():
             if line.startswith(b"("):
-                t = dendropy.Tree.get_from_string(str(line), schema="newick")
+                t = dendropy.Tree.get_from_string(line.decode(), schema="newick")
                 a = t.calc_node_ages()
                 T[j] = a[-1]
                 j += 1
@@ -243,7 +243,7 @@ class SimulationVerifier(object):
         max_s = 200
         hist = np.zeros(max_s)
         for line in output.splitlines():
-            if line.startswith("segsites"):
+            if line.startswith(b"segsites"):
                 s = int(line.split()[1])
                 if s <= max_s:
                     hist[s] += 1
@@ -357,8 +357,8 @@ class SimulationVerifier(object):
         tbl = np.zeros(R)
         j = 0
         for line in output.splitlines():
-            if line.startswith("("):
-                t = dendropy.Tree.get_from_string(line, schema="newick")
+            if line.startswith(b"("):
+                t = dendropy.Tree.get_from_string(line.decode(), schema="newick")
                 tbl[j] = t.length()
                 j += 1
         return tbl
@@ -418,9 +418,9 @@ class SimulationVerifier(object):
         T = np.zeros(R)
         j = -1
         for line in output.splitlines():
-            if line.startswith("//"):
+            if line.startswith(b"//"):
                 j += 1
-            if line.startswith("["):
+            if line.startswith(b"["):
                 T[j] += 1
         return T
 
@@ -430,9 +430,9 @@ class SimulationVerifier(object):
         T = np.zeros(R)
         j = -1
         for line in output.splitlines():
-            if line.startswith("//"):
+            if line.startswith(b"//"):
                 j += 1
-            if line.startswith("time"):
+            if line.startswith(b"time"):
                 T[j] += 1
         return T
 
@@ -442,9 +442,9 @@ class SimulationVerifier(object):
         T = np.zeros(R)
         j = -1
         for line in output.splitlines():
-            if line.startswith("//"):
+            if line.startswith(b"//"):
                 j += 1
-            if line.startswith("time:"):
+            if line.startswith(b"time:"):
                 T[j] = max(T[j], float(line.split()[1]))
         return T
 


### PR DESCRIPTION
Closes #487. Removes redundant time_scale argument.

Would you mind having a quick look over this please @hyanwong? 

In particular, do you think it's correct that a newick tree with a single node should be rendered as "1;"?