### PR TITLE
Generalise simplify

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,31 @@
 ********************
+[0.6.1] - 2018-xx-xx
+********************
+
+**Breaking changes**:
+
+- Change in the semantics of how populations are treated by simplify. By
+  default, populations that are not refenced will now be removed from the
+  data model. This can be avoided by setting ``filter_populations=False``.
+
+- Simplify now raises an error if called on a set of tables that contain
+  one or more migrations.
+
+**New features**:
+
+- Simplify generalised to support individuals, and the ``filter_populations``,
+  ``filter_individuals`` and ``filter_sites`` parameters added to allow
+  filtering of unreferenced objects from the data model. (#567).
+
+
+**Bug fixes**:
+
+**Deprecated**:
+
+- The ``filter_zero_mutation_sites`` parameter for simplify has been deprecated
+  in favour of ``filter_sites``.
+
+********************
 [0.6.0] - 2018-06-20
 ********************
 

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -4943,13 +4943,13 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     npy_intp *shape, dims;
     size_t num_samples;
     int flags = 0;
-    int filter_zero_mutation_sites = true;
+    int filter_sites = true;
     int reduce_to_site_topology = false;
     static char *kwlist[] = {
-        "samples", "filter_zero_mutation_sites", "reduce_to_site_topology", NULL};
+        "samples", "filter_sites", "reduce_to_site_topology", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ii", kwlist,
-            &samples, &filter_zero_mutation_sites, &reduce_to_site_topology)) {
+            &samples, &filter_sites, &reduce_to_site_topology)) {
         goto out;
     }
     samples_array = (PyArrayObject *) PyArray_FROMANY(samples, NPY_INT32, 1, 1,
@@ -4959,8 +4959,8 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     }
     shape = PyArray_DIMS(samples_array);
     num_samples = shape[0];
