### PR TITLE
New interface for load_tables

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -5495,143 +5495,24 @@ TreeSequence_load_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     int err;
     PyObject *ret = NULL;
-    NodeTable *py_nodes = NULL;
-    EdgeTable *py_edges = NULL;
-    MigrationTable *py_migrations = NULL;
-    SiteTable *py_sites = NULL;
-    MutationTable *py_mutations = NULL;
-    ProvenanceTable *py_provenances = NULL;
-    IndividualTable *py_individuals = NULL;
-    PopulationTable *py_populations = NULL;
-    table_collection_t tables;
-    double sequence_length = 0.0;
-    static char *kwlist[] = {"nodes", "edges", "migrations",
-        "sites", "mutations", "provenances", "individuals",
-        "populations", "sequence_length", NULL};
+    TableCollection *tables = NULL;
+    static char *kwlist[] = {"tables", NULL};
 
-    /* For now we keep a local table collection object, but we'll want to
-     * update this method to take a TableCollection object. The tricky
-     * bit is keeping API compatability with existing code, but hopefully
-     * this can be handled at the high-level API. */
-    err = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
-    if (ret != 0) {
-        handle_library_error(err);
-        goto out;
-    }
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!O!O!O!O!d", kwlist,
-            &NodeTableType, &py_nodes,
-            &EdgeTableType, &py_edges,
-            &MigrationTableType, &py_migrations,
-            &SiteTableType, &py_sites,
-            &MutationTableType, &py_mutations,
-            &ProvenanceTableType, &py_provenances,
-            &IndividualTableType, &py_individuals,
-            &PopulationTableType, &py_populations,
-            &sequence_length)) {
-        goto out;
-    }
-    if (NodeTable_check_state(py_nodes) != 0) {
-        goto out;
-    }
-    err = node_table_copy(py_nodes->table, tables.nodes);
-    if (err != 0) {
-        handle_library_error(err);
-        goto out;
-    }
-
-    if (EdgeTable_check_state(py_edges) != 0) {
-        goto out;
-    }
-    err = edge_table_copy(py_edges->table, tables.edges);
-    if (err != 0) {
-        handle_library_error(err);
-        goto out;
-    }
-
-    if (py_migrations != NULL) {
-        if (MigrationTable_check_state(py_migrations) != 0) {
-            goto out;
-        }
-        err = migration_table_copy(py_migrations->table, tables.migrations);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_sites != NULL) {
-        if (SiteTable_check_state(py_sites) != 0) {
-            goto out;
-        }
-        err = site_table_copy(py_sites->table, tables.sites);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_mutations != NULL) {
-        if (MutationTable_check_state(py_mutations) != 0) {
-            goto out;
-        }
-        err = mutation_table_copy(py_mutations->table, tables.mutations);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_provenances != NULL) {
-        if (ProvenanceTable_check_state(py_provenances) != 0) {
-            goto out;
-        }
-        err = provenance_table_copy(py_provenances->table, tables.provenances);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_individuals != NULL) {
-        if (IndividualTable_check_state(py_individuals) != 0) {
-            goto out;
-        }
-        err = individual_table_copy(py_individuals->table, tables.individuals);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_populations != NULL) {
-        if (PopulationTable_check_state(py_populations) != 0) {
-            goto out;
-        }
-        err = population_table_copy(py_populations->table, tables.populations);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if ((py_mutations == NULL) != (py_sites == NULL)) {
-        PyErr_SetString(PyExc_TypeError, "Must specify both site and mutation tables");
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist,
+            &TableCollectionType, &tables)) {
         goto out;
     }
     err = TreeSequence_alloc(self);
     if (err != 0) {
         goto out;
     }
-    tables.sequence_length = sequence_length;
-    err = tree_sequence_load_tables(self->tree_sequence, &tables, 0);
+    err = tree_sequence_load_tables(self->tree_sequence, tables->tables, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
     }
     ret = Py_BuildValue("");
 out:
-    table_collection_free(&tables);
     return ret;
 }
 
