### PR TITLE
Full arg migration test

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -790,8 +790,11 @@ class Simulator(object):
                     pop.add(alpha)
                     self.L.set_value(alpha.index, alpha.right - alpha.left - 1)
                 else:
-                    defrag_required |= (
-                        z.right == alpha.left and z.node == alpha.node)
+                    if self.full_arg:
+                        defrag_required |= z.right == alpha.left
+                    else:
+                        defrag_required |= (
+                            z.right == alpha.left and z.node == alpha.node)
                     z.next = alpha
                     self.L.set_value(alpha.index, alpha.right - z.right)
                 alpha.prev = z
@@ -911,8 +914,11 @@ class Simulator(object):
                     pop.add(alpha)
                     self.L.set_value(alpha.index, alpha.right - alpha.left - 1)
                 else:
-                    defrag_required |= (
-                        z.right == alpha.left and z.node == alpha.node)
+                    if self.full_arg:
+                        defrag_required |= z.right == alpha.left
+                    else:
+                        defrag_required |= (
+                            z.right == alpha.left and z.node == alpha.node)
                     z.next = alpha
                     self.L.set_value(alpha.index, alpha.right - z.right)
                 alpha.prev = z

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -1079,7 +1079,7 @@ msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
     msp_free_avl_node(self, node);
 
     if (self->store_full_arg) {
-        ret = msp_store_node(self, 0, self->time, dest_pop);
+        ret = msp_store_node(self, MSP_NODE_IS_MIG_EVENT, self->time, dest_pop);
         if (ret != 0) {
             goto out;
         }
@@ -1614,7 +1614,12 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                 fenwick_set_value(&self->links[label], alpha->id,
                         alpha->right - alpha->left - 1);
             } else {
-                defrag_required |= z->right == alpha->left && z->value == alpha->value;
+                if (self->store_full_arg) {
+                    // we pre-empt the fact that values will be set equal later
+                    defrag_required |= z->right == alpha->left;
+                } else {
+                    defrag_required |= z->right == alpha->left && z->value == alpha->value;
+                }
                 z->next = alpha;
                 fenwick_set_value(&self->links[label], alpha->id, alpha->right - z->right);
             }
@@ -1824,8 +1829,13 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                 fenwick_set_value(&self->links[label], alpha->id,
                         alpha->right - alpha->left - 1);
             } else {
-                defrag_required |=
-                    z->right == alpha->left && z->value == alpha->value;
+                if (self->store_full_arg) {
+                    // we pre-empt the fact that values will be set equal later
+                    defrag_required |= z->right == alpha->left;
+                } else {
+                    defrag_required |=
+                        z->right == alpha->left && z->value == alpha->value;
+                }
                 z->next = alpha;
                 fenwick_set_value(&self->links[label], alpha->id,
                         alpha->right - z->right);

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -1015,14 +1015,13 @@ class TestMigrationRecords(unittest.TestCase):
             record_migrations=True,
             random_seed=1)
         self.verify_two_pops_single_sample(ts, t)
-        
+
     def verify_two_pops_full_arg(self, ts):
-        migration_flag = 524288
         migrations = ts.tables.migrations
         edges = ts.tables.edges
         nodes = ts.tables.nodes
         for mig in migrations:
-            self.assertEqual(nodes[mig.node].flags, migration_flag)
+            self.assertEqual(nodes[mig.node].flags, msprime.NODE_IS_MIG_EVENT)
             self.assertEqual(nodes[mig.node].time, mig.time)
             self.assertEqual(nodes[mig.node].population, mig.dest)
             e1 = np.where(edges.parent == mig.node)
@@ -1033,7 +1032,7 @@ class TestMigrationRecords(unittest.TestCase):
             self.assertEqual(edges[e].right, mig.right)
             self.assertEqual(nodes[edges[e].child].population, mig.source)
         for edge in edges:
-            if nodes[edge.parent].flags == migration_flag:
+            if nodes[edge.parent].flags == msprime.NODE_IS_MIG_EVENT:
                 m1 = np.where(migrations.node == edge.parent)
                 m2 = np.where(migrations.left == edge.left)
                 m = np.intersect1d(m1[0], m2[0])