-    if (filter_zero_mutation_sites) {
-        flags |= MSP_FILTER_ZERO_MUTATION_SITES;
+    if (filter_sites) {
+        flags |= MSP_FILTER_SITES;
     }
     if (reduce_to_site_topology) {
         flags |= MSP_REDUCE_TO_SITE_TOPOLOGY;

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -4895,12 +4895,16 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     size_t num_samples;
     int flags = 0;
     int filter_sites = true;
+    int filter_individuals = false;
+    int filter_populations = false;
     int reduce_to_site_topology = false;
     static char *kwlist[] = {
-        "samples", "filter_sites", "reduce_to_site_topology", NULL};
+        "samples", "filter_sites", "filter_populations", "filter_individuals",
+        "reduce_to_site_topology", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|ii", kwlist,
-            &samples, &filter_sites, &reduce_to_site_topology)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|iiii", kwlist,
+            &samples, &filter_sites, &filter_populations, &filter_individuals,
+            &reduce_to_site_topology)) {
         goto out;
     }
     samples_array = (PyArrayObject *) PyArray_FROMANY(samples, NPY_INT32, 1, 1,
@@ -4912,6 +4916,12 @@ TableCollection_simplify(TableCollection *self, PyObject *args, PyObject *kwds)
     num_samples = shape[0];
     if (filter_sites) {
         flags |= MSP_FILTER_SITES;
+    }
+    if (filter_individuals) {
+        flags |= MSP_FILTER_INDIVIDUALS;
+    }
+    if (filter_populations) {
+        flags |= MSP_FILTER_POPULATIONS;
     }
     if (reduce_to_site_topology) {
         flags |= MSP_REDUCE_TO_SITE_TOPOLOGY;

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -1064,7 +1064,8 @@ static PyObject *
 IndividualTable_get_row(IndividualTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    int err;
+    Py_ssize_t row_id;
     individual_t individual;
 
     if (IndividualTable_check_state(self) != 0) {
@@ -1073,20 +1074,11 @@ IndividualTable_get_row(IndividualTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = individual_table_get_row(self->table, (size_t) row_id, &individual);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    individual.flags = self->table->flags[row_id];
-    individual.location = self->table->location
-        + self->table->location_offset[row_id];
-    individual.location_length = self->table->location_offset[row_id + 1]
-        - self->table->location_offset[row_id];
-    individual.metadata = self->table->metadata
-        + self->table->metadata_offset[row_id];
-    individual.metadata_length = self->table->metadata_offset[row_id + 1]
-        - self->table->metadata_offset[row_id];
     ret = make_individual_row(&individual);
 out:
     return ret;
@@ -2056,7 +2048,8 @@ static PyObject *
 EdgeTable_get_row(EdgeTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    Py_ssize_t row_id;
+    int err;
     edge_t edge;
 
     if (EdgeTable_check_state(self) != 0) {
@@ -2065,15 +2058,11 @@ EdgeTable_get_row(EdgeTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = edge_table_get_row(self->table, (size_t) row_id, &edge);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    edge.left = self->table->left[row_id];
-    edge.right = self->table->right[row_id];
-    edge.parent = self->table->parent[row_id];
-    edge.child = self->table->child[row_id];
     ret = make_edge(&edge);
 out:
     return ret;
@@ -2485,7 +2474,8 @@ static PyObject *
 MigrationTable_get_row(MigrationTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    Py_ssize_t row_id;
+    int err;
     migration_t migration;
 
     if (MigrationTable_check_state(self) != 0) {
@@ -2494,17 +2484,11 @@ MigrationTable_get_row(MigrationTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = migration_table_get_row(self->table, (size_t) row_id, &migration);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    migration.left = self->table->left[row_id];
-    migration.right = self->table->right[row_id];
-    migration.node = self->table->node[row_id];
-    migration.source = self->table->source[row_id];
-    migration.dest = self->table->dest[row_id];
-    migration.time = self->table->time[row_id];
     ret = make_migration(&migration);
 out:
     return ret;
@@ -2963,7 +2947,8 @@ static PyObject *
 SiteTable_get_row(SiteTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    Py_ssize_t row_id;
+    int err;
     site_t site;
 
     if (SiteTable_check_state(self) != 0) {
@@ -2972,21 +2957,11 @@ SiteTable_get_row(SiteTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = site_table_get_row(self->table, (size_t) row_id, &site);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    site.position = self->table->position[row_id];
-    site.ancestral_state = self->table->ancestral_state
-        + self->table->ancestral_state_offset[row_id];
-    site.ancestral_state_length = self->table->ancestral_state_offset[row_id + 1]
-        - self->table->ancestral_state_offset[row_id];
-    site.metadata = self->table->metadata
-        + self->table->metadata_offset[row_id];
-    site.metadata_length = self->table->metadata_offset[row_id + 1]
-        - self->table->metadata_offset[row_id];
-    site.mutations_length = 0;
     ret = make_site_row(&site);
 out:
     return ret;
@@ -3465,7 +3440,8 @@ static PyObject *
 MutationTable_get_row(MutationTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    Py_ssize_t row_id;
+    int err;
     mutation_t mutation;
 
     if (MutationTable_check_state(self) != 0) {
@@ -3474,22 +3450,11 @@ MutationTable_get_row(MutationTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = mutation_table_get_row(self->table, (size_t) row_id, &mutation);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    mutation.site = self->table->site[row_id];
-    mutation.node = self->table->node[row_id];
-    mutation.parent = self->table->parent[row_id];
-    mutation.derived_state = self->table->derived_state
-        + self->table->derived_state_offset[row_id];
-    mutation.derived_state_length = self->table->derived_state_offset[row_id + 1]
-        - self->table->derived_state_offset[row_id];
-    mutation.metadata = self->table->metadata
-        + self->table->metadata_offset[row_id];
-    mutation.metadata_length = self->table->metadata_offset[row_id + 1]
-        - self->table->metadata_offset[row_id];
     ret = make_mutation(&mutation);
 out:
     return ret;
@@ -4017,7 +3982,8 @@ static PyObject *
 PopulationTable_get_row(PopulationTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    Py_ssize_t row_id;
+    int err;
     tmp_population_t population;
 
     if (PopulationTable_check_state(self) != 0) {
@@ -4026,15 +3992,11 @@ PopulationTable_get_row(PopulationTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = population_table_get_row(self->table, (size_t) row_id, &population);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    population.metadata = self->table->metadata
-        + self->table->metadata_offset[row_id];
-    population.metadata_length = self->table->metadata_offset[row_id + 1]
-        - self->table->metadata_offset[row_id];
     ret = make_population(&population);
 out:
     return ret;
@@ -4411,7 +4373,8 @@ static PyObject *
 ProvenanceTable_get_row(ProvenanceTable *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    Py_ssize_t num_rows, row_id;
+    Py_ssize_t row_id;
+    int err;
     provenance_t provenance;
 
     if (ProvenanceTable_check_state(self) != 0) {
@@ -4420,19 +4383,11 @@ ProvenanceTable_get_row(ProvenanceTable *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "n", &row_id)) {
         goto out;
     }
-    num_rows = (Py_ssize_t) self->table->num_rows;
-    if (row_id < 0 || row_id >= num_rows) {
-        PyErr_SetString(PyExc_IndexError, "row index out of bounds");
+    err = provenance_table_get_row(self->table, (size_t) row_id, &provenance);
+    if (err != 0) {
+        handle_library_error(err);
         goto out;
     }
-    provenance.timestamp = self->table->timestamp
-        + self->table->timestamp_offset[row_id];
-    provenance.timestamp_length = self->table->timestamp_offset[row_id + 1]
-        - self->table->timestamp_offset[row_id];
-    provenance.record = self->table->record
-        + self->table->record_offset[row_id];
-    provenance.record_length = self->table->record_offset[row_id + 1]
-        - self->table->record_offset[row_id];
     ret = make_provenance(&provenance);
 out:
     return ret;

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -596,8 +596,8 @@ make_edge(edge_t *edge)
 static PyObject *
 make_migration(migration_t *r)
 {
-    int source = r->source == MSP_NULL_POPULATION_ID ? -1: r->source;
-    int dest = r->dest == MSP_NULL_POPULATION_ID ? -1: r->dest;
+    int source = r->source == MSP_NULL_POPULATION ? -1: r->source;
+    int dest = r->dest == MSP_NULL_POPULATION ? -1: r->dest;
     PyObject *ret = NULL;
 
     ret = Py_BuildValue("ddiiid",
@@ -5727,6 +5727,8 @@ TreeSequence_load_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
     PyObject *ret = NULL;
     TableCollection *tables = NULL;
     static char *kwlist[] = {"tables", NULL};
+    /* TODO add an interface to turn this on and off. */
+    int flags = MSP_BUILD_INDEXES;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!", kwlist,
             &TableCollectionType, &tables)) {
@@ -5736,7 +5738,7 @@ TreeSequence_load_tables(TreeSequence *self, PyObject *args, PyObject *kwds)
     if (err != 0) {
         goto out;
     }
-    err = tree_sequence_load_tables(self->tree_sequence, tables->tables, 0);
+    err = tree_sequence_load_tables(self->tree_sequence, tables->tables, flags);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -9646,7 +9648,7 @@ Simulator_get_samples(Simulator *self)
         goto out;
     }
     for (j = 0; j < num_samples; j++) {
-        population = samples[j].population_id == MSP_NULL_POPULATION_ID? -1:
+        population = samples[j].population_id == MSP_NULL_POPULATION? -1:
             samples[j].population_id;
         t = Py_BuildValue("id", population, samples[j].time);
         if (t == NULL) {

--- a/lib/hapgen.c
+++ b/lib/hapgen.c
@@ -162,7 +162,7 @@ hapgen_alloc(hapgen_t *self, tree_sequence_t *tree_sequence)
     }
     /* For each site set the ancestral type */
     for (k = 0; k < self->num_sites; k++) {
-        ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) k, &site);
+        ret = tree_sequence_get_site(self->tree_sequence, k, &site);
         if (ret != 0) {
             goto out;
         }

--- a/lib/ld.c
+++ b/lib/ld.c
@@ -120,8 +120,7 @@ ld_calc_position_trees(ld_calc_t *self, size_t site_index)
     sparse_tree_t *tA = self->outer_tree;
     sparse_tree_t *tB = self->inner_tree;
 
-    ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) site_index,
-            &mut);
+    ret = tree_sequence_get_site(self->tree_sequence, site_index, &mut);
     if (ret != 0) {
         goto out;
     }
@@ -216,7 +215,7 @@ ld_calc_get_r2_array_forward(ld_calc_t *self, size_t source_index,
 
     tA = self->outer_tree;
     tB = self->inner_tree;
-    ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) source_index, &sA);
+    ret = tree_sequence_get_site(self->tree_sequence, source_index, &sA);
     if (ret != 0) {
         goto out;
     }
@@ -231,8 +230,7 @@ ld_calc_get_r2_array_forward(ld_calc_t *self, size_t source_index,
         if (source_index + j + 1 >= self->num_sites) {
             break;
         }
-        ret = tree_sequence_get_site(self->tree_sequence,
-                (site_id_t) (source_index + j + 1), &sB);
+        ret = tree_sequence_get_site(self->tree_sequence, (source_index + j + 1), &sB);
         if (ret != 0) {
             goto out;
         }
@@ -306,7 +304,7 @@ ld_calc_get_r2_array_reverse(ld_calc_t *self, size_t source_index,
 
     tA = self->outer_tree;
     tB = self->inner_tree;
-    ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) source_index, &sA);
+    ret = tree_sequence_get_site(self->tree_sequence, source_index, &sA);
     if (ret != 0) {
         goto out;
     }
@@ -322,7 +320,7 @@ ld_calc_get_r2_array_reverse(ld_calc_t *self, size_t source_index,
         if (site_index < 0) {
             break;
         }
-        ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) site_index, &sB);
+        ret = tree_sequence_get_site(self->tree_sequence, (size_t) site_index, &sB);
         if (ret != 0) {
             goto out;
         }
@@ -434,11 +432,11 @@ ld_calc_get_r2(ld_calc_t *self, size_t a, size_t b, double *r2)
     /* We can probably do a lot better than this implementation... */
     tA = self->outer_tree;
     tB = self->inner_tree;
-    ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) a, &sA);
+    ret = tree_sequence_get_site(self->tree_sequence, a, &sA);
     if (ret != 0) {
         goto out;
     }
-    ret = tree_sequence_get_site(self->tree_sequence, (site_id_t) b, &sB);
+    ret = tree_sequence_get_site(self->tree_sequence, b, &sB);
     if (ret != 0) {
         goto out;
     }

--- a/lib/main.c
+++ b/lib/main.c
@@ -673,11 +673,11 @@ print_ld_matrix(tree_sequence_t *ts)
             fatal_library_error(ret, "ld_calc_get_r2_array");
         }
         for (k = 0; k < num_r2_values; k++) {
-            ret = tree_sequence_get_site(ts, (site_id_t) j, &sA);
+            ret = tree_sequence_get_site(ts, j, &sA);
             if (ret != 0) {
                 fatal_library_error(ret, "get_site");
             }
-            ret = tree_sequence_get_site(ts, (site_id_t) (j + k + 1), &sB);
+            ret = tree_sequence_get_site(ts, (j + k + 1), &sB);
             if (ret != 0) {
                 fatal_library_error(ret, "get_site");
             }

--- a/lib/main.c
+++ b/lib/main.c
@@ -1018,15 +1018,15 @@ run_stats(const char *filename, int MSP_UNUSED(verbose))
 
 static void
 run_simplify(const char *input_filename, const char *output_filename, size_t num_samples,
-        bool filter_zero_mutation_sites, int verbose)
+        bool filter_sites, int verbose)
 {
     tree_sequence_t ts, subset;
     node_id_t *samples;
     int flags = 0;
     int ret;
 
-    if (filter_zero_mutation_sites) {
-        flags |= MSP_FILTER_ZERO_MUTATION_SITES;
+    if (filter_sites) {
+        flags |= MSP_FILTER_SITES;
     }
 
     load_tree_sequence(&ts, input_filename);
@@ -1139,12 +1139,12 @@ main(int argc, char** argv)
     struct arg_lit *verbose9 = arg_lit0("v", "verbose", NULL);
     struct arg_int *num_samples9 = arg_int0("s", "sample-size", "<sample-size>",
             "Number of samples to keep in the simplified tree sequence.");
-    struct arg_lit *filter_zero_mutation_sites9 = arg_lit0("i",
+    struct arg_lit *filter_sites9 = arg_lit0("i",
             "filter-invariant-sites", "<filter-invariant-sites>");
     struct arg_file *infiles9 = arg_file1(NULL, NULL, NULL, NULL);
     struct arg_file *outfiles9 = arg_file1(NULL, NULL, NULL, NULL);
     struct arg_end *end9 = arg_end(20);
-    void* argtable9[] = {cmd9, verbose9, filter_zero_mutation_sites9, num_samples9,
+    void* argtable9[] = {cmd9, verbose9, filter_sites9, num_samples9,
         infiles9, outfiles9, end9};
     int nerrors9;
 
@@ -1187,7 +1187,7 @@ main(int argc, char** argv)
         run_stats(infiles8->filename[0], verbose8->count);
     } else if (nerrors9 == 0) {
         run_simplify(infiles9->filename[0], outfiles9->filename[0],
-                (size_t) num_samples9->ival[0], (bool) filter_zero_mutation_sites9->count,
+                (size_t) num_samples9->ival[0], (bool) filter_sites9->count,
                 verbose9->count);
     } else {
         /* We get here if the command line matched none of the possible syntaxes */

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -262,7 +262,7 @@ msp_set_population_configuration(msp_t *self, int population_id, double initial_
     simulation_model_t *model = &self->model;
 
     if (population_id < 0 || population_id > (int) self->num_populations) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     if (initial_size <= 0) {
@@ -2593,7 +2593,7 @@ msp_compute_population_size(msp_t *self, size_t population_id, double time,
     double dt;
 
     if (population_id > self->num_populations) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     pop = &self->populations[population_id];
@@ -2803,7 +2803,7 @@ msp_get_population_configuration(msp_t *self, size_t population_id, double *init
     simulation_model_t *model = &self->model;
 
     if (population_id > self->num_populations) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     pop = &self->populations[population_id];
@@ -2875,7 +2875,7 @@ msp_change_single_population_parameters(msp_t *self, size_t population_id,
     simulation_model_t *model = &self->model;
 
     if (population_id >= self->num_populations) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     pop = &self->populations[population_id];
@@ -2950,7 +2950,7 @@ msp_add_population_parameters_change(msp_t *self, double time, int population_id
     int N = (int) self->num_populations;
 
     if (population_id < -1 || population_id >= N) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     if (initial_size <= 0) {
@@ -3132,7 +3132,7 @@ msp_add_mass_migration(msp_t *self, double time, int source, int destination,
     int N = (int) self->num_populations;
 
     if (source < 0 || source >= N || destination < 0 || destination >= N) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     if (source == destination) {
@@ -3223,7 +3223,7 @@ msp_add_simple_bottleneck(msp_t *self, double time, int population_id, double pr
     int N = (int) self->num_populations;
 
     if (population_id < 0 || population_id >= N) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     if (proportion < 0.0 || proportion > 1.0) {
@@ -3401,7 +3401,7 @@ msp_add_instantaneous_bottleneck(msp_t *self, double time, int population_id,
     simulation_model_t *model = &self->model;
 
     if (population_id < 0 || population_id >= N) {
-        ret = MSP_ERR_BAD_POPULATION_ID;
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
         goto out;
     }
     if (strength < 0.0) {

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -391,10 +391,10 @@ test_simulator_getters_setters(void)
             MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(
             msp_set_population_configuration(&msp, -1, 0, 0),
-            MSP_ERR_BAD_POPULATION_ID);
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(
             msp_set_population_configuration(&msp, 3, 0, 0),
-            MSP_ERR_BAD_POPULATION_ID);
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
 
     ret = msp_set_simulation_model_hudson(&msp, Ne);
     CU_ASSERT_EQUAL(msp_get_model(&msp)->type, MSP_MODEL_HUDSON);
@@ -404,7 +404,7 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(
             msp_get_population_configuration(&msp, 3, NULL, NULL),
-            MSP_ERR_BAD_POPULATION_ID);
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     ret = msp_set_population_configuration(&msp, 0, 2 * Ne, 0.5);
     CU_ASSERT_EQUAL(ret, 0);
 
@@ -566,10 +566,10 @@ test_demographic_events(void)
 
     CU_ASSERT_EQUAL(
         msp_add_mass_migration(&msp, 10, -1, 0, 1),
-        MSP_ERR_BAD_POPULATION_ID);
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(
         msp_add_mass_migration(&msp, 10, 2, 0, 1),
-        MSP_ERR_BAD_POPULATION_ID);
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(
         msp_add_mass_migration(&msp, 10, 0, 0, 1),
         MSP_ERR_SOURCE_DEST_EQUAL);
@@ -589,7 +589,7 @@ test_demographic_events(void)
 
     CU_ASSERT_EQUAL(
         msp_add_population_parameters_change(&msp, 10, -2, 0, 0),
-        MSP_ERR_BAD_POPULATION_ID);
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(
         msp_add_population_parameters_change(&msp, 10, -1, -1, 0),
         MSP_ERR_BAD_PARAM_VALUE);
@@ -599,7 +599,7 @@ test_demographic_events(void)
 
     CU_ASSERT_EQUAL(
         msp_add_simple_bottleneck(&msp, 10, -1, 0),
-        MSP_ERR_BAD_POPULATION_ID);
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(
         msp_add_simple_bottleneck(&msp, 10, 0, -1),
         MSP_ERR_BAD_PARAM_VALUE);
@@ -609,13 +609,13 @@ test_demographic_events(void)
 
     CU_ASSERT_EQUAL(
         msp_add_instantaneous_bottleneck(&msp, 10, 2, 0),
-        MSP_ERR_BAD_POPULATION_ID);
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(
         msp_add_simple_bottleneck(&msp, 10, 0, -1),
         MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL_FATAL(
         msp_add_simple_bottleneck(&msp, 10, -1, 0),
-        MSP_ERR_BAD_POPULATION_ID);
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
 
     ret = msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5);
     CU_ASSERT_EQUAL(ret, 0);
@@ -666,7 +666,7 @@ test_demographic_events(void)
         CU_ASSERT_EQUAL(ret, 0);
         msp_print_state(&msp, _devnull);
         ret = msp_compute_population_size(&msp, 10, last_time, &pop_size);
-        CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_POPULATION_ID);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_OUT_OF_BOUNDS);
         for (k = 0; k < 2; k++) {
             ret = msp_compute_population_size(&msp, k, last_time, &pop_size);
             CU_ASSERT_EQUAL(ret, 0);

--- a/lib/simulation_tests.c
+++ b/lib/simulation_tests.c
@@ -857,7 +857,7 @@ test_mixed_model_simulation(void)
     /* TODO remove this when populate tables takes table_collection as arg */
     tables.sequence_length = msp->num_loci;
     CU_ASSERT_EQUAL_FATAL(tables.sequence_length, msp->num_loci);
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tree_sequence_print_state(&ts, _devnull);
     tree_sequence_free(&ts);
@@ -1282,7 +1282,7 @@ test_simulation_replicates(void)
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         /* TODO remove this when populate tables takes table_collection as arg */
         tables.sequence_length = m;
-        ret = tree_sequence_load_tables(&ts, &tables, 0);
+        ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_simulator_tree_sequence_equality(&msp, &ts, &mutgen, 1.0);
         tree_sequence_print_state(&ts, _devnull);

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -518,6 +518,25 @@ node_table_equals(node_table_t *self, node_table_t *other)
     return ret;
 }
 
+int
+node_table_get_row(node_table_t *self, size_t index, node_t *row)
+{
+    int ret = 0;
+    if (index >= self->num_rows) {
+        ret = MSP_ERR_OUT_OF_BOUNDS;
+        goto out;
+    }
+    row->flags = self->flags[index];
+    row->time = self->time[index];
+    row->population = self->population[index];
+    row->individual = self->individual[index];
+    row->metadata_length = self->metadata_offset[index + 1]
+        - self->metadata_offset[index];
+    row->metadata = self->metadata + self->metadata_offset[index];
+out:
+    return ret;
+}
+
 static int
 node_table_dump(node_table_t *self, kastore_t *store)
 {
@@ -4505,8 +4524,11 @@ out:
  * 0                             Check the integrity of ID & spatial references.
  * MSP_CHECK_OFFSETS             Check offsets for ragged columns.
  * MSP_CHECK_EDGE_ORDERING       Check edge ordering contraints for a tree sequence.
- * MSP_CHECK_SITE_ORDERING       Check site ordering contraints for a tree sequence.
+ * MSP_CHECK_SITE_ORDERING       Check that sites are in nondecreasing position order.
+ * MSP_CHECK_SITE_DUPLICATES     Check for any duplicate site positions.
  * MSP_CHECK_MUTATION_ORDERING   Check mutation ordering contraints for a tree sequence.
+ * MSP_CHECK_INDEXES             Check indexes exist & reference integrity.
+ * MSP_CHECK_ALL                 All above checks.
  */
 int WARN_UNUSED
 table_collection_check_integrity(table_collection_t *self, int flags)

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -4067,15 +4067,6 @@ simplifier_alloc(simplifier_t *self, node_id_t *samples, size_t num_samples,
             goto out;
         }
     }
-
-    /* Temporary workaround to make sure that we don't ship code with
-     * incorrect semantics in terms of individuals. Put this check in
-     * last so we catch other errors first, and so we don't need
-     * to change other tests.  */
-    if (tables->individuals->num_rows != 0) {
-        ret = MSP_ERR_INDIVIDUALS_NOT_SUPPORTED;
-        goto out;
-    }
 out:
     return ret;
 }

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -2319,6 +2319,10 @@ individual_table_get_row(individual_table_t *self, size_t index, individual_t *r
     row->metadata_length = self->metadata_offset[index + 1]
         - self->metadata_offset[index];
     row->metadata = self->metadata + self->metadata_offset[index];
+    /* Also have referencing individuals here. Should this be a different struct?
+     * See also site. */
+    row->nodes_length = 0;
+    row->nodes = NULL;
 out:
     return ret;
 }

--- a/lib/tables.c
+++ b/lib/tables.c
@@ -4447,6 +4447,20 @@ simplifier_finalise_references(simplifier_t *self)
         goto out;
     }
 
+    /* TODO Migrations fit reasonably neatly into the pattern that we have here. We can
+     * consider references to populations from migration objects in the same way
+     * as from nodes, so that we only remove a population if its referenced by
+     * neither. Mapping the population IDs in migrations is then easy. In principle
+     * nodes are similar, but the semantics are slightly different because we've
+     * already allocated all the nodes by their references from edges. We then
+     * need to decide whether we remove migrations that reference unmapped nodes
+     * or whether to add these nodes back in (probably the former is the correct
+     * approach).*/
+    if (self->input_tables.migrations->num_rows != 0) {
+        ret = MSP_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED;
+        goto out;
+    }
+
     for (j = 0; j < num_nodes; j++) {
         pop_id = node_population[j];
         if (pop_id != MSP_NULL_POPULATION) {

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -340,6 +340,7 @@ int node_table_dump_text(node_table_t *self, FILE *out);
 int node_table_copy(node_table_t *self, node_table_t *dest);
 void node_table_print_state(node_table_t *self, FILE *out);
 bool node_table_equals(node_table_t *self, node_table_t *other);
+int node_table_get_row(node_table_t *self, size_t index, node_t *row);
 
 int edge_table_alloc(edge_table_t *self, size_t max_rows_increment);
 edge_id_t edge_table_add_row(edge_table_t *self, double left, double right, node_id_t parent,

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -211,8 +211,6 @@ typedef struct _mutation_t {
     table_size_t derived_state_length;
     const char *metadata;
     table_size_t metadata_length;
-    // TODO remove this and change to ID?
-    size_t index;
 } mutation_t;
 
 typedef struct {

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -288,22 +288,9 @@ typedef struct {
     node_id_t *samples;
     size_t num_samples;
     int flags;
-    double sequence_length;
-    /* Keep a copy of the input nodes simplify mapping */
-    node_table_t input_nodes;
-    /* Also keep a copy of the input edges and a buffer to store unsorted edges */
-    edge_table_t input_edges;
-    /* Input copy of the sites and mutations */
-    site_table_t input_sites;
-    mutation_table_t input_mutations;
-    /* Input/output tables. */
-    node_table_t *nodes;
-    edge_table_t *edges;
-    site_table_t *sites;
-    mutation_table_t *mutations;
-    individual_table_t *individuals;
-    population_table_t *populations;
-    provenance_table_t *provenances;
+    table_collection_t *tables;
+    /* Keep a copy of the input tables */
+    table_collection_t input_tables;
     /* State for topology */
     simplify_segment_t **ancestor_map_head;
     simplify_segment_t **ancestor_map_tail;
@@ -333,7 +320,6 @@ typedef struct {
     /* When reducing topology, we need a map positions to their corresponding
      * sites.*/
     double *position_lookup;
-
 } simplifier_t;
 
 int node_table_alloc(node_table_t *self, size_t max_rows_increment,
@@ -511,6 +497,7 @@ int table_collection_record_position(table_collection_t *self,
         table_collection_position_t *position);
 int table_collection_reset_position(table_collection_t *self,
         table_collection_position_t *position);
+int table_collection_clear(table_collection_t *self);
 
 int simplifier_alloc(simplifier_t *self, node_id_t *samples, size_t num_samples,
         table_collection_t *tables, int flags);

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -498,6 +498,7 @@ int table_collection_record_position(table_collection_t *self,
 int table_collection_reset_position(table_collection_t *self,
         table_collection_position_t *position);
 int table_collection_clear(table_collection_t *self);
+int table_collection_check_integrity(table_collection_t *self, int flags);
 
 int simplifier_alloc(simplifier_t *self, node_id_t *samples, size_t num_samples,
         table_collection_t *tables, int flags);

--- a/lib/tables.h
+++ b/lib/tables.h
@@ -185,6 +185,7 @@ typedef struct {
 } individual_t;
 
 typedef struct {
+    node_id_t id;
     uint32_t flags;
     double time;
     population_id_t population;
@@ -194,6 +195,7 @@ typedef struct {
 } node_t;
 
 typedef struct {
+    edge_id_t id;
     node_id_t parent;
     node_id_t child;
     double left;
@@ -225,6 +227,7 @@ typedef struct {
 } site_t;
 
 typedef struct {
+    migration_id_t id;
     population_id_t source;
     population_id_t dest;
     node_id_t node;
@@ -238,13 +241,13 @@ typedef struct {
  * moved this code into tskit we can rename it, probably
  * tsk_population_t */
 typedef struct {
-    table_size_t id;
+    population_id_t id;
     const char *metadata;
     table_size_t metadata_length;
 } tmp_population_t;
 
 typedef struct {
-    table_size_t id;
+    provenance_id_t id;
     const char *timestamp;
     table_size_t timestamp_length;
     const char *record;
@@ -356,6 +359,7 @@ int edge_table_dump_text(edge_table_t *self, FILE *out);
 int edge_table_copy(edge_table_t *self, edge_table_t *dest);
 void edge_table_print_state(edge_table_t *self, FILE *out);
 bool edge_table_equals(edge_table_t *self, edge_table_t *other);
+int edge_table_get_row(edge_table_t *self, size_t index, edge_t *row);
 
 int site_table_alloc(site_table_t *self, size_t max_rows_increment,
         size_t max_ancestral_state_length_increment,
@@ -376,6 +380,7 @@ int site_table_copy(site_table_t *self, site_table_t *dest);
 int site_table_free(site_table_t *self);
 int site_table_dump_text(site_table_t *self, FILE *out);
 void site_table_print_state(site_table_t *self, FILE *out);
+int site_table_get_row(site_table_t *self, size_t index, site_t *row);
 
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
 int mutation_table_alloc(mutation_table_t *self, size_t max_rows_increment,
@@ -400,6 +405,7 @@ int mutation_table_copy(mutation_table_t *self, mutation_table_t *dest);
 int mutation_table_free(mutation_table_t *self);
 int mutation_table_dump_text(mutation_table_t *self, FILE *out);
 void mutation_table_print_state(mutation_table_t *self, FILE *out);
+int mutation_table_get_row(mutation_table_t *self, size_t index, mutation_t *row);
 
 int migration_table_alloc(migration_table_t *self, size_t max_rows_increment);
 migration_id_t migration_table_add_row(migration_table_t *self, double left,
@@ -418,6 +424,7 @@ int migration_table_copy(migration_table_t *self, migration_table_t *dest);
 int migration_table_dump_text(migration_table_t *self, FILE *out);
 void migration_table_print_state(migration_table_t *self, FILE *out);
 bool migration_table_equals(migration_table_t *self, migration_table_t *other);
+int migration_table_get_row(migration_table_t *self, size_t index, migration_t *row);
 
 int individual_table_alloc(individual_table_t *self, size_t max_rows_increment,
         size_t max_location_length_increment, size_t max_metadata_length_increment);
@@ -437,6 +444,7 @@ int individual_table_dump_text(individual_table_t *self, FILE *out);
 int individual_table_copy(individual_table_t *self, individual_table_t *dest);
 void individual_table_print_state(individual_table_t *self, FILE *out);
 bool individual_table_equals(individual_table_t *self, individual_table_t *other);
+int individual_table_get_row(individual_table_t *self, size_t index, individual_t *row);
 
 int population_table_alloc(population_table_t *self, size_t max_rows_increment,
         size_t max_metadata_length_increment);
@@ -453,6 +461,7 @@ int population_table_free(population_table_t *self);
 void population_table_print_state(population_table_t *self, FILE *out);
 int population_table_dump_text(population_table_t *self, FILE *out);
 bool population_table_equals(population_table_t *self, population_table_t *other);
+int population_table_get_row(population_table_t *self, size_t index, tmp_population_t *row);
 
 int provenance_table_alloc(provenance_table_t *self, size_t max_rows_increment,
         size_t max_timestamp_length_increment,
@@ -473,6 +482,7 @@ int provenance_table_free(provenance_table_t *self);
 int provenance_table_dump_text(provenance_table_t *self, FILE *out);
 void provenance_table_print_state(provenance_table_t *self, FILE *out);
 bool provenance_table_equals(provenance_table_t *self, provenance_table_t *other);
+int provenance_table_get_row(provenance_table_t *self, size_t index, provenance_t *row);
 
 int table_collection_alloc(table_collection_t *self, int flags);
 int table_collection_set_tables(table_collection_t *self,

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1207,7 +1207,7 @@ verify_trees(tree_sequence_t *ts, uint32_t num_trees, node_id_t* parents)
         for (k = 0; k < tree_sites_length; k++) {
             CU_ASSERT_EQUAL(sites[k].id, site_index);
             for (l = 0; l < sites[k].mutations_length; l++) {
-                CU_ASSERT_EQUAL(sites[k].mutations[l].index, mutation_index);
+                CU_ASSERT_EQUAL(sites[k].mutations[l].id, mutation_index);
                 CU_ASSERT_EQUAL(sites[k].mutations[l].site, site_index);
                 mutation_index++;
             }
@@ -4030,25 +4030,25 @@ test_single_tree_good_mutations(void)
     CU_ASSERT_EQUAL(other_sites[2].position, 0.3);
     CU_ASSERT_NSTRING_EQUAL(other_sites[2].ancestral_state, "0", 1);
 
-    CU_ASSERT_EQUAL(other_mutations[0].index, 0);
+    CU_ASSERT_EQUAL(other_mutations[0].id, 0);
     CU_ASSERT_EQUAL(other_mutations[0].node, 2);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[0].derived_state, "1", 1);
-    CU_ASSERT_EQUAL(other_mutations[1].index, 1);
+    CU_ASSERT_EQUAL(other_mutations[1].id, 1);
     CU_ASSERT_EQUAL(other_mutations[1].node, 4);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[1].derived_state, "1", 1);
-    CU_ASSERT_EQUAL(other_mutations[2].index, 2);
+    CU_ASSERT_EQUAL(other_mutations[2].id, 2);
     CU_ASSERT_EQUAL(other_mutations[2].node, 0);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[2].derived_state, "0", 1);
-    CU_ASSERT_EQUAL(other_mutations[3].index, 3);
+    CU_ASSERT_EQUAL(other_mutations[3].id, 3);
     CU_ASSERT_EQUAL(other_mutations[3].node, 0);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[3].derived_state, "1", 1);
-    CU_ASSERT_EQUAL(other_mutations[4].index, 4);
+    CU_ASSERT_EQUAL(other_mutations[4].id, 4);
     CU_ASSERT_EQUAL(other_mutations[4].node, 1);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[4].derived_state, "1", 1);
-    CU_ASSERT_EQUAL(other_mutations[5].index, 5);
+    CU_ASSERT_EQUAL(other_mutations[5].id, 5);
     CU_ASSERT_EQUAL(other_mutations[5].node, 2);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[5].derived_state, "1", 1);
-    CU_ASSERT_EQUAL(other_mutations[6].index, 6);
+    CU_ASSERT_EQUAL(other_mutations[6].id, 6);
     CU_ASSERT_EQUAL(other_mutations[6].node, 3);
     CU_ASSERT_NSTRING_EQUAL(other_mutations[6].derived_state, "1", 1);
 
@@ -6416,8 +6416,6 @@ verify_tree_sequences_equal(tree_sequence_t *ts1, tree_sequence_t *ts2,
             CU_ASSERT_EQUAL(ret, 0);
             CU_ASSERT_EQUAL(mutation_1.id, j);
             CU_ASSERT_EQUAL(mutation_1.id, mutation_2.id);
-            CU_ASSERT_EQUAL(mutation_1.index, j);
-            CU_ASSERT_EQUAL(mutation_1.index, mutation_2.index);
             CU_ASSERT_EQUAL(mutation_1.site, mutation_2.site);
             CU_ASSERT_EQUAL(mutation_1.node, mutation_2.node);
             CU_ASSERT_EQUAL_FATAL(mutation_1.parent, mutation_2.parent);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6596,6 +6596,7 @@ test_sort_tables(void)
     size_t j, k, start, starts[3];
     table_collection_t tables;
     int load_flags = MSP_BUILD_INDEXES;
+    node_id_t tmp_node;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6662,22 +6663,27 @@ test_sort_tables(void)
             /* Check for site bounds error */
             tables.mutations->site[0] = tables.sites->num_rows;
             ret = table_collection_sort(&tables, 0, 0);
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_OUT_OF_BOUNDS);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
             tables.mutations->site[0] = 0;
             ret = table_collection_sort(&tables, 0, 0);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
+
             /* Check for edge node bounds error */
+            tmp_node = tables.edges->parent[0];
             tables.edges->parent[0] = tables.nodes->num_rows;
             ret = table_collection_sort(&tables, 0, 0);
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_OUT_OF_BOUNDS);
-            tables.edges->parent[0] = 0;
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
+            tables.edges->parent[0] = tmp_node;
             ret = table_collection_sort(&tables, 0, 0);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
+
             /* Check for mutation node bounds error */
+            tmp_node = tables.mutations->node[0];
             tables.mutations->node[0] = tables.nodes->num_rows;
             ret = table_collection_sort(&tables, 0, 0);
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_OUT_OF_BOUNDS);
-            tables.mutations->node[0] = 0;
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
+            tables.mutations->node[0] = tmp_node;
+
             /* Check for mutation parent bounds error */
             tables.mutations->parent[0] = tables.mutations->num_rows;
             ret = table_collection_sort(&tables, 0, 0);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -6716,6 +6716,7 @@ test_deduplicate_sites_multichar(void)
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    tables.sequence_length = 10;
     ret = site_table_add_row(tables.sites, 0, "AA", 1, "M", 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_add_row(tables.sites, 0, "0", 1, NULL, 0);
@@ -6798,14 +6799,20 @@ test_deduplicate_sites(void)
     ret = table_collection_alloc(&messy, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    messy.sequence_length = 10;
+    tidy.sequence_length = 10;
+    parse_individuals(paper_ex_individuals, tidy.individuals);
+    parse_nodes(paper_ex_nodes, tidy.nodes);
     parse_sites(tidy_sites, tidy.sites);
     parse_mutations(tidy_mutations, tidy.mutations);
     // test cleaning doesn't mess up the tidy one
+    parse_individuals(paper_ex_individuals, messy.individuals);
+    parse_nodes(paper_ex_nodes, messy.nodes);
     parse_sites(tidy_sites, messy.sites);
     parse_mutations(tidy_mutations, messy.mutations);
 
     ret = table_collection_deduplicate_sites(&messy, 0);
-    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     verify_site_tables_equal(tidy.sites, messy.sites);
     verify_mutation_tables_equal(tidy.mutations, messy.mutations);
 
@@ -6834,12 +6841,16 @@ test_deduplicate_sites_errors(void)
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    tables.sequence_length = 10;
     ret = site_table_add_row(tables.sites, 2, "A", 1, "m", 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = site_table_add_row(tables.sites, 2, "TT", 2, "MM", 2);
     CU_ASSERT_EQUAL_FATAL(ret, 1);
     ret = mutation_table_add_row(tables.mutations, 0, 0, -1,
             "T", 1, NULL, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = node_table_add_row(tables.nodes, 0, 0, MSP_NULL_POPULATION,
+            MSP_NULL_INDIVIDUAL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Negative position */

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -561,7 +561,7 @@ tree_sequence_from_text(tree_sequence_t *ts, double sequence_length,
         }
     }
 
-    ret = tree_sequence_load_tables(ts, &tables, 0);
+    ret = tree_sequence_load_tables(ts, &tables, MSP_BUILD_INDEXES);
     /* tree_sequence_print_state(ts, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -714,7 +714,7 @@ add_individuals(tree_sequence_t *ts)
     }
     ret = tree_sequence_free(ts);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables(ts, &tables, 0);
+    ret = tree_sequence_load_tables(ts, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     table_collection_free(&tables);
 }
@@ -1587,7 +1587,7 @@ get_example_tree_sequence(uint32_t num_samples,
                 j % strlen(metadata));
         CU_ASSERT_FATAL(ret >= 0);
     }
-    ret = tree_sequence_load_tables(tree_seq, &tables, 0);
+    ret = tree_sequence_load_tables(tree_seq, &tables, MSP_BUILD_INDEXES);
     /* edge_table_print_state(edges, stdout); */
     /* printf("ret = %s\n", msp_strerror(ret)); */
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -2278,11 +2278,11 @@ test_empty_tree_sequence(void)
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SEQUENCE_LENGTH);
     tree_sequence_free(&ts);
     tables.sequence_length = 1.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     verify_empty_tree_sequence(&ts, 1.0);
@@ -3303,7 +3303,7 @@ test_simplest_individuals(void)
     parse_nodes(nodes, tables.nodes);
     CU_ASSERT_EQUAL_FATAL(tables.nodes->num_rows, 5);
 
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tree_sequence_get_node(&ts, 0, &node);
@@ -3356,6 +3356,7 @@ test_simplest_bad_individuals(void)
         "0  1   4   3\n";
     tree_sequence_t ts;
     table_collection_t tables;
+    int load_flags = MSP_BUILD_INDEXES;
     int ret;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
@@ -3370,20 +3371,20 @@ test_simplest_bad_individuals(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Make sure we have a good set of records */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tree_sequence_free(&ts);
 
     /* Bad individual ID */
     tables.nodes->individual[0] = -2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->individual[0] = MSP_NULL_INDIVIDUAL;
 
     /* Bad individual ID */
     tables.nodes->individual[0] = 0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->individual[0] = MSP_NULL_INDIVIDUAL;
@@ -3396,7 +3397,7 @@ test_simplest_bad_individuals(void)
 
     /* Bad individual ID */
     tables.nodes->individual[0] = 2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->individual[0] = MSP_NULL_INDIVIDUAL;
@@ -3421,6 +3422,7 @@ test_simplest_bad_records(void)
     tree_sequence_t ts;
     table_collection_t tables;
     int ret;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3434,46 +3436,46 @@ test_simplest_bad_records(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Make sure we have a good set of records */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tree_sequence_free(&ts);
 
     /* NULL for tables should be an error */
-    ret = tree_sequence_load_tables(&ts, NULL, 0);
+    ret = tree_sequence_load_tables(&ts, NULL, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     tree_sequence_free(&ts);
 
     /* Bad population ID */
     tables.nodes->population[0] = -2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->population[0] = 0;
 
     /* Bad population ID */
     tables.nodes->population[0] = 1;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->population[0] = 0;
 
     /* Bad interval */
     tables.edges->right[0] = 0.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
     tables.edges->right[0]= 1.0;
 
     /* Right coordinate > sequence length. */
     tables.edges->right[0] = 2.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_RIGHT_GREATER_SEQ_LENGTH);
     tree_sequence_free(&ts);
     tables.edges->right[0]= 1.0;
 
     /* Duplicate records */
     tables.edges->child[0] = 1;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_DUPLICATE_EDGES);
     tree_sequence_free(&ts);
     tables.edges->child[0] = 0;
@@ -3481,7 +3483,7 @@ test_simplest_bad_records(void)
     /* Duplicate records */
     tables.edges->child[0] = 1;
     tables.edges->left[0] = 0.5;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_LEFT);
     tree_sequence_free(&ts);
     tables.edges->child[0] = 0;
@@ -3489,7 +3491,7 @@ test_simplest_bad_records(void)
 
     /* child node == parent */
     tables.edges->child[1] = 2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_NODE_TIME_ORDERING);
     tree_sequence_free(&ts);
     tables.edges->child[1] = 1;
@@ -3497,7 +3499,7 @@ test_simplest_bad_records(void)
     /* Unsorted child nodes */
     tables.edges->child[0] = 1;
     tables.edges->child[1] = 0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_CHILD);
     tree_sequence_free(&ts);
     tables.edges->child[0] = 0;
@@ -3509,7 +3511,7 @@ test_simplest_bad_records(void)
     tables.edges->child[1] = 3;
     tables.edges->parent[2] = 2;
     tables.edges->child[2] = 1;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NONCONTIGUOUS_PARENTS);
     tree_sequence_free(&ts);
     tables.edges->parent[2] = 4;
@@ -3519,48 +3521,48 @@ test_simplest_bad_records(void)
 
     /* Null parent */
     tables.edges->parent[0] = MSP_NULL_NODE;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_PARENT);
     tree_sequence_free(&ts);
     tables.edges->parent[0] = 2;
 
     /* parent not in nodes list */
     tables.nodes->num_rows = 2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->num_rows = 5;
 
     /* parent negative */
     tables.edges->parent[0] = -2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.edges->parent[0] = 2;
 
     /* Null child */
     tables.edges->child[0] = MSP_NULL_NODE;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NULL_CHILD);
     tree_sequence_free(&ts);
     tables.edges->child[0] = 0;
 
     /* child node reference out of bounds */
     tables.edges->child[0] = 100;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.edges->child[0] = 0;
 
     /* child node reference negative */
     tables.edges->child[0] = -2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.edges->child[0] = 0;
 
     /* Make sure we've preserved a good tree sequence */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
 
@@ -3581,6 +3583,7 @@ test_simplest_overlapping_parents(void)
     table_collection_t tables;
     sparse_tree_t tree;
     int ret;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3593,7 +3596,7 @@ test_simplest_overlapping_parents(void)
 
     tables.edges->left[0] = 0;
     tables.edges->parent[0] = 2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -3629,6 +3632,7 @@ test_simplest_contradictory_children(void)
     table_collection_t tables;
     sparse_tree_t tree;
     int ret;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3639,7 +3643,7 @@ test_simplest_contradictory_children(void)
     CU_ASSERT_EQUAL_FATAL(tables.edges->num_rows, 2);
     tables.sequence_length = 1.0;
 
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     ret = sparse_tree_alloc(&tree, &ts, 0);
     CU_ASSERT_EQUAL(ret, 0);
@@ -3959,6 +3963,7 @@ test_single_tree_bad_records(void)
     int ret = 0;
     tree_sequence_t ts;
     table_collection_t tables;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3971,19 +3976,19 @@ test_single_tree_bad_records(void)
 
     /* Not sorted in time order */
     tables.nodes->time[5] = 0.5;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_EDGES_NOT_SORTED_PARENT_TIME);
     tree_sequence_free(&ts);
     tables.nodes->time[5] = 2.0;
 
     /* Left value greater than sequence right */
     tables.edges->left[2] = 2.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
     tables.edges->left[2] = 0.0;
 
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     tree_sequence_free(&ts);
     table_collection_free(&tables);
@@ -4067,6 +4072,7 @@ test_single_tree_bad_mutations(void)
         "2   2  1  -1\n";
     tree_sequence_t ts;
     table_collection_t tables;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4083,7 +4089,7 @@ test_single_tree_bad_mutations(void)
     tables.sequence_length = 1.0;
 
     /* Check to make sure we have legal mutations */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 6);
@@ -4091,97 +4097,104 @@ test_single_tree_bad_mutations(void)
 
     /* negative coordinate */
     tables.sites->position[0] = -1.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
     tables.sites->position[0] = 0.0;
 
     /* coordinate == sequence length */
     tables.sites->position[2] = 1.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
     tables.sites->position[2] = 0.2;
 
     /* coordinate > sequence length */
     tables.sites->position[2] = 1.1;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SITE_POSITION);
     tree_sequence_free(&ts);
     tables.sites->position[2] = 0.2;
 
+    /* Duplicate positions */
+    tables.sites->position[0] = 0.1;
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_DUPLICATE_SITE_POSITION);
+    tree_sequence_free(&ts);
+    tables.sites->position[0] = 0.0;
+
     /* Unsorted positions */
     tables.sites->position[0] = 0.3;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_UNSORTED_SITES);
     tree_sequence_free(&ts);
     tables.sites->position[0] = 0.0;
 
     /* site < 0 */
     tables.mutations->site[0] = -2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.mutations->site[0] = 0;
 
     /* site == num_sites */
     tables.mutations->site[0] = 3;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_SITE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.mutations->site[0] = 0;
 
     /* node = NULL */
     tables.mutations->node[0] = MSP_NULL_NODE;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.mutations->node[0] = 0;
 
     /* node >= num_nodes */
     tables.mutations->node[0] = 7;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.mutations->node[0] = 0;
 
     /* parent < -1 */
     tables.mutations->parent[0] = -2;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.mutations->parent[0] = MSP_NULL_MUTATION;
 
     /* parent >= num_mutations */
     tables.mutations->parent[0] = 7;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.mutations->parent[0] = MSP_NULL_MUTATION;
 
     /* parent on a different site */
     tables.mutations->parent[1] = 0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_DIFFERENT_SITE);
     tree_sequence_free(&ts);
     tables.mutations->parent[1] = MSP_NULL_MUTATION;
 
     /* parent is the same mutation */
     tables.mutations->parent[0] = 0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_EQUAL);
     tree_sequence_free(&ts);
     tables.mutations->parent[0] = MSP_NULL_MUTATION;
 
     /* parent_id > mutation id */
     tables.mutations->parent[2] = 3;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_MUTATION_PARENT_AFTER_CHILD);
     tree_sequence_free(&ts);
     tables.mutations->parent[2] = MSP_NULL_MUTATION;
 
     /* Check to make sure we've maintained legal mutations */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 6);
@@ -4746,7 +4759,7 @@ test_single_tree_vargen_many_alleles(void)
         /* When j = 0 we get a parent of -1, which is the NULL_NODE */
         ret = mutation_table_add_row(tables.mutations, 0, 0, j - 1, alleles, j, NULL, 0);
         CU_ASSERT_FATAL(ret >= 0);
-        ret = tree_sequence_load_tables(&ts, &tables, 0);
+        ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         for (l = 0; l < 2; l++) {
             flags = 0;
@@ -4891,6 +4904,7 @@ test_single_tree_compute_mutation_parents(void)
         "2   2  1  -1\n";
     tree_sequence_t ts;
     table_collection_t tables;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4907,7 +4921,7 @@ test_single_tree_compute_mutation_parents(void)
     tables.sequence_length = 1.0;
 
     /* Check to make sure we have legal mutations */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 6);
@@ -4971,7 +4985,7 @@ test_single_tree_compute_mutation_parents(void)
     tables.mutations->site[3] = 2;
 
     /* Check to make sure we still have legal mutations */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(tree_sequence_get_num_sites(&ts), 3);
     CU_ASSERT_EQUAL(tree_sequence_get_num_mutations(&ts), 6);
@@ -5866,6 +5880,7 @@ test_tree_sequence_bad_records(void)
         6, 5, 4, 4, 5, 6, MSP_NULL_NODE, MSP_NULL_NODE, MSP_NULL_NODE,
         7, 5, 4, 4, 5, 7, MSP_NULL_NODE, MSP_NULL_NODE, MSP_NULL_NODE,
     };
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -5876,7 +5891,7 @@ test_tree_sequence_bad_records(void)
     parse_individuals(paper_ex_individuals, tables.individuals);
 
     /* Make sure we have a good set of records */
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(ts.num_trees, 3);
     verify_trees(&ts, num_trees, parents);
@@ -5884,12 +5899,12 @@ test_tree_sequence_bad_records(void)
 
     /* Left value greater than right */
     tables.edges->left[0] = 10.0;
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_EDGE_INTERVAL);
     tree_sequence_free(&ts);
     tables.edges->left[0] = 2.0;
 
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, load_flags);
     CU_ASSERT_EQUAL(ret, 0);
     verify_trees(&ts, num_trees, parents);
     tree_sequence_free(&ts);
@@ -6487,7 +6502,7 @@ test_save_empty_kas(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = sequence_length;
 
-    ret = tree_sequence_load_tables(&ts1, &tables, 0);
+    ret = tree_sequence_load_tables(&ts1, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tree_sequence_dump(&ts1, _tmp_file_name, 0);
@@ -6580,6 +6595,7 @@ test_sort_tables(void)
     tree_sequence_t *ts1;
     size_t j, k, start, starts[3];
     table_collection_t tables;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6607,14 +6623,14 @@ test_sort_tables(void)
         for (k = 0; k < 3; k++) {
             start = starts[k];
             unsort_edges(tables.edges, start);
-            ret = tree_sequence_load_tables(&ts2, &tables, 0);
+            ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
             CU_ASSERT_NOT_EQUAL_FATAL(ret, 0);
             tree_sequence_free(&ts2);
 
             ret = table_collection_sort(&tables, 0, 0);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-            ret = tree_sequence_load_tables(&ts2, &tables, 0);
+            ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             verify_tree_sequences_equal(ts1, &ts2, true, true, false);
             tree_sequence_free(&ts2);
@@ -6623,7 +6639,7 @@ test_sort_tables(void)
         /* A start value of num_tables.edges should have no effect */
         ret = table_collection_sort(&tables, tables.edges->num_rows, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables(&ts2, &tables, 0);
+        ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, true, false);
         tree_sequence_free(&ts2);
@@ -6631,14 +6647,14 @@ test_sort_tables(void)
         if (tables.sites->num_rows > 1) {
             /* Check site sorting */
             unsort_sites(tables.sites, tables.mutations);
-            ret = tree_sequence_load_tables(&ts2, &tables, 0);
+            ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
             CU_ASSERT_NOT_EQUAL(ret, 0);
             tree_sequence_free(&ts2);
 
             ret = table_collection_sort(&tables, 0, 0);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-            ret = tree_sequence_load_tables(&ts2, &tables, 0);
+            ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             verify_tree_sequences_equal(ts1, &ts2, true, true, false);
             tree_sequence_free(&ts2);
@@ -6875,6 +6891,7 @@ test_dump_tables(void)
     tree_sequence_t *ts1;
     table_collection_t tables;
     size_t j;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6888,7 +6905,7 @@ test_dump_tables(void)
 
         ret = tree_sequence_dump_tables(ts1, &tables, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables(&ts2, &tables, 0);
+        ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         verify_tree_sequences_equal(ts1, &ts2, true, true, true);
         tree_sequence_print_state(&ts2, _devnull);
@@ -6908,6 +6925,7 @@ test_dump_tables_kas(void)
     size_t k;
     tree_sequence_t *ts1, ts2, ts3, **examples;
     table_collection_t tables;
+    int load_flags = MSP_BUILD_INDEXES;
 
     ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -6918,7 +6936,7 @@ test_dump_tables_kas(void)
         CU_ASSERT_FATAL(ts1 != NULL);
         ret = tree_sequence_dump_tables(ts1, &tables, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
-        ret = tree_sequence_load_tables(&ts2, &tables, 0);
+        ret = tree_sequence_load_tables(&ts2, &tables, load_flags);
         ret = tree_sequence_dump(&ts2, _tmp_file_name, 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         ret = tree_sequence_load(&ts3, _tmp_file_name, MSP_LOAD_EXTENDED_CHECKS);
@@ -7998,7 +8016,7 @@ test_individual_table(void)
     CU_ASSERT_TRUE_FATAL(individual_table_equals(tables.individuals, &table));
 
     // Round trip tables -> tree sequence -> tables
-    ret = tree_sequence_load_tables(&ts, &tables, 0);
+    ret = tree_sequence_load_tables(&ts, &tables, MSP_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tree_sequence_dump_tables(&ts, &tables2, MSP_ALLOC_TABLES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -3903,11 +3903,52 @@ test_simplest_population_filter(void)
     CU_ASSERT_EQUAL(tables.populations->metadata[1], '1');
     CU_ASSERT_EQUAL(tables.populations->metadata[2], '2');
 
-    /* ret = table_collection_simplify(&tables, samples, 2, MSP_FILTER_POPULATIONS, NULL); */
-    /* CU_ASSERT_EQUAL_FATAL(ret, 0); */
-    /* CU_ASSERT_EQUAL(tables.nodes->num_rows, 2); */
-    /* CU_ASSERT_EQUAL(tables.populations->num_rows, 1); */
-    /* CU_ASSERT_EQUAL(tables.populations->metadata[0], '1'); */
+    ret = table_collection_simplify(&tables, samples, 2, MSP_FILTER_POPULATIONS, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(tables.nodes->num_rows, 2);
+    CU_ASSERT_EQUAL(tables.nodes->population[0], 0);
+    CU_ASSERT_EQUAL(tables.nodes->population[1], 0);
+    CU_ASSERT_EQUAL(tables.populations->num_rows, 1);
+    CU_ASSERT_EQUAL(tables.populations->metadata[0], '1');
+
+    table_collection_free(&tables);
+}
+
+static void
+test_simplest_individual_filter(void)
+{
+    table_collection_t tables;
+    node_id_t samples[] = {0, 1};
+    int ret;
+
+    ret = table_collection_alloc(&tables, MSP_ALLOC_TABLES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    tables.sequence_length = 1;
+    individual_table_add_row(tables.individuals, 0, NULL, 0, "0", 1);
+    individual_table_add_row(tables.individuals, 0, NULL, 0, "1", 1);
+    individual_table_add_row(tables.individuals, 0, NULL, 0, "2", 1);
+    /* Two nodes referring to individual 1 */
+    node_table_add_row(tables.nodes, MSP_NODE_IS_SAMPLE, 0.0, MSP_NULL_POPULATION, 1,
+            NULL, 0);
+    node_table_add_row(tables.nodes, MSP_NODE_IS_SAMPLE, 0.0, MSP_NULL_POPULATION, 1,
+            NULL, 0);
+
+    ret = table_collection_simplify(&tables, samples, 2, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(tables.nodes->num_rows, 2);
+    CU_ASSERT_EQUAL(tables.individuals->num_rows, 3);
+    CU_ASSERT_EQUAL(tables.individuals->metadata[0], '0');
+    CU_ASSERT_EQUAL(tables.individuals->metadata[1], '1');
+    CU_ASSERT_EQUAL(tables.individuals->metadata[2], '2');
+
+    ret = table_collection_simplify(&tables, samples, 2, MSP_FILTER_INDIVIDUALS, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL(tables.nodes->num_rows, 2);
+    CU_ASSERT_EQUAL(tables.nodes->individual[0], 0);
+    CU_ASSERT_EQUAL(tables.nodes->individual[1], 0);
+    CU_ASSERT_EQUAL(tables.individuals->num_rows, 1);
+    CU_ASSERT_EQUAL(tables.individuals->metadata[0], '1');
 
     table_collection_free(&tables);
 }
@@ -9250,6 +9291,7 @@ main(int argc, char **argv)
             test_simplest_overlapping_unary_edges_internal_samples_simplify},
         {"test_simplest_reduce_site_topology", test_simplest_reduce_site_topology},
         {"test_simplest_population_filter", test_simplest_population_filter},
+        {"test_simplest_individual_filter", test_simplest_individual_filter},
         {"test_single_tree_good_records", test_single_tree_good_records},
         {"test_single_nonbinary_tree_good_records",
             test_single_nonbinary_tree_good_records},

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -4822,7 +4822,7 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     unsort_edges(tables.edges, 0);
     ret = simplifier_alloc(&simplifier, samples, 2, &tables, 0);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_EDGES_NOT_SORTED_PARENT_TIME);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_EDGES_NOT_SORTED_CHILD);
     ret = simplifier_free(&simplifier);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -4831,7 +4831,7 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.edges->parent[0] = -1;
     ret = simplifier_alloc(&simplifier, samples, 2, &tables, 0);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NULL_PARENT);
     ret = simplifier_free(&simplifier);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
@@ -4840,7 +4840,7 @@ test_single_tree_simplify(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.edges->child[0] = -1;
     ret = simplifier_alloc(&simplifier, samples, 2, &tables, 0);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NODE_OUT_OF_BOUNDS);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_NULL_CHILD);
     ret = simplifier_free(&simplifier);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -3377,14 +3377,14 @@ test_simplest_bad_individuals(void)
     /* Bad individual ID */
     tables.nodes->individual[0] = -2;
     ret = tree_sequence_load_tables(&ts, &tables, 0);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_INDIVIDUAL);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->individual[0] = MSP_NULL_INDIVIDUAL;
 
     /* Bad individual ID */
     tables.nodes->individual[0] = 0;
     ret = tree_sequence_load_tables(&ts, &tables, 0);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_INDIVIDUAL);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->individual[0] = MSP_NULL_INDIVIDUAL;
 
@@ -3397,7 +3397,7 @@ test_simplest_bad_individuals(void)
     /* Bad individual ID */
     tables.nodes->individual[0] = 2;
     ret = tree_sequence_load_tables(&ts, &tables, 0);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_INDIVIDUAL);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->individual[0] = MSP_NULL_INDIVIDUAL;
 
@@ -3446,14 +3446,14 @@ test_simplest_bad_records(void)
     /* Bad population ID */
     tables.nodes->population[0] = -2;
     ret = tree_sequence_load_tables(&ts, &tables, 0);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_POPULATION_ID);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->population[0] = 0;
 
     /* Bad population ID */
     tables.nodes->population[0] = 1;
     ret = tree_sequence_load_tables(&ts, &tables, 0);
-    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_POPULATION_ID);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     tree_sequence_free(&ts);
     tables.nodes->population[0] = 0;
 

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -7008,6 +7008,7 @@ test_node_table(void)
 {
     int ret;
     node_table_t table;
+    node_t node;
     size_t num_rows = 100;
     size_t j;
     uint32_t *flags;
@@ -7039,7 +7040,17 @@ test_node_table(void)
         /* check the metadata */
         memcpy(metadata_copy, table.metadata + table.metadata_offset[j], test_metadata_length);
         CU_ASSERT_NSTRING_EQUAL(metadata_copy, test_metadata, test_metadata_length);
+        ret = node_table_get_row(&table, j, &node);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+        CU_ASSERT_EQUAL(node.flags, j);
+        CU_ASSERT_EQUAL(node.time, j);
+        CU_ASSERT_EQUAL(node.population, j);
+        CU_ASSERT_EQUAL(node.individual, j);
+        CU_ASSERT_EQUAL(node.metadata_length, test_metadata_length);
+        CU_ASSERT_NSTRING_EQUAL(node.metadata, test_metadata, test_metadata_length);
     }
+    CU_ASSERT_EQUAL(node_table_get_row(&table, num_rows, &node),
+            MSP_ERR_OUT_OF_BOUNDS);
     node_table_print_state(&table, _devnull);
     node_table_dump_text(&table, _devnull);
 

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -610,12 +610,12 @@ tree_sequence_init_nodes(tree_sequence_t *self)
         }
         if (self->nodes.population[j] < -1
                 || self->nodes.population[j] >= num_populations) {
-            ret = MSP_ERR_BAD_POPULATION_ID;
+            ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
             goto out;
         }
         if (self->nodes.individual[j] < -1
                 || self->nodes.individual[j] >= num_individuals) {
-            ret = MSP_ERR_BAD_INDIVIDUAL;
+            ret = MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS;
             goto out;
         }
     }

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -446,8 +446,6 @@ tree_sequence_init_individuals(tree_sequence_t *self)
     size_t num_inds = self->individuals.num_records;
 
     // First find number of nodes per individual
-    // TODO: this doesn't take advantage of the fact that nodes are
-    // contigusous. See https://github.com/tskit-dev/msprime/issues/527
     self->individuals.individual_nodes_length = calloc(
             MSP_MAX(1, num_inds), sizeof(table_size_t));
     num_nodes = calloc(MSP_MAX(1, num_inds), sizeof(size_t));
@@ -460,12 +458,6 @@ tree_sequence_init_individuals(tree_sequence_t *self)
     for (k = 0; k < (node_id_t) self->nodes.num_records; k++) {
         j = self->nodes.individual[k];
         if (j != MSP_NULL_INDIVIDUAL) {
-            if (k > 0 && self->individuals.individual_nodes_length[j] > 0) {
-                if (self->nodes.individual[k - 1] != j) {
-                    ret = MSP_ERR_NODES_NONCONTIGUOUS_INDIVIDUALS;
-                    goto out;
-                }
-            }
             self->individuals.individual_nodes_length[j] += 1;
         }
         total_nodes++;

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -914,7 +914,7 @@ tree_sequence_get_population(tree_sequence_t *self, size_t index,
         ret = MSP_ERR_OUT_OF_BOUNDS;
         goto out;
     }
-    population->id = (table_size_t) index;
+    population->id = (provenance_id_t) index;
     offset = self->populations.metadata_offset[index];
     length = self->populations.metadata_offset[index + 1] - offset;
     population->metadata = self->populations.metadata + offset;
@@ -933,7 +933,7 @@ tree_sequence_get_provenance(tree_sequence_t *self, size_t index, provenance_t *
         ret = MSP_ERR_OUT_OF_BOUNDS;
         goto out;
     }
-    provenance->id = (table_size_t) index;
+    provenance->id = (provenance_id_t) index;
     offset = self->provenances.timestamp_offset[index];
     length = self->provenances.timestamp_offset[index + 1] - offset;
     provenance->timestamp = self->provenances.timestamp + offset;

--- a/lib/trees.h
+++ b/lib/trees.h
@@ -26,6 +26,13 @@ extern "C" {
  * this somehow to remove this redundancy. Probably downstream code should
  * be forced to use some functions rather than accessing these structs
  * to obtain pointers to indexes, edges data and so on.
+ *
+ * UPDATE 2018-08-11. This is ready for refactoring now. Anywhere we're looking
+ * the actual arrays we can access via the tables, and should take a
+ * const local pointer anyway, instead of chasing through a bunch of references.
+ * We can make the tree struct a bit more efficient as well by using
+ * const and restrict for the pointers we're using. For printing and so on,
+ * should use the get_row type accesses to simplify the pointers, etc.
  */
 typedef struct {
     size_t num_trees;

--- a/lib/trees.h
+++ b/lib/trees.h
@@ -282,12 +282,12 @@ size_t tree_sequence_get_num_samples(tree_sequence_t *self);
 double tree_sequence_get_sequence_length(tree_sequence_t *self);
 bool tree_sequence_is_sample(tree_sequence_t *self, node_id_t u);
 
-int tree_sequence_get_node(tree_sequence_t *self, node_id_t index, node_t *node);
+int tree_sequence_get_node(tree_sequence_t *self, size_t index, node_t *node);
 int tree_sequence_get_edge(tree_sequence_t *self, size_t index, edge_t *edge);
 int tree_sequence_get_migration(tree_sequence_t *self, size_t index,
         migration_t *migration);
-int tree_sequence_get_site(tree_sequence_t *self, site_id_t id, site_t *site);
-int tree_sequence_get_mutation(tree_sequence_t *self, mutation_id_t id,
+int tree_sequence_get_site(tree_sequence_t *self, size_t index, site_t *site);
+int tree_sequence_get_mutation(tree_sequence_t *self, size_t index,
         mutation_t *mutation);
 int tree_sequence_get_provenance(tree_sequence_t *self, size_t index,
         provenance_t *provenance);

--- a/lib/util.c
+++ b/lib/util.c
@@ -265,6 +265,11 @@ msp_strerror_internal(int err)
         case MSP_ERR_TABLES_NOT_INDEXED:
             ret = "Table collection must be indexed.";
             break;
+        case MSP_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED:
+            ret = "Migrations currently not supported in simplify. Please open an "
+                "issue on GitHub if this operation is important to you.";
+            break;
+
         case MSP_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);

--- a/lib/util.c
+++ b/lib/util.c
@@ -223,6 +223,9 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_SEQUENCE_LENGTH:
             ret = "Sequence length must be > 0.";
             break;
+        case MSP_ERR_LEFT_LESS_ZERO:
+            ret = "Left coordinate must be >= 0";
+            break;
         case MSP_ERR_RIGHT_GREATER_SEQ_LENGTH:
             ret = "Right coordinate > sequence length.";
             break;
@@ -258,6 +261,9 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_BAD_EDGE_INDEX:
             ret = "Invalid edge index value.";
+            break;
+        case MSP_ERR_TABLES_NOT_INDEXED:
+            ret = "Table collection must be indexed.";
             break;
         case MSP_ERR_IO:
             if (errno != 0) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -120,9 +120,6 @@ msp_strerror_internal(int err)
         case MSP_ERR_EDGES_NONCONTIGUOUS_PARENTS:
             ret = "All edges for a given parent must be contiguous";
             break;
-        case MSP_ERR_NODES_NONCONTIGUOUS_INDIVIDUALS:
-            ret = "All nodes for a given individual must be contiguous";
-            break;
         case MSP_ERR_EDGES_NOT_SORTED_CHILD:
             ret = "Edges must be listed in (time[parent], child, left) order;"
                 " child order violated";
@@ -255,10 +252,6 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_DUPLICATE_SITE_POSITION:
             ret = "Duplicate site positions.";
-            break;
-        case MSP_ERR_INDIVIDUALS_NOT_SUPPORTED:
-            /* Temporary error to flag a limitation in current implementation. */
-            ret = "Individuals are currently not supported in simplify.";
             break;
         case MSP_ERR_BAD_TABLE_POSITION:
             ret = "Bad table position provided to truncate/reset.";

--- a/lib/util.c
+++ b/lib/util.c
@@ -83,8 +83,8 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_POPULATION_SIZE:
             ret = "Bad population size provided. Must be > 0.";
             break;
-        case MSP_ERR_BAD_POPULATION_ID:
-            ret = "Bad population id provided.";
+        case MSP_ERR_POPULATION_OUT_OF_BOUNDS:
+            ret = "Population ID out of bounds.";
             break;
         case MSP_ERR_BAD_MIGRATION_MATRIX:
             ret = "Bad migration matrix provided.";
@@ -244,8 +244,8 @@ msp_strerror_internal(int err)
         case MSP_ERR_TOO_MANY_ALLELES:
             ret = "Cannot have more than 255 alleles.";
             break;
-        case MSP_ERR_BAD_INDIVIDUAL:
-            ret = "Individual ID not in individual table.";
+        case MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS:
+            ret = "Individual ID out of bounds";
             break;
         case MSP_ERR_GENERATE_UUID:
             ret = "Error generating UUID";
@@ -255,6 +255,9 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_BAD_TABLE_POSITION:
             ret = "Bad table position provided to truncate/reset.";
+            break;
+        case MSP_ERR_BAD_EDGE_INDEX:
+            ret = "Invalid edge index value.";
             break;
         case MSP_ERR_IO:
             if (errno != 0) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -63,7 +63,7 @@ msp_strerror_internal(int err)
             ret = "Links Overflow occurred.";
             break;
         case MSP_ERR_OUT_OF_BOUNDS:
-            ret = "Array index out of bounds";
+            ret = "Object reference out of bounds";
             break;
         case MSP_ERR_BAD_ORDERING:
             ret = "Bad record ordering requested";

--- a/lib/util.h
+++ b/lib/util.h
@@ -179,6 +179,7 @@
 #define MSP_ERR_BAD_EDGE_INDEX                                      -74
 #define MSP_ERR_LEFT_LESS_ZERO                                      -75
 #define MSP_ERR_TABLES_NOT_INDEXED                                  -76
+#define MSP_ERR_SIMPLIFY_MIGRATIONS_NOT_SUPPORTED                   -77
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/lib/util.h
+++ b/lib/util.h
@@ -59,6 +59,7 @@
 #define MSP_DBL_DECIMAL_DIG (DBL_DIG + 3)
 #endif
 
+/* Node flags */
 #define MSP_NODE_IS_SAMPLE 1
 
 /* The root node indicator */
@@ -70,13 +71,11 @@
 /* Indicates that no individual has been set */
 #define MSP_NULL_INDIVIDUAL (-1)
 
-/* Flags for individuals */
-#define MSP_INDIVIDUAL_FEMALE 1
-#define MSP_INDIVIDUAL_MALE 2
-
 /* Flags for simplify() */
-#define MSP_FILTER_ZERO_MUTATION_SITES   1
+#define MSP_FILTER_SITES                 (1 << 0)
 #define MSP_REDUCE_TO_SITE_TOPOLOGY      (1 << 1)
+#define MSP_FILTER_POPULATIONS           (1 << 2)
+#define MSP_FILTER_INDIVIDUALS           (1 << 3)
 
 /* Flags for dump tables */
 #define MSP_ALLOC_TABLES 1

--- a/lib/util.h
+++ b/lib/util.h
@@ -65,7 +65,7 @@
 /* The root node indicator */
 #define MSP_NULL_NODE (-1)
 /* Indicates the that the population ID has not been set. */
-#define MSP_NULL_POPULATION_ID (-1)
+#define MSP_NULL_POPULATION (-1)
 /* There is no parent for a given mutation */
 #define MSP_NULL_MUTATION (-1)
 /* Indicates that no individual has been set */
@@ -76,6 +76,11 @@
 #define MSP_REDUCE_TO_SITE_TOPOLOGY      (1 << 1)
 #define MSP_FILTER_POPULATIONS           (1 << 2)
 #define MSP_FILTER_INDIVIDUALS           (1 << 3)
+
+/* Flags for check_integrity */
+#define MSP_CHECK_OFFSETS                (1 << 0)
+#define MSP_CHECK_ORDERING               (1 << 1)
+#define MSP_CHECK_ALL                    (MSP_CHECK_OFFSETS | MSP_CHECK_ORDERING)
 
 /* Flags for dump tables */
 #define MSP_ALLOC_TABLES 1
@@ -105,7 +110,7 @@
 #define MSP_ERR_POPULATION_OVERFLOW                                 -11
 #define MSP_ERR_LINKS_OVERFLOW                                      -12
 #define MSP_ERR_HDF5                                                -13
-#define MSP_ERR_BAD_POPULATION_ID                                   -14
+#define MSP_ERR_POPULATION_OUT_OF_BOUNDS                            -14
 #define MSP_ERR_DUPLICATE_SAMPLE                                    -15
 #define MSP_ERR_BAD_ORDERING                                        -16
 #define MSP_ERR_BAD_MUTATION                                        -17
@@ -163,8 +168,9 @@
 #define MSP_ERR_MUTATION_PARENT_DIFFERENT_SITE                      -69
 #define MSP_ERR_MUTATION_PARENT_EQUAL                               -70
 #define MSP_ERR_MUTATION_PARENT_AFTER_CHILD                         -71
-#define MSP_ERR_BAD_INDIVIDUAL                                      -72
+#define MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS                            -72
 #define MSP_ERR_GENERATE_UUID                                       -73
+#define MSP_ERR_BAD_EDGE_INDEX                                      -74
 
 
 /* This bit is 0 for any errors originating from kastore */

--- a/lib/util.h
+++ b/lib/util.h
@@ -79,8 +79,13 @@
 
 /* Flags for check_integrity */
 #define MSP_CHECK_OFFSETS                (1 << 0)
-#define MSP_CHECK_ORDERING               (1 << 1)
-#define MSP_CHECK_ALL                    (MSP_CHECK_OFFSETS | MSP_CHECK_ORDERING)
+#define MSP_CHECK_EDGE_ORDERING          (1 << 1)
+#define MSP_CHECK_SITE_ORDERING          (1 << 2)
+#define MSP_CHECK_MUTATION_ORDERING      (1 << 3)
+#define MSP_CHECK_INDEXES                (1 << 4)
+#define MSP_CHECK_ALL                    \
+    (MSP_CHECK_OFFSETS | MSP_CHECK_EDGE_ORDERING | MSP_CHECK_SITE_ORDERING | \
+     MSP_CHECK_MUTATION_ORDERING | MSP_CHECK_INDEXES)
 
 /* Flags for dump tables */
 #define MSP_ALLOC_TABLES 1
@@ -171,7 +176,8 @@
 #define MSP_ERR_INDIVIDUAL_OUT_OF_BOUNDS                            -72
 #define MSP_ERR_GENERATE_UUID                                       -73
 #define MSP_ERR_BAD_EDGE_INDEX                                      -74
-
+#define MSP_ERR_LEFT_LESS_ZERO                                      -75
+#define MSP_ERR_TABLES_NOT_INDEXED                                  -76
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/lib/util.h
+++ b/lib/util.h
@@ -121,7 +121,7 @@
 #define MSP_ERR_BAD_RECOMBINATION_MAP                               -26
 #define MSP_ERR_BAD_POPULATION_SIZE                                 -27
 #define MSP_ERR_BAD_SAMPLES                                         -28
-#define MSP_ERR_NODES_NONCONTIGUOUS_INDIVIDUALS                     -29
+#define MSP_ERR_BAD_TABLE_POSITION                                  -29
 #define MSP_ERR_FILE_VERSION_TOO_OLD                                -30
 #define MSP_ERR_FILE_VERSION_TOO_NEW                                -31
 #define MSP_ERR_CANNOT_SIMPLIFY                                     -32
@@ -166,13 +166,7 @@
 #define MSP_ERR_MUTATION_PARENT_AFTER_CHILD                         -71
 #define MSP_ERR_BAD_INDIVIDUAL                                      -72
 #define MSP_ERR_GENERATE_UUID                                       -73
-/* TODO remove this code once we've fixed up support for
- * individuals in simplify */
-#define MSP_ERR_INDIVIDUALS_NOT_SUPPORTED                           -74
 
-/* REUSE: * -57 */
-
-#define MSP_ERR_BAD_TABLE_POSITION                                  -75
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/lib/util.h
+++ b/lib/util.h
@@ -60,7 +60,7 @@
 #endif
 
 /* Node flags */
-#define MSP_NODE_IS_SAMPLE 1
+#define MSP_NODE_IS_SAMPLE 1u
 
 /* The root node indicator */
 #define MSP_NULL_NODE (-1)

--- a/lib/util.h
+++ b/lib/util.h
@@ -81,11 +81,12 @@
 #define MSP_CHECK_OFFSETS                (1 << 0)
 #define MSP_CHECK_EDGE_ORDERING          (1 << 1)
 #define MSP_CHECK_SITE_ORDERING          (1 << 2)
-#define MSP_CHECK_MUTATION_ORDERING      (1 << 3)
-#define MSP_CHECK_INDEXES                (1 << 4)
+#define MSP_CHECK_SITE_DUPLICATES        (1 << 3)
+#define MSP_CHECK_MUTATION_ORDERING      (1 << 4)
+#define MSP_CHECK_INDEXES                (1 << 5)
 #define MSP_CHECK_ALL                    \
     (MSP_CHECK_OFFSETS | MSP_CHECK_EDGE_ORDERING | MSP_CHECK_SITE_ORDERING | \
-     MSP_CHECK_MUTATION_ORDERING | MSP_CHECK_INDEXES)
+     MSP_CHECK_SITE_DUPLICATES | MSP_CHECK_MUTATION_ORDERING | MSP_CHECK_INDEXES)
 
 /* Flags for dump tables */
 #define MSP_ALLOC_TABLES 1

--- a/lib/vcf.c
+++ b/lib/vcf.c
@@ -192,7 +192,7 @@ vcf_converter_convert_positions(vcf_converter_t *self, tree_sequence_t *tree_seq
     size_t j;
 
     for (j = 0; j < self->num_sites; j++) {
-        ret = tree_sequence_get_site(tree_sequence, (site_id_t) j, &site);
+        ret = tree_sequence_get_site(tree_sequence, j, &site);
         if (ret != 0) {
             goto out;
         }

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1812,8 +1812,7 @@ def simplify_tables(
             sequence_length=sequence_length)
     except AttributeError as e:
         raise TypeError(str(e))
-    return ll_tables.simplify(
-        samples, filter_zero_mutation_sites=filter_zero_mutation_sites)
+    return ll_tables.simplify(samples, filter_sites=filter_zero_mutation_sites)
 
 
 def pack_bytes(data):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1559,8 +1559,9 @@ class TableCollection(object):
         return msprime.TreeSequence.load_tables(self)
 
     def simplify(
-            self, samples, filter_zero_mutation_sites=True,
-            reduce_to_site_topology=False):
+            self, samples, filter_zero_mutation_sites=None,
+            reduce_to_site_topology=False,
+            filter_sites=True):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
@@ -1593,8 +1594,10 @@ class TableCollection(object):
             corresponding node IDs in the output tables.
         :rtype: numpy array (dtype=np.int32).
         """
+        if filter_zero_mutation_sites is not None:
+            filter_sites = filter_zero_mutation_sites
         return self.ll_tables.simplify(
-            samples, filter_zero_mutation_sites,
+            samples, filter_sites,
             reduce_to_site_topology=reduce_to_site_topology)
 
     def sort(self, edge_start=0):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1597,7 +1597,7 @@ class TableCollection(object):
         if filter_zero_mutation_sites is not None:
             filter_sites = filter_zero_mutation_sites
         return self.ll_tables.simplify(
-            samples, filter_sites,
+            samples, filter_sites=filter_sites,
             reduce_to_site_topology=reduce_to_site_topology)
 
     def sort(self, edge_start=0):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 import base64
 import collections
 import datetime
+import warnings
 
 import numpy as np
 from six.moves import copyreg
@@ -1559,9 +1560,10 @@ class TableCollection(object):
         return msprime.TreeSequence.load_tables(self)
 
     def simplify(
-            self, samples, filter_zero_mutation_sites=None,
+            self, samples,
+            filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
             reduce_to_site_topology=False,
-            filter_populations=False, filter_individuals=False, filter_sites=True):
+            filter_populations=True, filter_individuals=True, filter_sites=True):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
@@ -1586,15 +1588,30 @@ class TableCollection(object):
         of the remaining parameters.
 
         :param list[int] samples: A list of node IDs to retain as samples.
-        :param bool filter_zero_mutation_sites: Whether to remove sites that have no
-            mutations from the output (default: True).
+        :param bool filter_zero_mutation_sites: Deprecated alias for ``filter_sites``.
         :param bool reduce_to_site_topology: Whether to reduce the topology down
             to the trees that are present at sites. (default: False).
+        :param bool filter_populations: If True, remove any populations that are
+            not referenced by nodes after simplification; new population IDs are
+            allocated sequentially from zero. If False, the population table will
+            not be altered in any way. (Default: True)
+        :param bool filter_individuals: If True, remove any individuals that are
+            not referenced by nodes after simplification; new individual IDs are
+            allocated sequentially from zero. If False, the individual table will
+            not be altered in any way. (Default: True)
+        :param bool filter_sites: If True, remove any sites that are
+            not referenced by mutations after simplification; new site IDs are
+            allocated sequentially from zero. If False, the site table will not
+            be altered in any way. (Default: True)
         :return: A numpy array mapping node IDs in the input tables to their
             corresponding node IDs in the output tables.
         :rtype: numpy array (dtype=np.int32).
         """
         if filter_zero_mutation_sites is not None:
+            # Deprecated in 0.6.1.
+            warnings.warn(
+                "filter_zero_mutation_sites is deprecated; use filter_sites instead",
+                DeprecationWarning)
             filter_sites = filter_zero_mutation_sites
         return self.ll_tables.simplify(
             samples, filter_sites=filter_sites,

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1561,7 +1561,7 @@ class TableCollection(object):
     def simplify(
             self, samples, filter_zero_mutation_sites=None,
             reduce_to_site_topology=False,
-            filter_sites=True):
+            filter_populations=True, filter_individuals=True, filter_sites=True):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1561,7 +1561,7 @@ class TableCollection(object):
     def simplify(
             self, samples, filter_zero_mutation_sites=None,
             reduce_to_site_topology=False,
-            filter_populations=True, filter_individuals=True, filter_sites=True):
+            filter_populations=False, filter_individuals=False, filter_sites=True):
         """
         Simplifies the tables in place to retain only the information necessary
         to reconstruct the tree sequence describing the given ``samples``.
@@ -1598,6 +1598,8 @@ class TableCollection(object):
             filter_sites = filter_zero_mutation_sites
         return self.ll_tables.simplify(
             samples, filter_sites=filter_sites,
+            filter_individuals=filter_individuals,
+            filter_populations=filter_populations,
             reduce_to_site_topology=reduce_to_site_topology)
 
     def sort(self, edge_start=0):

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1799,6 +1799,14 @@ def simplify_tables(
         mutations = MutationTable()
     if sequence_length == 0 and len(edges) > 0:
         sequence_length = edges.right.max()
+    # To make this work with the old semantics we need to create a populations
+    max_pop = np.max(nodes.population)
+    populations = _msprime.PopulationTable()
+    for _ in range(max_pop + 1):
+        populations.add_row()
+    max_ind = np.max(nodes.individual)
+    if max_ind != msprime.NULL_INDIVIDUAL:
+        raise ValueError("Individuals not supported in this deprecated function")
     try:
         ll_tables = _msprime.TableCollection(
             individuals=_msprime.IndividualTable(),
@@ -1807,7 +1815,7 @@ def simplify_tables(
             migrations=migrations.ll_table,
             sites=sites.ll_table,
             mutations=mutations.ll_table,
-            populations=_msprime.PopulationTable(),
+            populations=populations,
             provenances=_msprime.ProvenanceTable(),
             sequence_length=sequence_length)
     except AttributeError as e:

--- a/msprime/tables.py
+++ b/msprime/tables.py
@@ -1734,9 +1734,18 @@ def sort_tables(
         sites = SiteTable()
     if mutations is None:
         mutations = MutationTable()
-    sequence_length = 0
+    sequence_length = 1
     if len(edges) > 0:
         sequence_length = edges.right.max()
+    # To make this work with the old semantics we need to create a populations
+    populations = _msprime.PopulationTable()
+    if len(nodes) > 0:
+        max_pop = np.max(nodes.population)
+        for _ in range(max_pop + 1):
+            populations.add_row()
+        max_ind = np.max(nodes.individual)
+        if max_ind != msprime.NULL_INDIVIDUAL:
+            raise ValueError("Individuals not supported in this deprecated function")
     try:
         ll_tables = _msprime.TableCollection(
             individuals=_msprime.IndividualTable(),
@@ -1745,7 +1754,7 @@ def sort_tables(
             migrations=migrations.ll_table,
             sites=sites.ll_table,
             mutations=mutations.ll_table,
-            populations=_msprime.PopulationTable(),
+            populations=populations,
             provenances=_msprime.ProvenanceTable(),
             sequence_length=sequence_length)
     except AttributeError as e:
@@ -1802,11 +1811,12 @@ def simplify_tables(
     # To make this work with the old semantics we need to create a populations
     max_pop = np.max(nodes.population)
     populations = _msprime.PopulationTable()
-    for _ in range(max_pop + 1):
-        populations.add_row()
-    max_ind = np.max(nodes.individual)
-    if max_ind != msprime.NULL_INDIVIDUAL:
-        raise ValueError("Individuals not supported in this deprecated function")
+    if len(nodes) > 0:
+        for _ in range(max_pop + 1):
+            populations.add_row()
+        max_ind = np.max(nodes.individual)
+        if max_ind != msprime.NULL_INDIVIDUAL:
+            raise ValueError("Individuals not supported in this deprecated function")
     try:
         ll_tables = _msprime.TableCollection(
             individuals=_msprime.IndividualTable(),

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -2392,8 +2392,11 @@ class TreeSequence(object):
             output.write(record)
 
     def simplify(
-            self, samples=None, filter_zero_mutation_sites=None, map_nodes=False,
-            reduce_to_site_topology=False, filter_sites=True):
+            self, samples=None,
+            filter_zero_mutation_sites=None,  # Deprecated alias for filter_sites
+            map_nodes=False,
+            reduce_to_site_topology=False,
+            filter_populations=True, filter_individuals=True, filter_sites=True):
         """
         Returns a simplified tree sequence that retains only the history of
         the nodes given in the list ``samples``. If ``map_nodes`` is true,
@@ -2421,16 +2424,34 @@ class TreeSequence(object):
         (up to node ID remapping) to the topology of the corresponding tree
         in the input tree sequence.
 
+        If ``filter_populations``, ``filter_individuals`` or ``filter_sites`` is
+        True, any of the corresponding objects that are not referenced elsewhere
+        are filtered out. As this is the default behaviour, it is important to
+        realise IDs for these objects may change through simplification. By setting
+        these parameters to False, however, the corresponding tables can be preserved
+        without changes.
+
         :param list samples: The list of nodes for which to retain information. This
             may be a numpy array (or array-like) object (dtype=np.int32).
-        :param bool filter_zero_mutation_sites: If True, remove any sites that have
-            no mutations in the simplified tree sequence. Defaults to True.
+        :param bool filter_zero_mutation_sites: Deprecated alias for ``filter_sites``.
         :param bool map_nodes: If True, return a tuple containing the resulting
             tree sequence and a numpy array mapping node IDs in the current tree
             sequence to their corresponding node IDs in the returned tree sequence.
             If False (the default), return only the tree sequence object itself.
         :param bool reduce_to_site_topology: Whether to reduce the topology down
-            to the trees that are present at sites. (default: False).
+            to the trees that are present at sites. (Default: False)
+        :param bool filter_populations: If True, remove any populations that are
+            not referenced by nodes after simplification; new population IDs are
+            allocated sequentially from zero. If False, the population table will
+            not be altered in any way. (Default: True)
+        :param bool filter_individuals: If True, remove any individuals that are
+            not referenced by nodes after simplification; new individual IDs are
+            allocated sequentially from zero. If False, the individual table will
+            not be altered in any way. (Default: True)
+        :param bool filter_sites: If True, remove any sites that are
+            not referenced by mutations after simplification; new site IDs are
+            allocated sequentially from zero. If False, the site table will not
+            be altered in any way. (Default: True)
         :return: The simplified tree sequence, or (if ``map_nodes`` is True)
             a tuple consisting of the simplified tree sequence and a numpy array
             mapping source node IDs to their corresponding IDs in the new tree
@@ -2445,6 +2466,8 @@ class TreeSequence(object):
             samples=samples,
             filter_zero_mutation_sites=filter_zero_mutation_sites,
             reduce_to_site_topology=reduce_to_site_topology,
+            filter_populations=filter_populations,
+            filter_individuals=filter_individuals,
             filter_sites=filter_sites)
         # TODO add simplify arguments here??
         tables.provenances.add_row(record=json.dumps(

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -2392,8 +2392,8 @@ class TreeSequence(object):
             output.write(record)
 
     def simplify(
-            self, samples=None, filter_zero_mutation_sites=True, map_nodes=False,
-            reduce_to_site_topology=False):
+            self, samples=None, filter_zero_mutation_sites=None, map_nodes=False,
+            reduce_to_site_topology=False, filter_sites=True):
         """
         Returns a simplified tree sequence that retains only the history of
         the nodes given in the list ``samples``. If ``map_nodes`` is true,
@@ -2444,7 +2444,8 @@ class TreeSequence(object):
         node_map = tables.simplify(
             samples=samples,
             filter_zero_mutation_sites=filter_zero_mutation_sites,
-            reduce_to_site_topology=reduce_to_site_topology)
+            reduce_to_site_topology=reduce_to_site_topology,
+            filter_sites=filter_sites)
         # TODO add simplify arguments here??
         tables.provenances.add_row(record=json.dumps(
             provenance.get_provenance_dict("simplify", [])))

--- a/tests/simplify.py
+++ b/tests/simplify.py
@@ -98,7 +98,7 @@ class Simplifier(object):
     """
     def __init__(
             self, ts, sample, reduce_to_site_topology=False, filter_sites=True,
-            filter_populations=False, filter_individuals=False):
+            filter_populations=True, filter_individuals=True):
         self.ts = ts
         self.n = len(sample)
         self.reduce_to_site_topology = reduce_to_site_topology

--- a/tests/simplify.py
+++ b/tests/simplify.py
@@ -97,13 +97,13 @@ class Simplifier(object):
     of the leaves.
     """
     def __init__(
-            self, ts, sample, filter_zero_mutation_sites=True,
+            self, ts, sample, filter_sites=True,
             reduce_to_site_topology=False):
         self.ts = ts
         self.n = len(sample)
         self.reduce_to_site_topology = reduce_to_site_topology
         self.sequence_length = ts.sequence_length
-        self.filter_zero_mutation_sites = filter_zero_mutation_sites
+        self.filter_sites = filter_sites
         self.num_mutations = ts.num_mutations
         self.input_sites = list(ts.sites())
         self.A_head = [None for _ in range(ts.num_nodes)]
@@ -327,7 +327,7 @@ class Simplifier(object):
                     num_output_mutations += 1
                     num_output_site_mutations += 1
             output_site = True
-            if self.filter_zero_mutation_sites and num_output_site_mutations == 0:
+            if self.filter_sites and num_output_site_mutations == 0:
                 output_site = False
 
             if output_site:

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1404,24 +1404,17 @@ class TestTreeSequence(HighLevelTestCase):
     def test_simplify(self):
         num_mutations = 0
         for ts in get_example_tree_sequences():
-            if ts.num_individuals > 0:
-                # We don't support individuals in simplify for the moment,
-                # so we raise an error. See
-                # https://github.com/tskit-dev/msprime/issues/522
-                self.assertRaises(
-                    _msprime.LibraryError, self.verify_simplify_provenance, ts)
-            else:
-                self.verify_simplify_provenance(ts)
-                n = ts.get_sample_size()
-                num_mutations += ts.get_num_mutations()
-                sample_sizes = {0, 1}
-                if n > 2:
-                    sample_sizes |= set([2, max(2, n // 2), n - 1])
-                for k in sample_sizes:
-                    subset = random.sample(list(ts.samples()), k)
-                    self.verify_simplify_topology(ts, subset)
-                    self.verify_simplify_equality(ts, subset)
-                    self.verify_simplify_variants(ts, subset)
+            self.verify_simplify_provenance(ts)
+            n = ts.get_sample_size()
+            num_mutations += ts.get_num_mutations()
+            sample_sizes = {0, 1}
+            if n > 2:
+                sample_sizes |= set([2, max(2, n // 2), n - 1])
+            for k in sample_sizes:
+                subset = random.sample(list(ts.samples()), k)
+                self.verify_simplify_topology(ts, subset)
+                self.verify_simplify_equality(ts, subset)
+                self.verify_simplify_variants(ts, subset)
         self.assertGreater(num_mutations, 0)
 
     def test_simplify_bugs(self):

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -1440,6 +1440,19 @@ class TestTreeSequence(HighLevelTestCase):
             j += 1
         self.assertGreater(j, 1)
 
+    def test_simplify_migrations_fails(self):
+        ts = msprime.simulate(
+            population_configurations=[
+                msprime.PopulationConfiguration(10),
+                msprime.PopulationConfiguration(10)],
+            migration_matrix=[[0, 1], [1, 0]],
+            random_seed=2,
+            record_migrations=True)
+        self.assertGreater(ts.num_migrations, 0)
+        # We don't support simplify with migrations, so should fail.
+        with self.assertRaises(_msprime.LibraryError):
+            ts.simplify()
+
     def test_deprecated_apis(self):
         ts = msprime.simulate(10, random_seed=1)
         self.assertEqual(ts.get_ll_tree_sequence(), ts.ll_tree_sequence)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -50,6 +50,7 @@ import msprime
 import _msprime
 import tests
 import tests.tsutil as tsutil
+import tests.simplify as simplify
 
 
 def insert_uniform_mutations(tables, num_mutations, nodes):
@@ -297,7 +298,7 @@ def simplify_tree_sequence(ts, samples, filter_sites=True):
     """
     Simple tree-by-tree algorithm to get a simplify of a tree sequence.
     """
-    s = tests.Simplifier(
+    s = simplify.Simplifier(
         ts, samples, filter_sites=filter_sites)
     return s.simplify()
 
@@ -1378,7 +1379,7 @@ class TestTreeSequence(HighLevelTestCase):
             self.assertEqual(s2.num_samples,  len(sample))
             self.assertTrue(all(node_map1 == node_map2))
             self.assertEqual(t1.individuals, t2.individuals)
-            # self.assertEqual(t1.nodes, t2.nodes)
+            self.assertEqual(t1.nodes, t2.nodes)
             self.assertEqual(t1.edges, t2.edges)
             self.assertEqual(t1.migrations, t2.migrations)
             self.assertEqual(t1.sites, t2.sites)

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -293,12 +293,12 @@ def get_pairwise_diversity(tree_sequence, samples=None):
     return pi
 
 
-def simplify_tree_sequence(ts, samples, filter_zero_mutation_sites=True):
+def simplify_tree_sequence(ts, samples, filter_sites=True):
     """
     Simple tree-by-tree algorithm to get a simplify of a tree sequence.
     """
     s = tests.Simplifier(
-        ts, samples, filter_zero_mutation_sites=filter_zero_mutation_sites)
+        ts, samples, filter_sites=filter_sites)
     return s.simplify()
 
 
@@ -1368,13 +1368,11 @@ class TestTreeSequence(HighLevelTestCase):
                         old_tree.get_population(mrca1), new_tree.get_population(mrca2))
 
     def verify_simplify_equality(self, ts, sample):
-        for filter_zero_mutation_sites in [False, True]:
+        for filter_sites in [False, True]:
             s1, node_map1 = ts.simplify(
-                sample, map_nodes=True,
-                filter_zero_mutation_sites=filter_zero_mutation_sites)
+                sample, map_nodes=True, filter_sites=filter_sites)
             t1 = s1.dump_tables()
-            s2, node_map2 = simplify_tree_sequence(
-                ts, sample, filter_zero_mutation_sites=filter_zero_mutation_sites)
+            s2, node_map2 = simplify_tree_sequence(ts, sample, filter_sites=filter_sites)
             t2 = s2.dump_tables()
             self.assertEqual(s1.num_samples,  len(sample))
             self.assertEqual(s2.num_samples,  len(sample))

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -3404,9 +3404,9 @@ class TestLdCalculator(LowLevelTestCase):
         ldc = _msprime.LdCalculator(ts)
         for bad_index in bad_indexes:
             self.assertRaises(
-                _msprime.LibraryError, ldc.get_r2_array, self.get_buffer(1), bad_index)
-            self.assertRaises(_msprime.LibraryError, ldc.get_r2, bad_index, 0)
-            self.assertRaises(_msprime.LibraryError, ldc.get_r2, 0, bad_index)
+                IndexError, ldc.get_r2_array, self.get_buffer(1), bad_index)
+            self.assertRaises(IndexError, ldc.get_r2, bad_index, 0)
+            self.assertRaises(IndexError, ldc.get_r2, 0, bad_index)
 
     def test_get_r2_interface(self):
         ts = self.get_tree_sequence()

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1648,9 +1648,9 @@ class TestDeduplicateSites(unittest.TestCase):
     Tests for the TableCollection.deduplicate_sites method.
     """
     def test_empty(self):
-        tables = msprime.TableCollection()
+        tables = msprime.TableCollection(1)
         tables.deduplicate_sites()
-        self.assertEqual(tables, msprime.TableCollection())
+        self.assertEqual(tables, msprime.TableCollection(1))
 
     def test_unsorted(self):
         tables = msprime.simulate(10, mutation_rate=1, random_seed=1).dump_tables()

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1117,22 +1117,13 @@ class TestSortTables(unittest.TestCase):
             sites=tables2.sites, mutations=tables2.mutations)
 
     def test_empty_tables(self):
-        nodes = msprime.NodeTable()
-        edges = msprime.EdgeTable()
-        msprime.sort_tables(nodes, edges)
-        self.assertEqual(nodes.num_rows, 0)
-        self.assertEqual(edges.num_rows, 0)
-        sites = msprime.SiteTable()
-        mutations = msprime.MutationTable()
-        msprime.sort_tables(nodes, edges, sites=sites, mutations=mutations)
-        self.assertEqual(sites.num_rows, 0)
-        self.assertEqual(mutations.num_rows, 0)
-        migrations = msprime.MigrationTable()
-        msprime.sort_tables(
-            nodes, edges, sites=sites, mutations=mutations, migrations=migrations)
-        self.assertEqual(migrations.num_rows, 0)
-        msprime.sort_tables(nodes, edges, migrations=migrations)
-        self.assertEqual(migrations.num_rows, 0)
+        tables = msprime.TableCollection(1)
+        tables.sort()
+        self.assertEqual(tables.nodes.num_rows, 0)
+        self.assertEqual(tables.edges.num_rows, 0)
+        self.assertEqual(tables.sites.num_rows, 0)
+        self.assertEqual(tables.mutations.num_rows, 0)
+        self.assertEqual(tables.migrations.num_rows, 0)
 
     def test_sort_interface(self):
         self.assertRaises(TypeError, msprime.sort_tables)
@@ -1141,8 +1132,6 @@ class TestSortTables(unittest.TestCase):
             TypeError, msprime.sort_tables, edges=msprime.EdgeTable())
         self.assertRaises(
             TypeError, msprime.sort_tables, nodes=msprime.NodeTable(), edges=None)
-        self.assertRaises(
-            TypeError, msprime.sort_tables, nodes=None, edges=msprime.EdgeTable())
         nodes = msprime.NodeTable()
         edges = msprime.EdgeTable()
         # Verify that nodes and edges are OK
@@ -1167,6 +1156,11 @@ class TestSortTables(unittest.TestCase):
                 TypeError, msprime.sort_tables,
                 nodes=nodes, edges=edges, sites=sites, mutations=mutations,
                 migrations=bad_type)
+        # Cannot have a node table with individuals in it.
+        nodes = msprime.NodeTable()
+        nodes.add_row(flags=0, individual=1)
+        self.assertRaises(
+            ValueError, msprime.sort_tables, nodes=nodes, edges=msprime.EdgeTable())
 
 
 class TestSortMutations(unittest.TestCase):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1694,7 +1694,7 @@ class TestDeduplicateSites(unittest.TestCase):
         self.assertEqual(t1, t2)
 
     def test_order_maintained(self):
-        t1 = msprime.TableCollection()
+        t1 = msprime.TableCollection(1)
         t1.sites.add_row(position=0, ancestral_state="first")
         t1.sites.add_row(position=0, ancestral_state="second")
         t1.deduplicate_sites()

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1453,22 +1453,19 @@ class TestSimplifyTables(unittest.TestCase):
         self.assertRaises(
             TypeError, msprime.simplify_tables, samples=[0, 1],
             nodes=msprime.NodeTable(), edges=None)
-        self.assertRaises(
-            TypeError, msprime.simplify_tables, samples=[0, 1],
-            nodes=None, edges=msprime.EdgeTable())
         tables = msprime.simulate(2, random_seed=1).dump_tables()
         samples = [0, 1]
         # Verify that samples, nodes and edges are OK
         msprime.simplify_tables(samples=samples, nodes=tables.nodes, edges=tables.edges)
-        for bad_type in [None, "", 1]:
+        for bad_type in [{}, "", 1]:
             self.assertRaises(
-                TypeError, msprime.simplify_tables, samples=samples, nodes=None,
+                TypeError, msprime.simplify_tables, samples=samples, nodes=tables.nodes,
                 edges=msprime.EdgeTable(), sites=bad_type)
             self.assertRaises(
-                TypeError, msprime.simplify_tables, samples=samples, nodes=None,
+                TypeError, msprime.simplify_tables, samples=samples, nodes=tables.nodes,
                 edges=msprime.EdgeTable(), mutations=bad_type)
             self.assertRaises(
-                TypeError, msprime.simplify_tables, samples=samples, nodes=None,
+                TypeError, msprime.simplify_tables, samples=samples, nodes=tables.nodes,
                 edges=msprime.EdgeTable(), migrations=bad_type)
         sites = msprime.SiteTable()
         mutations = msprime.MutationTable()
@@ -1481,6 +1478,12 @@ class TestSimplifyTables(unittest.TestCase):
                 TypeError, msprime.simplify_tables,
                 nodes=tables.nodes, edges=tables.edges, sites=sites,
                 mutations=mutations, migrations=bad_type)
+        # Cannot have a node table with individuals in it.
+        nodes = msprime.NodeTable()
+        nodes.add_row(flags=0, individual=1)
+        self.assertRaises(
+            ValueError, msprime.simplify_tables, samples=[0], nodes=nodes,
+            edges=msprime.EdgeTable())
 
     def test_node_table_empty_name_bug(self):
         # Issue #236. Calling simplify on copied tables unexpectedly fails.

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -2586,7 +2586,7 @@ class TestSimplify(unittest.TestCase):
 
     def do_simplify(
             self, ts, samples=None, compare_lib=True, filter_sites=True,
-            filter_populations=False, filter_individuals=False):  # False for now
+            filter_populations=True, filter_individuals=True):
         """
         Runs the Python test implementation of simplify.
         """
@@ -2597,25 +2597,39 @@ class TestSimplify(unittest.TestCase):
             filter_populations=filter_populations, filter_individuals=filter_individuals)
         new_ts, node_map = s.simplify()
         if compare_lib:
-            lib_tables = ts.dump_tables()
-            lib_node_map = lib_tables.simplify(
-                samples, filter_sites=filter_sites,
+            sts, lib_node_map1 = ts.simplify(
+                samples,
+                filter_sites=filter_sites,
+                filter_individuals=filter_individuals,
+                filter_populations=filter_populations,
+                map_nodes=True)
+            lib_tables1 = sts.dump_tables()
+
+            lib_tables2 = ts.dump_tables()
+            lib_node_map2 = lib_tables2.simplify(
+                samples,
+                filter_sites=filter_sites,
                 filter_individuals=filter_individuals,
                 filter_populations=filter_populations)
-            py_tables = new_ts.dump_tables()
-            # print("lib = ")
-            # print(lib_tables.nodes)
-            # print(lib_tables.edges)
-            # print("py = ")
-            # print(py_tables.nodes)
-            # print(py_tables.edges)
 
-            self.assertEqual(lib_tables.nodes, py_tables.nodes)
-            self.assertEqual(lib_tables.edges, py_tables.edges)
-            self.assertEqual(lib_tables.migrations, py_tables.migrations)
-            self.assertEqual(lib_tables.sites, py_tables.sites)
-            self.assertEqual(lib_tables.mutations, py_tables.mutations)
-            self.assertTrue(all(node_map == lib_node_map))
+            py_tables = new_ts.dump_tables()
+            for lib_tables, lib_node_map in [
+                    (lib_tables1, lib_node_map1), (lib_tables2, lib_node_map2)]:
+                # print("lib = ")
+                # print(lib_tables.nodes)
+                # print(lib_tables.edges)
+                # print("py = ")
+                # print(py_tables.nodes)
+                # print(py_tables.edges)
+
+                self.assertEqual(lib_tables.nodes, py_tables.nodes)
+                self.assertEqual(lib_tables.edges, py_tables.edges)
+                self.assertEqual(lib_tables.migrations, py_tables.migrations)
+                self.assertEqual(lib_tables.sites, py_tables.sites)
+                self.assertEqual(lib_tables.mutations, py_tables.mutations)
+                self.assertEqual(lib_tables.individuals, py_tables.individuals)
+                self.assertEqual(lib_tables.populations, py_tables.populations)
+                self.assertTrue(all(node_map == lib_node_map))
         return new_ts, node_map
 
     def verify_single_childified(self, ts):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -2598,7 +2598,10 @@ class TestSimplify(unittest.TestCase):
         new_ts, node_map = s.simplify()
         if compare_lib:
             lib_tables = ts.dump_tables()
-            lib_node_map = lib_tables.simplify(samples, filter_sites=filter_sites)
+            lib_node_map = lib_tables.simplify(
+                samples, filter_sites=filter_sites,
+                filter_individuals=filter_individuals,
+                filter_populations=filter_populations)
             py_tables = new_ts.dump_tables()
             # print("lib = ")
             # print(lib_tables.nodes)
@@ -3057,14 +3060,9 @@ class TestSimplify(unittest.TestCase):
         tables = ts.dump_tables()
         tables.populations.add_row(metadata=b"unreferenced")
         self.assertEqual(len(tables.populations), 2)
-        print("\n\nFIXME: comparelib false\n")
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_populations=True,
-            compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_populations=True)
         self.assertEqual(tss.num_populations, 1)
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_populations=False,
-            compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_populations=False)
         self.assertEqual(tss.num_populations, 2)
 
     def test_interleaved_populations_filter(self):
@@ -3083,14 +3081,13 @@ class TestSimplify(unittest.TestCase):
             tables.populations.add_row(metadata=bytes([j]))
         ts = tables.tree_sequence()
         id_map = np.array([-1, 0, -1, -1], dtype=np.int32)
-        print("\n\nFIXME: comparelib false\n")
-        tss, _ = self.do_simplify(ts, filter_populations=True, compare_lib=False)
+        tss, _ = self.do_simplify(ts, filter_populations=True)
         self.assertEqual(tss.num_populations, 1)
         population = tss.population(0)
         self.assertEqual(population.metadata, bytes([1]))
         self.assertTrue(np.array_equal(
             id_map[ts.tables.nodes.population], tss.tables.nodes.population))
-        tss, _ = self.do_simplify(ts, filter_populations=False, compare_lib=False)
+        tss, _ = self.do_simplify(ts, filter_populations=False)
         self.assertEqual(tss.num_populations, 4)
 
     def test_removed_node_population_filter(self):
@@ -3103,9 +3100,7 @@ class TestSimplify(unittest.TestCase):
         # will disappear.
         tables.nodes.add_row(flags=0, population=1)
         tables.nodes.add_row(flags=1, population=2)
-        print("\n\nFIXME: comparelib false\n")
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_populations=True, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_populations=True)
         self.assertEqual(tss.num_nodes, 2)
         self.assertEqual(tss.num_populations, 2)
         self.assertEqual(tss.population(0).metadata, bytes(0))
@@ -3114,7 +3109,7 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(tss.node(1).population, 1)
 
         tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_populations=False, compare_lib=False)
+            tables.tree_sequence(), filter_populations=False)
         self.assertEqual(tss.tables.populations, tables.populations)
 
     def test_simple_individual_filter(self):
@@ -3123,15 +3118,12 @@ class TestSimplify(unittest.TestCase):
         tables.individuals.add_row(flags=1)
         tables.nodes.add_row(flags=1, individual=0)
         tables.nodes.add_row(flags=1, individual=0)
-        print("\n\nFIXME: comparelib false\n")
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_individuals=True, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=True)
         self.assertEqual(tss.num_nodes, 2)
         self.assertEqual(tss.num_individuals, 1)
         self.assertEqual(tss.individual(0).flags, 0)
 
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_individuals=False, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=False)
         self.assertEqual(tss.tables.individuals, tables.individuals)
 
     def test_interleaved_individual_filter(self):
@@ -3142,15 +3134,12 @@ class TestSimplify(unittest.TestCase):
         tables.nodes.add_row(flags=1, individual=1)
         tables.nodes.add_row(flags=1, individual=-1)
         tables.nodes.add_row(flags=1, individual=1)
-        print("\n\nFIXME: comparelib false\n")
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_individuals=True, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=True)
         self.assertEqual(tss.num_nodes, 3)
         self.assertEqual(tss.num_individuals, 1)
         self.assertEqual(tss.individual(0).flags, 1)
 
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_individuals=False, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=False)
         self.assertEqual(tss.tables.individuals, tables.individuals)
 
     def test_removed_node_individual_filter(self):
@@ -3163,9 +3152,7 @@ class TestSimplify(unittest.TestCase):
         # will disappear.
         tables.nodes.add_row(flags=0, individual=1)
         tables.nodes.add_row(flags=1, individual=2)
-        print("\n\nFIXME: comparelib false\n")
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_individuals=True, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=True)
         self.assertEqual(tss.num_nodes, 2)
         self.assertEqual(tss.num_individuals, 2)
         self.assertEqual(tss.individual(0).flags, 0)
@@ -3173,8 +3160,7 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(tss.node(0).individual, 0)
         self.assertEqual(tss.node(1).individual, 1)
 
-        tss, _ = self.do_simplify(
-            tables.tree_sequence(), filter_individuals=False, compare_lib=False)
+        tss, _ = self.do_simplify(tables.tree_sequence(), filter_individuals=False)
         self.assertEqual(tss.tables.individuals, tables.individuals)
 
     def verify_simplify_haplotypes(self, ts, samples):


### PR DESCRIPTION
This PR is to add support for individuals and populations to simplify.

The first step here is to remove the restriction that nodes for individuals must be contiguous. I realised that this wouldn't be possible to guarantee with simplify, unless we change the property that the nodes in the output tree sequence are 0 to n. I think I'm basically the only person who thought this restriction was worthwhile anyway, so I think it's fine to ditch it.

The second step is to update simplify so that it can filter unreferenced individuals and populations from the output tables. I'm thinking of changing the API so that it looks like:

```python
def simplify(..., filter_sites=True, filter_individuals=True, filter_populations=True):

```

Each of these meaning, if there's no objects referring to these entities, we remove them from the tables. The ``filter_sites`` parameter would replace the current ``filter_zero_mutation_sites``. I thought about making them ``filter_unreferenced_sites``, ``filter_unreferenced_individuals``, etc, but I think ``filter_sites`` is unambiguous enough here in this context.

What do you think @petrelharp?