### PR TITLE
Fix site dedup bug

### DIFF
--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6219,6 +6219,42 @@ test_sort_tables(void)
 }
 
 static void
+test_deduplicate_sites_multichar(void)
+{
+    int ret;
+    table_collection_t tables;
+
+    ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    ret = site_table_add_row(tables.sites, 0, "AA", 1, "M", 1);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = site_table_add_row(tables.sites, 0, "0", 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 1);
+    ret = site_table_add_row(tables.sites, 1, "BBBBB", 5, "NNNNN", 5);
+    CU_ASSERT_EQUAL_FATAL(ret, 2);
+    ret = site_table_add_row(tables.sites, 1, "0", 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 3);
+
+    ret = table_collection_deduplicate_sites(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->num_rows, 2);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->position[0], 0);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->position[1], 1);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->ancestral_state[0], 'A');
+    CU_ASSERT_EQUAL_FATAL(tables.sites->ancestral_state_offset[1], 1);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->metadata[0], 'M');
+    CU_ASSERT_EQUAL_FATAL(tables.sites->metadata_offset[1], 1);
+
+    CU_ASSERT_NSTRING_EQUAL(tables.sites->ancestral_state + 1, "BBBBB", 5);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->ancestral_state_offset[2], 6);
+    CU_ASSERT_NSTRING_EQUAL(tables.sites->metadata + 1, "NNNNN", 5);
+    CU_ASSERT_EQUAL_FATAL(tables.sites->metadata_offset[2], 6);
+
+    table_collection_free(&tables);
+}
+
+static void
 test_deduplicate_sites(void)
 {
     int ret;
@@ -8284,6 +8320,7 @@ main(int argc, char **argv)
         {"test_save_kas_tables", test_save_kas_tables},
         {"test_dump_tables", test_dump_tables},
         {"test_sort_tables", test_sort_tables},
+        {"test_deduplicate_sites_multichar", test_deduplicate_sites_multichar},
         {"test_deduplicate_sites", test_deduplicate_sites},
         {"test_deduplicate_sites_errors", test_deduplicate_sites_errors},
         {"test_dump_tables_kas", test_dump_tables_kas},

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1633,7 +1633,6 @@ class TestDeduplicateSites(unittest.TestCase):
         self.assertEqual(len(t1.sites), 1)
         self.assertEqual(t1.sites.ancestral_state.tobytes(), b"first")
 
-    @unittest.skip("BUG: deduplicate with mixtures of different lengths")
     def test_multichar_ancestral_state(self):
         ts = msprime.simulate(8, random_seed=3, mutation_rate=1)
         self.assertGreater(ts.num_sites, 2)
@@ -1647,15 +1646,12 @@ class TestDeduplicateSites(unittest.TestCase):
             for mutation in site.mutations:
                 tables.mutations.add_row(
                     site=site_id, node=mutation.node, derived_state="T" * site.id)
-        print(tables.sites)
         tables.deduplicate_sites()
-        print(tables.sites)
         new_ts = msprime.load_tables(**tables.asdict())
         self.assertEqual(new_ts.num_sites, ts.num_sites)
-        for site in ts.sites():
+        for site in new_ts.sites():
             self.assertEqual(site.ancestral_state, site.id * "A")
 
-    @unittest.skip("BUG: deduplicate with mixtures of different lengths")
     def test_multichar_metadata(self):
         ts = msprime.simulate(8, random_seed=3, mutation_rate=1)
         self.assertGreater(ts.num_sites, 2)
@@ -1670,10 +1666,8 @@ class TestDeduplicateSites(unittest.TestCase):
                 tables.mutations.add_row(
                     site=site_id, node=mutation.node, derived_state="1",
                     metadata=b"T" * site.id)
-        print(tables.sites)
         tables.deduplicate_sites()
-        print(tables.sites)
         new_ts = msprime.load_tables(**tables.asdict())
         self.assertEqual(new_ts.num_sites, ts.num_sites)
-        for site in ts.sites():
+        for site in new_ts.sites():
             self.assertEqual(site.metadata, site.id * b"A")


### PR DESCRIPTION
Closes #511.

Depends on #510.

cc @petrelharp. The existing algorithm was missing the last offsets, so wasn't getting the sizes of metadata and ancestral state correctly. More seriously though, the algorithm required memcpys on overlapping memory areas within these buffers. Rather than use memmove (which might have had other subtle consequences) I decided to use a simpler algorithm based on taking a copy of the site table rather than doing it in-place.