@@ -1043,7 +1042,7 @@ class TestMigrationRecords(unittest.TestCase):
                 self.assertEqual(migrations[m].time, nodes[edge.parent].time)
                 self.assertEqual(migrations[m].source, nodes[edge.child].population)
                 self.assertEqual(migrations[m].dest, nodes[edge.parent].population)
-        
+
     def test_full_arg_migration(self):
         population_configurations = [
             msprime.PopulationConfiguration(10),
@@ -1054,7 +1053,7 @@ class TestMigrationRecords(unittest.TestCase):
             migration_matrix=[
                 [0, 1],
                 [1, 0]],
-            random_seed=1, recombination_rate = 0.1, 
+            random_seed=1, recombination_rate=0.1,
             record_migrations=True, record_full_arg=True)
         self.verify_two_pops_full_arg(ts)
 

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -1015,6 +1015,48 @@ class TestMigrationRecords(unittest.TestCase):
             record_migrations=True,
             random_seed=1)
         self.verify_two_pops_single_sample(ts, t)
+        
+    def verify_two_pops_full_arg(self, ts):
+        migration_flag = 524288
+        migrations = ts.tables.migrations
+        edges = ts.tables.edges
+        nodes = ts.tables.nodes
+        for mig in migrations:
+            self.assertEqual(nodes[mig.node].flags, migration_flag)
+            self.assertEqual(nodes[mig.node].time, mig.time)
+            self.assertEqual(nodes[mig.node].population, mig.dest)
+            e1 = np.where(edges.parent == mig.node)
+            e2 = np.where(edges.left == mig.left)
+            e = np.intersect1d(e1[0], e2[0])
+            self.assertEqual(len(e), 1)
+            e = np.asscalar(e)
+            self.assertEqual(edges[e].right, mig.right)
+            self.assertEqual(nodes[edges[e].child].population, mig.source)
+        for edge in edges:
+            if nodes[edge.parent].flags == migration_flag:
+                m1 = np.where(migrations.node == edge.parent)
+                m2 = np.where(migrations.left == edge.left)
+                m = np.intersect1d(m1[0], m2[0])
+                self.assertEqual(len(m), 1)
+                m = np.asscalar(m)
+                self.assertEqual(migrations[m].right, edge.right)
+                self.assertEqual(migrations[m].time, nodes[edge.parent].time)
+                self.assertEqual(migrations[m].source, nodes[edge.child].population)
+                self.assertEqual(migrations[m].dest, nodes[edge.parent].population)
+        
+    def test_full_arg_migration(self):
+        population_configurations = [
+            msprime.PopulationConfiguration(10),
+            msprime.PopulationConfiguration(10),
+        ]
+        ts = msprime.simulate(
+            population_configurations=population_configurations,
+            migration_matrix=[
+                [0, 1],
+                [1, 0]],
+            random_seed=1, recombination_rate = 0.1, 
+            record_migrations=True, record_full_arg=True)
+        self.verify_two_pops_full_arg(ts)
 
     def verify_two_pops_asymmetric_migrations(self, ts):
         self.verify_migrations(ts)


### PR DESCRIPTION
I've made three changes here:

1) The most immediate is that I've added a test which runs through the list of stored migration events, verifies that each corresponds to exactly one full-arg edge, and vice versa. I haven't worked out how to actually run these tests from the `test_demography.py` file, but have run a functionally identical code as a stand-alone Python script (just replacing self.assertEquals with assert, for example), and that seemed to work fine.

2) I've added the `MSP_NODE_IS_MIG_EVENT` flag to nodes created by the `msp_move_individual` function under `store_full_arg`. Previously the flag was set to 0. The test in the Python file uses the hard-coded, numerical value of this flag - is that an ok thing to do?

3) I've changed the condition for running `defrag_required` when merging ancestors to take into account the fact that all segments will point to a common node under `store_full_arg`. This wasn't captured by the earlier implementation since the values of the segments were compared to determine `defrag_required` before running `msp_store_arg_edges`.