@@ -5640,140 +5521,23 @@ TreeSequence_dump_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
 {
     int err;
     PyObject *ret = NULL;
-    NodeTable *py_nodes = NULL;
-    EdgeTable *py_edges = NULL;
-    MigrationTable *py_migrations = NULL;
-    SiteTable *py_sites = NULL;
-    MutationTable *py_mutations = NULL;
-    ProvenanceTable *py_provenances = NULL;
-    PopulationTable *py_populations = NULL;
-    IndividualTable *py_individuals = NULL;
-    table_collection_t tables;
-    static char *kwlist[] = {"nodes", "edges", "migrations",
-        "sites", "mutations", "provenances", "individuals", "populations", NULL};
+    TableCollection *tables = NULL;
+    static char *kwlist[] = {"tables", NULL};
 
-    /* For now we keep a local table collection object, but we'll want to
-     * update this method to take a TableCollection object. The tricky
-     * bit is keeping API compatability with existing code, but hopefully
-     * this can be handled at the high-level API. */
-    err = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
-    if (ret != 0) {
-        handle_library_error(err);
-        goto out;
-    }
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!|O!O!O!O!O!O!", kwlist,
-            &NodeTableType, &py_nodes,
-            &EdgeTableType, &py_edges,
-            &MigrationTableType, &py_migrations,
-            &SiteTableType, &py_sites,
-            &MutationTableType, &py_mutations,
-            &ProvenanceTableType, &py_provenances,
-            &IndividualTableType, &py_individuals,
-            &PopulationTableType, &py_populations)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist,
+            &TableCollectionType, &tables)) {
         goto out;
     }
     if (TreeSequence_check_tree_sequence(self) != 0) {
         goto out;
     }
-    err = tree_sequence_dump_tables(self->tree_sequence, &tables, 0);
+    err = tree_sequence_dump_tables(self->tree_sequence, tables->tables, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
     }
-
-    if (NodeTable_check_state(py_nodes) != 0) {
-        goto out;
-    }
-    err = node_table_copy(tables.nodes, py_nodes->table);
-    if (err != 0) {
-        handle_library_error(err);
-        goto out;
-    }
-
-    if (EdgeTable_check_state(py_edges) != 0) {
-        goto out;
-    }
-    err = edge_table_copy(tables.edges, py_edges->table);
-    if (err != 0) {
-        handle_library_error(err);
-        goto out;
-    }
-
-    if (py_migrations != NULL) {
-        if (MigrationTable_check_state(py_migrations) != 0) {
-            goto out;
-        }
-        err = migration_table_copy(tables.migrations, py_migrations->table);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_sites != NULL) {
-        if (SiteTable_check_state(py_sites) != 0) {
-            goto out;
-        }
-        err = site_table_copy(tables.sites, py_sites->table);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-    if (py_mutations != NULL) {
-        if (MutationTable_check_state(py_mutations) != 0) {
-            goto out;
-        }
-        err = mutation_table_copy(tables.mutations, py_mutations->table);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if ((py_mutations == NULL) != (py_sites == NULL)) {
-        PyErr_SetString(PyExc_TypeError, "Must specify both mutations and sites");
-        goto out;
-    }
-
-    if (py_provenances != NULL) {
-        if (ProvenanceTable_check_state(py_provenances) != 0) {
-            goto out;
-        }
-        err = provenance_table_copy(tables.provenances, py_provenances->table);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_individuals != NULL) {
-        if (IndividualTable_check_state(py_individuals) != 0) {
-            goto out;
-        }
-        err = individual_table_copy(tables.individuals, py_individuals->table);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
-    if (py_populations != NULL) {
-        if (PopulationTable_check_state(py_populations) != 0) {
-            goto out;
-        }
-        err = population_table_copy(tables.populations,
-                py_populations->table);
-        if (err != 0) {
-            handle_library_error(err);
-            goto out;
-        }
-    }
-
     ret = Py_BuildValue("");
 out:
-    table_collection_free(&tables);
     return ret;
 }
 

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -9496,36 +9496,17 @@ Simulator_populate_tables(Simulator *self, PyObject *args, PyObject *kwds)
 {
     int err;
     PyObject *ret = NULL;
-    NodeTable *nodes = NULL;
-    EdgeTable *edges = NULL;
-    MigrationTable *migrations = NULL;
-    PopulationTable *populations = NULL;
+    TableCollection *tables = NULL;
     RecombinationMap *recombination_map = NULL;
     recomb_map_t *recomb_map = NULL;
-    static char *kwlist[] = {"nodes", "edges", "migrations", "populations",
-        "recombination_map", NULL};
+    static char *kwlist[] = {"tables", "recombination_map", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!O!|O!", kwlist,
-            &NodeTableType, &nodes,
-            &EdgeTableType, &edges,
-            &MigrationTableType, &migrations,
-            &PopulationTableType, &populations,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|O!", kwlist,
+            &TableCollectionType, &tables,
             &RecombinationMapType, &recombination_map)) {
         goto out;
     }
     if (Simulator_check_sim(self) != 0) {
-        goto out;
-    }
-    if (NodeTable_check_state(nodes) != 0) {
-        goto out;
-    }
-    if (EdgeTable_check_state(edges) != 0) {
-        goto out;
-    }
-    if (MigrationTable_check_state(migrations) != 0) {
-        goto out;
-    }
-    if (PopulationTable_check_state(populations) != 0) {
         goto out;
     }
     if (recombination_map != NULL) {
@@ -9534,9 +9515,7 @@ Simulator_populate_tables(Simulator *self, PyObject *args, PyObject *kwds)
         }
         recomb_map = recombination_map->recomb_map;
     }
-    err = msp_populate_tables(self->sim, recomb_map, nodes->table,
-            edges->table, migrations->table,
-            populations->table);
+    err = msp_populate_tables(self->sim, recomb_map, tables->tables);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/lib/main.c
+++ b/lib/main.c
@@ -887,10 +887,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
             goto out;
         }
         /* Create the tree_sequence from the state of the simulator. */
