### PR TITLE
clarified error

### DIFF
--- a/lib/ld.c
+++ b/lib/ld.c
@@ -214,7 +214,7 @@ ld_calc_get_r2_array_forward(ld_calc_t *self, size_t source_index,
         goto out;
     }
     if (sA.mutations_length > 1) {
-        ret = MSP_ERR_UNSUPPORTED_OPERATION;
+        ret = MSP_ERR_ONLY_INFINITE_SITES;
         goto out;
     }
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
@@ -229,7 +229,7 @@ ld_calc_get_r2_array_forward(ld_calc_t *self, size_t source_index,
             goto out;
         }
         if (sB.mutations_length > 1) {
-            ret = MSP_ERR_UNSUPPORTED_OPERATION;
+            ret = MSP_ERR_ONLY_INFINITE_SITES;
             goto out;
         }
         if (sB.position - sA.position > max_distance) {
@@ -303,7 +303,7 @@ ld_calc_get_r2_array_reverse(ld_calc_t *self, size_t source_index,
         goto out;
     }
     if (sA.mutations_length > 1) {
-        ret = MSP_ERR_UNSUPPORTED_OPERATION;
+        ret = MSP_ERR_ONLY_INFINITE_SITES;
         goto out;
     }
     fA = ((double) tA->num_samples[sA.mutations[0].node]) / n;
@@ -319,7 +319,7 @@ ld_calc_get_r2_array_reverse(ld_calc_t *self, size_t source_index,
             goto out;
         }
         if (sB.mutations_length > 1) {
-            ret = MSP_ERR_UNSUPPORTED_OPERATION;
+            ret = MSP_ERR_ONLY_INFINITE_SITES;
             goto out;
         }
         if (sA.position - sB.position > max_distance) {
@@ -435,7 +435,7 @@ ld_calc_get_r2(ld_calc_t *self, size_t a, size_t b, double *r2)
         goto out;
     }
     if (sA.mutations_length > 1 || sB.mutations_length > 1) {
-        ret = MSP_ERR_UNSUPPORTED_OPERATION;
+        ret = MSP_ERR_ONLY_INFINITE_SITES;
         goto out;
     }
     assert(sA.mutations_length == 1);

--- a/lib/tests.c
+++ b/lib/tests.c
@@ -1128,7 +1128,7 @@ verify_stats(tree_sequence_t *ts)
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_TRUE_FATAL(pi >= 0);
         } else {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         }
     }
 }
@@ -2131,7 +2131,7 @@ verify_ld(tree_sequence_t *ts)
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_DOUBLE_EQUAL_FATAL(x, 1.0, eps);
         } else {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         }
     }
 
@@ -2140,7 +2140,7 @@ verify_ld(tree_sequence_t *ts)
         ret = ld_calc_get_r2_array(&ld_calc, 0, MSP_DIR_FORWARD,
                 num_sites, DBL_MAX, r2, &num_r2_values);
         if (multi_mutations_exist(ts, 0, num_sites)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
@@ -2150,7 +2150,7 @@ verify_ld(tree_sequence_t *ts)
         ret = ld_calc_get_r2_array(&ld_calc, num_sites - 2, MSP_DIR_FORWARD,
                 num_sites, DBL_MAX, r2_prime, &num_r2_values);
         if (multi_mutations_exist(ts, num_sites - 2, num_sites)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
@@ -2160,7 +2160,7 @@ verify_ld(tree_sequence_t *ts)
         ret = ld_calc_get_r2_array(&ld_calc, 0, MSP_DIR_FORWARD,
                 num_sites, DBL_MAX, r2_prime, &num_r2_values);
         if (multi_mutations_exist(ts, 0, num_sites)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
@@ -2179,7 +2179,7 @@ verify_ld(tree_sequence_t *ts)
                 MSP_DIR_REVERSE, num_sites, DBL_MAX,
                 r2, &num_r2_values);
         if (multi_mutations_exist(ts, 0, num_sites)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
@@ -2189,7 +2189,7 @@ verify_ld(tree_sequence_t *ts)
         ret = ld_calc_get_r2_array(&ld_calc, 1, MSP_DIR_REVERSE,
                 num_sites, DBL_MAX, r2_prime, &num_r2_values);
         if (multi_mutations_exist(ts, 0, 1)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
@@ -2200,7 +2200,7 @@ verify_ld(tree_sequence_t *ts)
                 MSP_DIR_REVERSE, num_sites, DBL_MAX,
                 r2_prime, &num_r2_values);
         if (multi_mutations_exist(ts, 0, num_sites)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, num_sites - 1);
@@ -2228,7 +2228,7 @@ verify_ld(tree_sequence_t *ts)
         ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_FORWARD, num_sites,
                 x, r2, &num_r2_values);
         if (multi_mutations_exist(ts, j, num_sites)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);
@@ -2238,7 +2238,7 @@ verify_ld(tree_sequence_t *ts)
         ret = ld_calc_get_r2_array(&ld_calc, j, MSP_DIR_REVERSE, num_sites,
                 x, r2, &num_r2_values);
         if (multi_mutations_exist(ts, 0, j + 1)) {
-            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+            CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ONLY_INFINITE_SITES);
         } else {
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL_FATAL(num_r2_values, 1);

--- a/lib/tree_sequence.c
+++ b/lib/tree_sequence.c
@@ -590,7 +590,7 @@ tree_sequence_get_pairwise_diversity(tree_sequence_t *self,
         }
         for (j = 0; j < num_sites; j++) {
             if (sites[j].mutations_length != 1) {
-                ret = MSP_ERR_UNSUPPORTED_OPERATION;
+                ret = MSP_ERR_ONLY_INFINITE_SITES;
                 goto out;
             }
             for (k = 0; k < sites[j].mutations_length; k++) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -294,6 +294,9 @@ msp_strerror_internal(int err)
                 "of multiple bottlenecks happening at the same time or because of "
                 "numerical imprecision with very small population sizes.";
             break;
+        case MSP_ERR_ONLY_INFINITE_SITES:
+            ret = "Only infinite sites mutations are supported for this operation.";
+            break;
 
         case MSP_ERR_IO:
             if (errno != 0) {

--- a/lib/util.h
+++ b/lib/util.h
@@ -186,6 +186,7 @@
 #define MSP_ERR_BAD_DEMOGRAPHIC_EVENT_TIME                          -81
 #define MSP_ERR_RECOMB_MAP_TOO_COARSE                               -82
 #define MSP_ERR_TIME_TRAVEL                                         -83
+#define MSP_ERR_ONLY_INFINITE_SITES                                 -84
 
 /* This bit is 0 for any errors originating from kastore */
 #define MSP_KAS_ERR_BIT 14

--- a/msprime/trees.py
+++ b/msprime/trees.py
@@ -318,7 +318,7 @@ class Population(SimpleContainer):
 
 class Variant(SimpleContainer):
     """
-    A variant is represents the observed variation among the samples
+    A variant represents the observed variation among the samples
     for a given site. A variant consists (a) of a reference to the
     :class:`.Site` instance in question; (b) the **alleles** that may be
     observed at the samples for this site; and (c) the **genotypes**


### PR DESCRIPTION
Computing pairwise diversity on a tree sequence with more than one mutation per site was producing the crpytic error
```
_msprime.LibraryError: Operation cannot be performed in current configuration
```

This changes that error to
```
_msprime.LibraryError: Only infinite sites mutations are supported for this operation.
```

Also in the LD code in a few places.
