### PR TITLE
Rough outline of Python simplify individuals.

### DIFF
--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1344,7 +1344,7 @@ class TableCollection(object):
     def __str__(self):
         s = self.__banner("Individuals")
         s += str(self.individuals) + "\n"
-        s = self.__banner("Nodes")
+        s += self.__banner("Nodes")
         s += str(self.nodes) + "\n"
         s += self.__banner("Edges")
         s += str(self.edges) + "\n"

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -2373,7 +2373,9 @@ class TreeSequence(object):
         for record in converter:
             output.write(record)
 
-    def simplify(self, samples=None, filter_zero_mutation_sites=True, map_nodes=False):
+    def simplify(
+            self, samples=None, filter_zero_mutation_sites=True, map_nodes=False,
+            filter_zero_node_individuals=True):
         """
         Returns a simplified tree sequence that retains only the history of
         the nodes given in the list ``samples``. If ``map_nodes`` is true,
@@ -2401,6 +2403,9 @@ class TreeSequence(object):
             tree sequence and a numpy array mapping node IDs in the current tree
             sequence to their corresponding node IDs in the returned tree sequence.
             If False (the default), return only the tree sequence object itself.
+        :param bool filter_zero_node_individuals: If True, remove any individuals
+            that have no associated nodes in the simplified tree sequence.
+            Defaults to True.
         :return: The simplified tree sequence, or (if ``map_nodes`` is True)
             a tuple containing the simplified tree sequence and a numpy array
             mapping source node IDs to their corresponding IDs in the new tree

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1448,8 +1448,7 @@ class TestSimplifyTables(unittest.TestCase):
         tables = ts.dump_tables()
         nodes = tables.nodes.copy()
         edges = tables.edges.copy()
-        msprime.simplify_tables(
-            samples=ts.samples(), nodes=nodes, edges=edges)
+        msprime.simplify_tables(samples=ts.samples(), nodes=nodes, edges=edges)
         self.assertEqual(nodes, tables.nodes)
         self.assertEqual(edges, tables.edges)
 


### PR DESCRIPTION
Closes #501

I it's not clear to me how to do this and **guarantee** that the output nodes for a given individual are always adjacent. Under the implementation I have here we output individuals as we encounter them forwards in time, which seems like a nice property. But, there may be some way we can have multiple nodes that have the same time value referencing different individuals, and then somehow end up with these nodes in the table with non-adjacent individuals. I think that if the input has the property that all nodes for a given individual are adjacent then all output nodes for the same individual must also be adjacent, but I'm not 100% confident in that.

What do you think @petrelharp? Do you think the algorithm I've outlined here will work? If we're not totally confident that this approach will be correct I think we should take the functionality out and just raise an error if someone tries to simplify a set of tables in which there are 1 or more individuals. That way at least we're sure we're not shipping something that's incorrect and that we'll have to backtrack on afterwards.

I do want to release 0.6.0 on Friday with the functionality needed for SLiM 3, so if simplifying with individuals isn't essential (ISTR that you add the individuals at the end?) then cutting it out might be the best short term solution.