-        /* TODO this is messy; we should pass the table_collection to populate_tables */
-        tables.sequence_length = recomb_map->sequence_length;
-        ret = msp_populate_tables(msp, recomb_map, tables.nodes, tables.edges,
-                tables.migrations, tables.populations);
+        ret = msp_populate_tables(msp, recomb_map, &tables);
         if (ret != 0) {
             goto out;
         }

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -288,9 +288,7 @@ int msp_add_instantaneous_bottleneck(msp_t *self, double time, int population_id
 int msp_initialise(msp_t *self);
 int msp_run(msp_t *self, double max_time, unsigned long max_events);
 int msp_debug_demography(msp_t *self, double *end_time);
-int msp_populate_tables(msp_t *self, recomb_map_t *recomb_map,
-        node_table_t *node_table, edge_table_t *edge_table,
-        migration_table_t *migration_table, population_table_t *populations);
+int msp_populate_tables(msp_t *self, recomb_map_t *recomb_map, table_collection_t *tables);
 int msp_reset(msp_t *self);
 int msp_print_state(msp_t *self, FILE *out);
 int msp_free(msp_t *self);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1504,10 +1504,9 @@ get_example_tree_sequence(uint32_t num_samples,
     /* Create the tree_sequence from the state of the simulator.
      * We want to use coalescent time here, so use an Ne of 1/4
      * to cancel scaling factor. */
-    tables.sequence_length = sequence_length;
-    ret = msp_populate_tables(msp, recomb_map, tables.nodes, tables.edges,
-            tables.migrations, tables.populations);
+    ret = msp_populate_tables(msp, recomb_map, &tables);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sequence_length, sequence_length);
     ret = mutgen_generate(mutgen, &tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = provenance_table_add_row(tables.provenances,

--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -29,8 +29,8 @@ from _msprime import REVERSE  # NOQA
 from msprime.provenance import __version__  # NOQA
 from msprime.formats import *  # NOQA
 from msprime.trees import *  # NOQA
+from msprime.tables import *  # NOQA
 from msprime.simulations import *  # NOQA
 from msprime.stats import *  # NOQA
 from msprime.exceptions import *  # NOQA
-from msprime.tables import *  # NOQA
 from msprime.mutations import *  # NOQA

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -571,15 +571,13 @@ class Simulator(object):
         Returns a TreeSequence representing the state of the simulation.
         """
         ll_recomb_map = self.recombination_map.get_ll_recombination_map()
-        t = self.tables
         self.ll_sim.populate_tables(
-            t.nodes.ll_table, t.edges.ll_table, t.migrations.ll_table,
-            t.populations.ll_table, recombination_map=ll_recomb_map)
+            self.tables.ll_tables, recombination_map=ll_recomb_map)
         if mutation_generator is not None:
             mutation_generator.generate(self.tables.ll_tables)
-        t.provenances.clear()
+        self.tables.provenances.clear()
         if provenance_record is not None:
-            t.provenances.add_row(provenance_record)
+            self.tables.provenances.add_row(provenance_record)
         return self.tables.tree_sequence()
 
     def reset(self):

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -32,7 +32,6 @@ import warnings
 
 import _msprime
 import msprime.tables as _tables
-import msprime.trees as trees
 import msprime.provenance as provenance
 
 # Make the low-level generator appear like its from this module
@@ -581,12 +580,7 @@ class Simulator(object):
         t.provenances.clear()
         if provenance_record is not None:
             t.provenances.add_row(provenance_record)
-        ll_tree_sequence = _msprime.TreeSequence()
-        ll_tree_sequence.load_tables(
-            t.nodes.ll_table, t.edges.ll_table, t.migrations.ll_table,
-            t.sites.ll_table, t.mutations.ll_table, t.provenances.ll_table,
-            populations=t.populations.ll_table)
-        return trees.TreeSequence(ll_tree_sequence)
+        return self.tables.tree_sequence()
 
     def reset(self):
         """

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -30,6 +30,11 @@ import numpy as np
 from six.moves import copyreg
 
 import _msprime
+# This circular import is ugly but it seems hard to avoid it since table collection
+# and tree sequence depend on each other. Unless they're in the same module they
+# need to import each other. In Py3 at least we can import the modules but we
+# can't do this in Py3.
+import msprime
 
 
 IndividualTableRow = collections.namedtuple(
@@ -1361,6 +1366,21 @@ class TableCollection(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def tree_sequence(self):
+        """
+        Returns a :class:`TreeSequence` instance with the structure defined by the
+        tables in this :class:`TableCollection`. If the table collection is not
+        in canonical form (i.e., does not meet sorting requirements) or cannot be
+        interpreted as a tree sequence an exception is raised. The
+        :meth:`.sort` method may be used to ensure that input sorting requirements
+        are met.
+
+        :return: A :class:`TreeSequence` instance reflecting the structures
+            defined in this set of tables.
+        :rtype: .TreeSequence
+        """
+        return msprime.TreeSequence.load_tables(self)
 
     def simplify(self, samples, filter_zero_mutation_sites=True):
         """

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -2476,20 +2476,19 @@ class TestNodeOrdering(HighLevelTestCase):
         random.shuffle(internal_nodes)
         for j, node in enumerate(internal_nodes):
             node_map[n + j] = node
-        node_table = msprime.NodeTable()
+        other_tables = msprime.TableCollection(ts.sequence_length)
         # Insert the new nodes into the table.
         inv_node_map = {v: k for k, v in node_map.items()}
         for j in range(ts.num_nodes):
             node = ts.node(inv_node_map[j])
-            node_table.add_row(
+            other_tables.nodes.add_row(
                 flags=node.flags, time=node.time, population=node.population)
-        edge_table = msprime.EdgeTable()
         for e in ts.edges():
-            edge_table.add_row(
+            other_tables.edges.add_row(
                 left=e.left, right=e.right, parent=node_map[e.parent],
                 child=node_map[e.child])
-        msprime.sort_tables(nodes=node_table, edges=edge_table)
-        other_ts = msprime.load_tables(nodes=node_table, edges=edge_table)
+        other_tables.sort()
+        other_ts = other_tables.tree_sequence()
 
         self.assertEqual(ts.get_num_trees(), other_ts.get_num_trees())
         self.assertEqual(ts.get_sample_size(), other_ts.get_sample_size())


### PR DESCRIPTION
Closes #499.

This PR depends on #507; it'll get much smaller once that is merged.

Rather than complicate the interface for ``load_tables`` to make it take a ``TableCollection`` as a parameter, I decided to add a ``TableCollection.tree_sequence()`` method instead. This returns a new tree sequence instance based on the tables, and does the same thing as ``load_tables``, essentially (but much more simply). I suggest we undocument ``load_tables`` then and keep it around as a deprecated interface.

So, the forward simulation now goes:

```python
tables = msprime.TableCollection()
tables.nodes.add_row(...)
tables.edges.add_row(...)
# Etc, etc. filling in some stuff in your tables
tables.sort()
tables.simplify(samples)
tree_sequence = tables.tree_sequence()
```

What do you think @petrelharp, @molpopgen?