### PR TITLE
Added inferface for managing GSL error handlers.

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -442,9 +442,6 @@ msp_alloc(msp_t *self,
     self->demographic_events_tail = NULL;
     self->next_demographic_event = NULL;
     self->state = MSP_STATE_NEW;
-
-    /* Make sure GSL error handling is turned off */
-    gsl_set_error_handler_off();
 out:
     return ret;
 }
@@ -4005,6 +4002,10 @@ msp_compute_beta_integral(msp_t *self, unsigned int num_ancestors, double alpha,
     double epsabs = self->model.params.beta_coalescent.integration_epsabs;
     struct beta_integral_params params = {num_ancestors, alpha};
 
+    if (w == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     F.function = &beta_integrand;
     F.params = &params;
     ret = gsl_integration_qags(&F, 0, 1, epsabs, epsrel, workspace_size, w, result, &err);
@@ -4014,6 +4015,7 @@ msp_compute_beta_integral(msp_t *self, unsigned int num_ancestors, double alpha,
         fprintf(stderr,  "GSL error: %s\n", gsl_strerror(ret));
         ret = MSP_ERR_INTEGRATION_FAILED;
     }
+out:
     return ret;
 }
 

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -41,6 +41,12 @@ import msprime.trees as trees
 from _msprime import RandomGenerator
 from _msprime import MutationGenerator
 
+# Make sure the GSL error handler is turned off so that we can be sure that
+# we don't abort on errors. This can be reset by using the function
+# _msprime.restore_gsl_error_handler(), which will set the error handler to
+# the value that it had before this function was called.
+_msprime.unset_gsl_error_handler()
+
 
 Sample = collections.namedtuple(
     "Sample",

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -411,6 +411,14 @@ class TestModule(tests.MsprimeTestCase):
         version_str = _msprime.get_library_version_str()
         self.assertEqual(version_str, _library_version)
 
+    def test_gsl_error_handler(self):
+        # Not a lot we can test here. Just make sure the error handler is unset when
+        # we finish.
+        _msprime.restore_gsl_error_handler()
+        _msprime.unset_gsl_error_handler()
+        _msprime.restore_gsl_error_handler()
+        _msprime.unset_gsl_error_handler()
+
 
 def get_random_population_models(n):
     """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -233,6 +233,12 @@ class TestMultipleMergerModels(unittest.TestCase):
         # TODO real tests
         self.assertTrue(ts is not None)
 
+    def test_beta_coalescent_integration_fails(self):
+        model = msprime.BetaCoalescent(
+            population_size=5, alpha=1e-10, truncation_point=10)
+        with self.assertRaises(_msprime.LibraryError):
+            msprime.simulate(sample_size=10, model=model)
+
     def test_dtwf(self):
         model = msprime.DiscreteTimeWrightFisher()
         ts = msprime.simulate(sample_size=10, model=model)


### PR DESCRIPTION
Closes #632.

@molpopgen, this will hopefully fix the issues that you've seen. If you do the following:

```python
import msprime
import _msprime

_msprime.restore_gsl_error_handler()
```
It should restore the GSL error handler to it's value before ``msprime`` was imported. I've left the function in the low-level module as this seems like a fairly obscure case that we don't need to complicate the high-level interface for. I'm happy to provide a function in the top level so we can avoid importing the low-level package though, if you think this would be easier to work with. Also happy to provide a different interface, if anything would work better for you.