### PR TITLE
Fix replication performance regression.

### DIFF
--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -662,7 +662,8 @@ class Simulator(object):
         """
         if self.random_generator is None:
             raise ValueError("A random generator instance must be set")
-        self.ll_sim = self.create_ll_instance()
+        if self.ll_sim is None:
+            self.ll_sim = self.create_ll_instance()
         for event in self.model_change_events:
             self.ll_sim.run(event.time)
             self.ll_sim.set_model(event.model.get_ll_representation())


### PR DESCRIPTION
Closes #608 

Code like this was affected:
```python
reps = msprime.simulate(100, num_replicates=10000)
before = time.perf_counter()
for rep in reps:
    pass # Do something with the simulation
duration = time.perf_counter() - before
print("Duration = {:.2f} sec".format(duration))
```
Before: 
```
Duration = 7.62 sec
```
After:
```
Duration = 0.91 sec
```

