### PR TITLE
Initial version of provenance schema.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include lib/*.h
 include lib/kastore/c/kastore.h
+include msprime/provenance.schema.json
 include README.txt
 include ez_setup.py
 include LICENSE

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -635,3 +635,21 @@ Table functions
 .. autofunction:: msprime.pack_bytes
 
 .. autofunction:: msprime.unpack_bytes
+
+
+.. _sec_provenance_api:
+
+**************
+Provenance API
+**************
+
+We provide some preliminary support for validating JSON documents against the
+:ref:`provenance schema <sec_provenance>`. Programmatic access to provenance
+information is planned for future versions.
+
+.. autofunction:: msprime.validate_provenance
+
+.. autoexception:: msprime.ProvenanceValidationError
+
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Contents:
    api
    cli
    interchange
+   provenance
    development
    CITATION
 

--- a/docs/provenance.rst
+++ b/docs/provenance.rst
@@ -1,0 +1,230 @@
+.. _sec_provenance:
+
+==========
+Provenance
+==========
+
+Every tree sequence has provenance information associated with it. The purpose of this
+information is to improve `reproducibility <https://en.wikipedia.org/wiki/Reproducibility>`_:
+given the provenance associated with a given tree sequence, it should be possible to
+reproduce it. Provenance is split into three sections: the primary **software** used to
+produce a tree sequence; the **parameters** provided to this software; and the computational
+**environment** where the software was run.
+
+This documentation serves two distinct purposes:
+
+1. For developers using ``tskit`` in their own applications, it provides normative documentation
+   for how provenance information should be stored.
+2. For end-users of ``tskit``, it provides documentation to allows them to inspect and interpret
+   the provenance information stored in ``.trees`` files.
+
+Provenance information is encoded using `JSON <https://www.json.org/>`_.
+To standardise the provenance information produced by different software and improve
+interoperability we define a formal specification using `JSON Schema <http://json-schema.org/>`_.
+The full schema is provided :ref:`below <sec_provenance_schema>`, which may be used to
+automatically validate input. In the following we describe the intention of the various
+sections in more detail.
+
+This document defines specification version 1.0.0. Specification version numbers follow
+`SemVer <https://semver.org/>`_ semantics.
+
+.. _sec_provenance_example:
+
+*******
+Example
+*******
+
+To make things more concrete, let's consider an example:
+
+.. code-block:: json
+
+    {
+      "schema_version": "1.0.0",
+      "software": {
+        "name": "msprime",
+        "version": "0.6.1.dev123+ga252341.d20180820"
+      },
+      "parameters": {
+        "sample_size": 5,
+        "random_seed": 12345,
+        "command": "simulate"
+      },
+      "environment": {
+        "libraries": {
+          "gsl": {
+            "version": "2.1"
+          },
+          "kastore": {
+            "version": "0.1.0"
+          }
+        },
+        "python": {
+          "version": "3.5.2",
+          "implementation": "CPython"
+        },
+        "os": {
+          "system": "Linux",
+          "node": "powderfinger",
+          "release": "4.15.0-29-generic",
+          "version": "#31~16.04.1-Ubuntu SMP Wed Jul 18 08:54:04 UTC 2018",
+          "machine": "x86_64"
+        }
+      }
+    }
+
+This information records the provenance for a very simple msprime simulation. The record is a JSON
+object with three mandatory fields ("software", "parameters" and "environment")
+which we discuss separately in the following sections.
+
+.. _sec_provenance_software:
+
+********
+Software
+********
+
+Every tree sequence is produced by some piece of software. For example, this may be a
+coalescent simulation produced by ``msprime``, a forwards-time simulation from ``SLiM``
+or tree sequence inferred from data by ``tsinfer``. The software provenance is
+intended to capture the details about this primary software.
+
+================    ==============      ===========
+Field               Type                Description
+================    ==============      ===========
+name                string              The name of the software.
+version             string              The software version.
+================    ==============      ===========
+
+
+Note that libraries that the primary software links against are considered part of the
+:ref:`sec_provenance_environment` and should be recorded there.
+
+.. _sec_provenance_parameters:
+
+**********
+Parameters
+**********
+
+The parameters section of a provenance document records the input that was used to
+produce a particular tree sequence. There are no requirements on what may be stored
+within it, but we make some recommendations here on how to encode such information.
+
+As a general principle, sufficient information should be recorded in the parameters
+section to allow the output tree sequence to be reproduced exactly. There will be instances,
+however, where this is not possible due to missing files, issues with numerical precision
+and so on.
+
++++++++++++++++
+API invocations
++++++++++++++++
+
+Consider an API call like the following simple msprime simulation:
+
+.. code-block:: python
+
+    ts = msprime.simulate(sample_size=10, recombination_rate=2)
+
+We recommend encoding the parameters provenance as follows (other fields omitted
+for clarity):
+
+.. code-block:: json
+
+    {
+      "parameters": {
+        "command": "simulate",
+        "sample_size": 10,
+        "recombination_rate": 2,
+        "random_seed": 123456789,
+      }
+    }
+
+Specifically, we encode the name of the function using the ``command`` key and
+the function parameters in the obvious way. Note that we include the ``random_seed``
+here even though it was automatically generated.
+
+
++++++++++++++++
+CLI invocations
++++++++++++++++
+
+Consider the following invocation of a hypothetical command line program:
+
+.. code-block:: bash
+
+    $ supersim --sample-size=10 --do-some-stuff -O out.trees
+
+We recommend encoding the parameters provenance as follows (other fields omitted
+for clarity):
+
+.. code-block:: json
+
+    {
+      "parameters": {
+        "command": "supersim",
+        "args": ["--sample-size=10", "--do-some-stuff", "-O", "out.trees"],
+        "random_seed": 56789
+      }
+    }
+
+Here we encode the name of the program using the ``command`` key
+and its command line arguments as a list of strings in the ``args`` key. We
+also include the automatically generated random seed in the parameters list.
+
+If parameters that affect the output tree sequence are derived from environment
+variables these should also be recorded.
+
+.. _sec_provenance_environment:
+
+***********
+Environment
+***********
+
+The environment section captures details about the computational environment in
+which the software was executed. Two optional fields are defined: ``os``
+and ``libraries``. We recommend including any additional relevant platform
+information here; for example, if using Python store the interpreter information
+as shown in the example above.
+
+++++++++++++++++
+Operating system
+++++++++++++++++
+
+The ``os`` section records details about the operating system on which the
+software was executed. This section is optional and has no required internal
+structure. We recommend the following structure based on the output of the
+POSIX `uname <http://pubs.opengroup.org/onlinepubs/009695399/functions/uname.html>`_
+function:
+
+.. code-block:: json
+
+    {
+      "environment": {
+        "os": {
+          "system": "Linux",
+          "node": "powderfinger",
+          "release": "4.15.0-29-generic",
+          "version": "#31~16.04.1-Ubuntu SMP Wed Jul 18 08:54:04 UTC 2018",
+          "machine": "x86_64"
+        }
+    }
+
+
++++++++++
+Libraries
++++++++++
+
+The ``libraries`` section captures information about important libraries that the
+primary software links against. There is no required structure.
+
+
+.. _sec_provenance_schema:
+
+***********
+Full schema
+***********
+
+This schema is formally defined using `JSON Schema <http://json-schema.org/>`_ and
+given in full here. Developers writing provenance information to ``.trees`` files
+should validate the output JSON against this schema.
+
+.. literalinclude:: ../msprime/provenance.schema.json
+    :language: json

--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -27,6 +27,7 @@ from _msprime import FORWARD  # NOQA
 from _msprime import REVERSE  # NOQA
 
 from msprime.provenance import __version__  # NOQA
+from msprime.provenance import validate_provenance  # NOQA
 from msprime.formats import *  # NOQA
 from msprime.trees import *  # NOQA
 from msprime.tables import *  # NOQA

--- a/msprime/exceptions.py
+++ b/msprime/exceptions.py
@@ -49,3 +49,9 @@ class VersionTooOldError(FileFormatError):
     """
     The version of the file is too old and cannot be read by the library.
     """
+
+
+class ProvenanceValidationError(MsprimeException):
+    """
+    The provenance information for the tree sequence violated the schema.
+    """

--- a/msprime/exceptions.py
+++ b/msprime/exceptions.py
@@ -53,5 +53,5 @@ class VersionTooOldError(FileFormatError):
 
 class ProvenanceValidationError(MsprimeException):
     """
-    The provenance information for the tree sequence violated the schema.
+    A JSON document did non validate against the provenance schema.
     """

--- a/msprime/formats.py
+++ b/msprime/formats.py
@@ -51,7 +51,8 @@ def _get_v2_provenance(command, attrs):
         parameters = json.loads(str(attrs["parameters"]))
     except ValueError:
         logging.warn("Failed to convert parameters provenance")
-    provenance_dict = provenance.get_provenance_dict(command, parameters)
+    parameters["command"] = command
+    provenance_dict = provenance.get_provenance_dict(parameters)
     provenance_dict["version"] = environment.get("msprime_version", "Unknown_version")
     provenance_dict["environment"] = environment
     return json.dumps(provenance_dict).encode()
@@ -63,9 +64,10 @@ def _get_upgrade_provenance(root):
     """
     # TODO add more parameters here like filename, etc.
     parameters = {
+        "command": "upgrade",
         "source_version": list(map(int, root.attrs["format_version"]))
     }
-    s = json.dumps(provenance.get_provenance_dict("upgrade", parameters))
+    s = json.dumps(provenance.get_provenance_dict(parameters))
     return s.encode()
 
 

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -127,7 +127,8 @@ def mutate(
     if rate is None:
         rate = 0
 
-    parameters = {"rate": rate, "random_seed": random_seed, "keep": keep}
+    parameters = {
+        "command": "mutate", "rate": rate, "random_seed": random_seed, "keep": keep}
     if start_time is not None:
         parameters["start_time"] = start_time
     else:
@@ -137,7 +138,7 @@ def mutate(
     else:
         end_time = sys.float_info.max
     # TODO Add a JSON representation of the model to the provenance.
-    provenance_dict = provenance.get_provenance_dict("mutate", parameters)
+    provenance_dict = provenance.get_provenance_dict(parameters)
 
     if start_time > end_time:
         raise ValueError("start_time must be <= end_time")

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -105,7 +105,14 @@ def get_provenance_dict(parameters=None):
 
 def validate_provenance(provenance):
     """
-    TODO document.
+    Validates the specified dict-like object against the tskit
+    :ref:`provenance schema <sec_provenance>`. If the input does
+    not represent a valid instance of the schema an exception is
+    raised.
+
+    :param dict provenance: The dictionary representing a JSON document
+        to be validated against the schema.
+    :raises: :class:`.ProvenanceValidationError`
     """
     base = os.path.dirname(__file__)
     schema_file = os.path.join(base, "provenance.schema.json")

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -24,8 +24,13 @@ from __future__ import print_function
 from __future__ import division
 
 import platform
+import json
+import os.path
+
+import jsonschema
 
 import _msprime
+import msprime.exceptions as exceptions
 
 __version__ = "undefined"
 try:
@@ -35,18 +40,15 @@ except ImportError:
     pass
 
 
-_gsl_version = _msprime.get_gsl_version()
+_environment = None
 
 
-def get_environment():
-    """
-    Returns a dictionary describing the environment in which msprime
-    is currently running.
-    """
+def _get_environment():
+    gsl_version = ".".join(map(str, _msprime.get_gsl_version()))
     env = {
         "libraries": {
             "gsl": {
-                "version": _gsl_version
+                "version": gsl_version
             },
             "kastore": {
                 # Hard coding this for now as there is no way to get version
@@ -54,7 +56,7 @@ def get_environment():
                 # https://github.com/tskit-dev/kastore/issues/41
                 # We could import the kastore module here and use its version,
                 # but this is not the same as the C code we have compiler against.
-                "version": (0, 1, 0)
+                "version": "0.1.0",
             }
         },
         "os": {
@@ -66,23 +68,49 @@ def get_environment():
         },
         "python": {
             "implementation": platform.python_implementation(),
-            "version": platform.python_version_tuple(),
+            "version": platform.python_version(),
         }
     }
     return env
 
 
-def get_provenance_dict(command, parameters=None):
+def get_environment():
     """
-    Returns a dictionary encoding an execution of msprime.
+    Returns a dictionary describing the environment in which msprime
+    is currently running.
+    """
+    # Everything here is fixed so we cache it
+    global _environment
+    if _environment is None:
+        _environment = _get_environment()
+    return _environment
 
-    Note: this format is incomplete and provisional.
+
+def get_provenance_dict(parameters=None):
+    """
+    Returns a dictionary encoding an execution of msprime conforming to the
+    provenance schema.
     """
     document = {
-        "software": "msprime",
-        "version": __version__,
-        "command": command,
+        "software": {
+            "name": "msprime",
+            "version": __version__,
+        },
         "parameters": parameters,
         "environment": get_environment()
     }
     return document
+
+
+def validate_provenance(provenance):
+    """
+    TODO document.
+    """
+    base = os.path.dirname(__file__)
+    schema_file = os.path.join(base, "provenance.schema.json")
+    with open(schema_file) as f:
+        schema = json.load(f)
+    try:
+        jsonschema.validate(provenance, schema)
+    except jsonschema.exceptions.ValidationError as ve:
+        raise exceptions.ProvenanceValidationError(str(ve))

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -92,6 +92,7 @@ def get_provenance_dict(parameters=None):
     provenance schema.
     """
     document = {
+        "schema_version": "1.0.0",
         "software": {
             "name": "msprime",
             "version": __version__,

--- a/msprime/provenance.schema.json
+++ b/msprime/provenance.schema.json
@@ -1,45 +1,50 @@
 {
-    "schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "FIXME",
-    "title": "tskit provenance",
-    "description": "The combination of software, parameters and environment that produced a particular tree sequence",
-    "type": "object",
-    "required": ["software", "parameters", "environment"],
-    "properties": {
-        "software": {
-            "description": "The primary software used to produce the tree sequence.",
-            "type": "object",
-            "required": ["name", "version"],
-            "properties": {
-                "name": {
-                    "description": "The name of the primary software.",
-                    "type": "string",
-                    "minLength": 1
-                },
-                "version": {
-                    "description": "The version of primary software.",
-                    "type": "string",
-                    "minLength": 1
-                }
-            }
+  "schema": "http://json-schema.org/draft-07/schema#",
+  "version": "1.0.0",
+  "title": "tskit provenance",
+  "description": "The combination of software, parameters and environment that produced a tree sequence",
+  "type": "object",
+  "required": ["schema_version", "software", "parameters", "environment"],
+  "properties": {
+    "schema_version": {
+      "description": "The version of this schema used.",
+      "type": "string",
+      "minLength": 1
+    },
+    "software": {
+      "description": "The primary software used to produce the tree sequence.",
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": {
+          "description": "The name of the primary software.",
+          "type": "string",
+          "minLength": 1
         },
-        "parameters": {
-            "description": "The parameters used to produce the tree sequence.",
-            "type": "object"
-        },
-        "environment": {
-            "description": "The computational environment within which the primary software ran.",
-            "type": "object",
-            "properties": {
-                "os": {
-                    "description": "Operating system.",
-                    "type": "object"
-                },
-                "libraries": {
-                    "description": "Details of libraries the primary software linked against.",
-                    "type": "object"
-                }
-            }
+        "version": {
+          "description": "The version of primary software.",
+          "type": "string",
+          "minLength": 1
         }
+      }
+    },
+    "parameters": {
+      "description": "The parameters used to produce the tree sequence.",
+      "type": "object"
+    },
+    "environment": {
+      "description": "The computational environment within which the primary software ran.",
+      "type": "object",
+      "properties": {
+        "os": {
+          "description": "Operating system.",
+          "type": "object"
+        },
+        "libraries": {
+          "description": "Details of libraries the primary software linked against.",
+          "type": "object"
+        }
+      }
     }
+  }
 }

--- a/msprime/provenance.schema.json
+++ b/msprime/provenance.schema.json
@@ -1,0 +1,45 @@
+{
+    "schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "FIXME",
+    "title": "tskit provenance",
+    "description": "The combination of software, parameters and environment that produced a particular tree sequence",
+    "type": "object",
+    "required": ["software", "parameters", "environment"],
+    "properties": {
+        "software": {
+            "description": "The primary software used to produce the tree sequence.",
+            "type": "object",
+            "required": ["name", "version"],
+            "properties": {
+                "name": {
+                    "description": "The name of the primary software.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "version": {
+                    "description": "The version of primary software.",
+                    "type": "string",
+                    "minLength": 1
+                }
+            }
+        },
+        "parameters": {
+            "description": "The parameters used to produce the tree sequence.",
+            "type": "object"
+        },
+        "environment": {
+            "description": "The computational environment within which the primary software ran.",
+            "type": "object",
+            "properties": {
+                "os": {
+                    "description": "Operating system.",
+                    "type": "object"
+                },
+                "libraries": {
+                    "description": "Details of libraries the primary software linked against.",
+                    "type": "object"
+                }
+            }
+        }
+    }
+}

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -364,10 +364,14 @@ def simulate(
         record_migrations=record_migrations,
         from_ts=from_ts,
         start_time=start_time)
-    # The provenance API is very tentative, and only included now as a
-    # pre-alpha feature.
-    parameters = {"TODO": "encode simulation parameters"}
-    provenance_dict = provenance.get_provenance_dict("simulate", parameters)
+
+    parameters = {
+        "command": "simulate",
+        "sample_size": sample_size,
+        "TODO": "add other simulation parameters"
+    }
+    provenance_dict = provenance.get_provenance_dict(parameters)
+
     if mutation_generator is not None:
         # This error was added in version 0.6.1.
         raise ValueError(

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -2664,9 +2664,13 @@ class TreeSequence(object):
             filter_populations=filter_populations,
             filter_individuals=filter_individuals,
             filter_sites=filter_sites)
-        # TODO add simplify arguments here??
+        # TODO add simplify arguments here
+        parameters = {
+            "command": "simplify",
+            "TODO": "add simplify parameters"
+        }
         tables.provenances.add_row(record=json.dumps(
-            provenance.get_provenance_dict("simplify", [])))
+            provenance.get_provenance_dict(parameters)))
         new_ts = tables.tree_sequence()
         assert new_ts.sequence_length == self.sequence_length
         if map_nodes:

--- a/requirements/conda-minimal.txt
+++ b/requirements/conda-minimal.txt
@@ -3,3 +3,4 @@ nose
 h5py
 gsl
 six
+jsonschema

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,6 +8,7 @@ nose
 numpy
 six
 kastore
+jsonschema
 # TODO we're pinning the version here because of problems on Travis.
 # versions weren't correctly being set for v1.12.1
 setuptools_scm == 1.11.1

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -2,3 +2,4 @@ six
 setuptools_scm 
 sphinx-argparse
 h5py
+jsonschema

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,8 @@ setup(
             'msp=msprime.cli:msp_main',
         ]
     },
-    install_requires=["numpy>=1.7.0", "h5py", "svgwrite", "six"],
+    include_package_data=True,
+    install_requires=["numpy>=1.7.0", "h5py", "svgwrite", "six", "jsonschema"],
     ext_modules=[_msprime_module],
     keywords=["Coalescent simulation", "ms"],
     license="GNU GPLv3+",

--- a/tests/test_file_format.py
+++ b/tests/test_file_format.py
@@ -26,6 +26,7 @@ import os
 import tempfile
 import unittest
 import uuid as _uuid
+import json
 
 import h5py
 import kastore
@@ -235,6 +236,8 @@ class TestRoundTrip(TestFileFormat):
         tsp.dump(self.temp_file)
         tsp = msprime.load(self.temp_file)
         self.verify_tree_sequences_equal(ts, tsp, simplify=simplify)
+        for provenance in tsp.provenances():
+            msprime.validate_provenance(json.loads(provenance.record))
 
     def verify_malformed_json_v2(self, ts, group_name, attr, bad_json):
         msprime.dump_legacy(ts, self.temp_file, 2)

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -41,7 +41,7 @@ class TestMutateProvenance(unittest.TestCase):
         for mutation_rate in [0, 1, 1e-5]:
             mutated = msprime.mutate(ts, mutation_rate)
             record = json.loads(mutated.provenance(mutated.num_provenances - 1).record)
-            self.assertEqual(record["command"], "mutate")
+            self.assertEqual(record["parameters"]["command"], "mutate")
             self.assertEqual(record["parameters"]["rate"], mutation_rate)
             self.assertTrue(record["parameters"]["random_seed"] >= 0)
 
@@ -50,7 +50,7 @@ class TestMutateProvenance(unittest.TestCase):
         for start_time in [0, 1, -1]:
             mutated = msprime.mutate(ts, 1, start_time=start_time)
             record = json.loads(mutated.provenance(mutated.num_provenances - 1).record)
-            self.assertEqual(record["command"], "mutate")
+            self.assertEqual(record["parameters"]["command"], "mutate")
             self.assertEqual(record["parameters"]["start_time"], start_time)
             self.assertTrue(record["parameters"]["random_seed"] >= 0)
 
@@ -59,7 +59,7 @@ class TestMutateProvenance(unittest.TestCase):
         for end_time in [0, 1, 100]:
             mutated = msprime.mutate(ts, 1, start_time=-1, end_time=end_time)
             record = json.loads(mutated.provenance(mutated.num_provenances - 1).record)
-            self.assertEqual(record["command"], "mutate")
+            self.assertEqual(record["parameters"]["command"], "mutate")
             self.assertEqual(record["parameters"]["start_time"], -1)
             self.assertEqual(record["parameters"]["end_time"], end_time)
             self.assertTrue(record["parameters"]["random_seed"] >= 0)
@@ -69,7 +69,7 @@ class TestMutateProvenance(unittest.TestCase):
         for seed in range(1, 10):
             mutated = msprime.mutate(ts, rate=1, random_seed=seed)
             record = json.loads(mutated.provenance(mutated.num_provenances - 1).record)
-            self.assertEqual(record["command"], "mutate")
+            self.assertEqual(record["parameters"]["command"], "mutate")
             self.assertEqual(record["parameters"]["rate"], 1)
             self.assertEqual(record["parameters"]["random_seed"], seed)
 
@@ -78,7 +78,7 @@ class TestMutateProvenance(unittest.TestCase):
         for keep in [True, False]:
             mutated = msprime.mutate(ts, rate=1, keep=keep)
             record = json.loads(mutated.provenance(mutated.num_provenances - 1).record)
-            self.assertEqual(record["command"], "mutate")
+            self.assertEqual(record["parameters"]["command"], "mutate")
             self.assertEqual(record["parameters"]["keep"], keep)
 
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -24,9 +24,10 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import unittest
+import json
 
 import _msprime
-
+import msprime
 import msprime.provenance as provenance
 
 
@@ -36,9 +37,125 @@ class TestProvenance(unittest.TestCase):
     """
 
     def test_libraries(self):
-        d = provenance.get_provenance_dict("test")
+        d = provenance.get_provenance_dict()
         libs = d["environment"]["libraries"]
-        self.assertEqual(libs["gsl"], {"version": _msprime.get_gsl_version()})
-        self.assertEqual(libs["kastore"], {"version": (0, 1, 0)})
+        self.assertEqual(libs["gsl"], {
+            "version": ".".join(map(str, _msprime.get_gsl_version()))})
+        self.assertEqual(libs["kastore"], {"version": "0.1.0"})
 
     # TODO more tests when we finalise the format of these dictionaries.
+
+
+class TestEnvironment(unittest.TestCase):
+    """
+    Basic tests for the provenance dict function.
+    """
+    def test_cache(self):
+        d = provenance.get_environment()
+        self.assertIn("os", d)
+        self.assertIs(d, provenance.get_environment())
+
+
+def get_provenance(
+        software_name="x", software_version="y", environment=None, parameters=None):
+    document = {
+        "software": {
+            "name": software_name,
+            "version": software_version,
+        },
+        "environment": {} if environment is None else environment,
+        "parameters": {} if parameters is None else parameters,
+    }
+    return document
+
+
+class TestSchema(unittest.TestCase):
+    """
+    Tests for schema validation.
+    """
+    def test_empty(self):
+        with self.assertRaises(msprime.ProvenanceValidationError):
+            msprime.validate_provenance({})
+
+    def test_missing_keys(self):
+        minimal = get_provenance()
+        msprime.validate_provenance(minimal)
+        for key in minimal.keys():
+            copy = dict(minimal)
+            del copy[key]
+            with self.assertRaises(msprime.ProvenanceValidationError):
+                msprime.validate_provenance(copy)
+        copy = dict(minimal)
+        del copy["software"]["name"]
+        with self.assertRaises(msprime.ProvenanceValidationError):
+            msprime.validate_provenance(copy)
+        copy = dict(minimal)
+        del copy["software"]["version"]
+        with self.assertRaises(msprime.ProvenanceValidationError):
+            msprime.validate_provenance(copy)
+
+    def test_software_types(self):
+        for bad_type in [0, [1, 2, 3], {}]:
+            doc = get_provenance(software_name=bad_type)
+            with self.assertRaises(msprime.ProvenanceValidationError):
+                msprime.validate_provenance(doc)
+            doc = get_provenance(software_version=bad_type)
+            with self.assertRaises(msprime.ProvenanceValidationError):
+                msprime.validate_provenance(doc)
+
+    def test_software_empty_strings(self):
+        doc = get_provenance(software_name="")
+        with self.assertRaises(msprime.ProvenanceValidationError):
+            msprime.validate_provenance(doc)
+        doc = get_provenance(software_version="")
+        with self.assertRaises(msprime.ProvenanceValidationError):
+            msprime.validate_provenance(doc)
+
+    def test_minimal(self):
+        minimal = {
+            "software": {
+                "name": "x",
+                "version": "y",
+            },
+            "environment": {},
+            "parameters": {}
+        }
+        msprime.validate_provenance(minimal)
+
+    def test_extra_stuff(self):
+        extra = {
+            "you": "can",
+            "software": {
+                "put": "anything",
+                "name": "x",
+                "version": "y",
+            },
+            "environment": {"extra": ["you", "want"]},
+            "parameters": {"so": ["long", "its", "JSON", 0]}
+        }
+        msprime.validate_provenance(extra)
+
+
+class ValidateSchemas(unittest.TestCase):
+    """
+    Check that the schemas we produce in msprime are valid.
+    """
+    def test_simulation(self):
+        ts = msprime.simulate(5, random_seed=1)
+        prov = json.loads(ts.provenance(0).record)
+        msprime.validate_provenance(prov)
+        self.assertEqual(prov["parameters"]["command"], "simulate")
+
+    def test_mutate(self):
+        ts = msprime.simulate(5, random_seed=1)
+        ts = msprime.mutate(ts, rate=1, random_seed=1)
+        prov = json.loads(ts.provenance(1).record)
+        msprime.validate_provenance(prov)
+        self.assertEqual(prov["parameters"]["command"], "mutate")
+
+    def test_simplify(self):
+        ts = msprime.simulate(5, random_seed=1)
+        ts = ts.simplify()
+        prov = json.loads(ts.provenance(1).record)
+        msprime.validate_provenance(prov)
+        self.assertEqual(prov["parameters"]["command"], "simplify")

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -33,7 +33,7 @@ import msprime
 
 
 def add_provenance(provenance_table, method_name):
-    d = provenance.get_provenance_dict("tsutil.{}".format(method_name))
+    d = provenance.get_provenance_dict({"command": "tsutil.{}".format(method_name)})
     provenance_table.add_row(json.dumps(d))
 
 


### PR DESCRIPTION
First pass at defining the provenance schema using [JSON schema](http://json-schema.org/).   Closes #556 

The purpose of provenance is **reproducability**: given a tree sequence that has this provenance information associated with it, you should be able to reproduce it. This won't always be possible for various reasons (parameters too big to encode as JSON, referencing files that don't exist, numerical precision of parameters, ...), but this is the basic spirit of the idea.

**UPDATED to include schema_version**

Here's the current schema:
```json
{
  "schema": "http://json-schema.org/draft-07/schema#",
  "version": "1.0.0",
  "title": "tskit provenance",
  "description": "The combination of software, parameters and environment that produced a tree sequence",
  "type": "object",
  "required": ["schema_version", "software", "parameters", "environment"],
  "properties": {
    "schema_version": {
      "description": "The version of this schema used.",
      "type": "string",
      "minLength": 1
    },
    "software": {
      "description": "The primary software used to produce the tree sequence.",
      "type": "object",
      "required": ["name", "version"],
      "properties": {
        "name": {
          "description": "The name of the primary software.",
          "type": "string",
          "minLength": 1
        },
        "version": {
          "description": "The version of primary software.",
          "type": "string",
          "minLength": 1
        }
      }
    },
    "parameters": {
      "description": "The parameters used to produce the tree sequence.",
      "type": "object"
    },
    "environment": {
      "description": "The computational environment within which the primary software ran.",
      "type": "object",
      "properties": {
        "os": {
          "description": "Operating system.",
          "type": "object"
        },
        "libraries": {
          "description": "Details of libraries the primary software linked against.",
          "type": "object"
        }
      }
    }
  }
} 
```

This is what we end with from msprime:
```json
{
  "schema_version": "1.0.0",
  "environment": {
    "libraries": {
      "gsl": {
        "version": "2.1"
      },
      "kastore": {
        "version": "0.1.0"
      }
    },
    "python": {
      "version": "3.5.2",
      "implementation": "CPython"
    },
    "os": {
      "system": "Linux",
      "node": "powderfinger",
      "release": "4.15.0-29-generic",
      "version": "#31~16.04.1-Ubuntu SMP Wed Jul 18 08:54:04 UTC 2018",
      "machine": "x86_64"
    }
  },
  "parameters": {
    "sample_size": 5,
    "command": "simulate",
    "TODO": "add other simulation parameters"
  },
  "software": {
    "name": "msprime",
    "version": "0.6.1.dev123+ga252341.d20180820"
  }
}
```

This is slightly different to what we had before, but in the same spirit. The basic idea is that we have three things we need to document for provenance: the **software** used, the **parameters** provided to this software and the **environment** within which this software was run. 

The schema is pretty light-touch, as there's no point in over-specifying this stuff. The minimal compliant instance is:
```json
    {
            "schema_version": "1",
            "software": {
                "name": "x",
                "version": "x",
            },
            "environment": {},
            "parameters": {}
     }
```
Basically, you have to have these three keys, and you have to give non-empty strings for the **name** and **version** keys, and specify the **schema_version** You can put anything extra in there that you want.

**TODO**

- High-level documentation explaining what this is for.

Pinging @petrelharp, @molpopgen and @bhaller for comments!
