### PR TITLE
Detect when simulations produce bad node times.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@
 
 **Bug fixes**:
 
+- Throw a more intelligle error during simulation if a topology is produced
+  where the time of a parent is equal to the time of the child. (#570, #87).
+
 **Deprecated**:
 
 - The ``filter_zero_mutation_sites`` parameter for simplify has been deprecated

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -992,8 +992,10 @@ msp_store_edge(msp_t *self, double left, double right, node_id_t parent, node_id
 {
     int ret = 0;
     edge_t *edge;
+    const double *node_time = self->tables.nodes->time;
 
     assert(parent > child);
+    assert(parent < (node_id_t) self->tables.nodes->num_rows);
     if (self->num_buffered_edges == self->max_buffered_edges - 1) {
         /* Grow the array */
         self->max_buffered_edges *= 2;
@@ -1003,6 +1005,10 @@ msp_store_edge(msp_t *self, double left, double right, node_id_t parent, node_id
             goto out;
         }
         self->buffered_edges = edge;
+    }
+    if (node_time[child] >= node_time[parent]) {
+        ret = MSP_ERR_TIME_TRAVEL;
+        goto out;
     }
     edge = self->buffered_edges + self->num_buffered_edges;
     edge->left = left;

--- a/lib/util.c
+++ b/lib/util.c
@@ -288,6 +288,11 @@ msp_strerror_internal(int err)
                 "for the specified tree sequence. It is either too coarse (num_loci "
                 "is too small) or contains zero recombination rates. Please either "
                 "increase the number of loci or recombination rate";
+        case MSP_ERR_TIME_TRAVEL:
+            ret = "The simulation model supplied resulted in a parent node having "
+                "a time value <= to its child. This can occur either as a result "
+                "of multiple bottlenecks happening at the same time or because of "
+                "numerical imprecision with very small population sizes.";
             break;
 
         case MSP_ERR_IO:

--- a/lib/util.h
+++ b/lib/util.h
@@ -185,6 +185,7 @@
 #define MSP_ERR_BAD_START_TIME                                      -80
 #define MSP_ERR_BAD_DEMOGRAPHIC_EVENT_TIME                          -81
 #define MSP_ERR_RECOMB_MAP_TOO_COARSE                               -82
+#define MSP_ERR_TIME_TRAVEL                                         -83
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14


### PR DESCRIPTION
Closes #87
Closes #570 

cc @petrelharp. The message now is:
```
Traceback (most recent call last):
  File "/home/jk/work/github/msprime/tests/test_demography.py", line 44, in test_multiple_bottlenecks
    random_seed=1)
  File "/home/jk/work/github/msprime/msprime/simulations.py", line 304, in simulate
    return next(_replicate_generator(sim, mutation_generator, 1, provenance_dict))
  File "/home/jk/work/github/msprime/msprime/simulations.py", line 89, in _replicate_generator
    sim.run()
  File "/home/jk/work/github/msprime/msprime/simulations.py", line 561, in run
    self.ll_sim.run()
_msprime.LibraryError: The simulation model supplied resulted in a parent node having a time value >= to its child. This can occur either as a result of multiple bottlenecks happening at the same time or because of numerical imprecision with very small population sizes.
```

Is this more helpful? It's not great if you want to catch this stuff programmatically though, as it's just raising the generic ``_msprime.LibraryError``. We could create another exception class here if you want to (e.g.) catch this error and realise that your population sizes have gotten too small in your MCMC or whatever.