### PR TITLE
trailing zero recombination rate fix

### DIFF
--- a/lib/recomb_map.c
+++ b/lib/recomb_map.c
@@ -221,6 +221,10 @@ recomb_map_genetic_to_phys(recomb_map_t *self, double genetic_x)
         if (self->sequence_length != num_loci) {
             ret = (genetic_x / num_loci) * self->sequence_length;
         }
+    } else if (genetic_x == num_loci) {
+        /* Map the right end of the chromosome to the right end of the
+         * chromosome, even if there are zero-recomb regions on the end. */
+        ret = self->sequence_length;
     } else {
         /* genetic_x is in the range [0,num_loci], and so we rescale
          * this into [0,total_recombination_rate] so that we can

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -758,19 +758,29 @@ class RecombinationMap(object):
     @classmethod
     def read_hapmap(cls, filename):
         """
-        Parses the specified file in HapMap format. These files must contain
-        a single header line (which is ignored), and then each subsequent
-        line denotes a position/rate pair. Positions are in units of bases,
-        and recombination rates in centimorgans/Megabase. The first column
-        in this file is ignored, as are subsequence columns after the
-        Position and Rate. A sample of this format is as follows::
+        Parses the specified file in HapMap format. These files must be
+        white-space-delimited, and contain a single header line (which is
+        ignored), and then each subsequent line contains the starting position
+        and recombination rate for the segment from that position (inclusive)
+        to the starting position on the next line (exclusive). Starting
+        positions of each segment are given in units of bases, and
+        recombination rates in centimorgans/Megabase. The first column in this
+        file is ignored, as are additional columns after the third (Position is
+        assumed to be the second column, and Rate is assumed to be the third).
+        If the first starting position is not equal to zero, then a
+        zero-recombination region is inserted at the start of the chromosome.
+
+        A sample of this format is as follows::
 
             Chromosome	Position(bp)	Rate(cM/Mb)	Map(cM)
-            chr1	55550	2.981822	0.000000
-            chr1	82571	2.082414	0.080572
-            chr1	88169	2.081358	0.092229
-            chr1	254996	3.354927	0.439456
-            chr1	564598	2.887498	1.478148
+            chr1	55550	        2.981822	0.000000
+            chr1	82571	        2.082414	0.080572
+            chr1	88169	        2.081358	0.092229
+            chr1	254996	        3.354927	0.439456
+            chr1	564598	        2.887498	1.478148
+            ...
+            chr1	182973428	1.036438	122.832331
+            chr1	183030013	0.000000	124.482178
 
         :param str filename: The name of the file to be parsed. This may be
             in plain text or gzipped plain text.

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -624,6 +624,18 @@ class TestSimulatorFactory(unittest.TestCase):
             ll_sim = sim.create_ll_instance()
             self.assertEqual(ll_sim.get_num_loci(), recomb_map.get_num_loci())
 
+    def test_zero_recombination_map(self):
+        # test that beginning and trailing zero recombination regions in the
+        # recomb map are included in the sequence
+        for n in range(3, 10):
+            positions = list(range(n))
+            rates = [0.0, 0.2] + [0.0] * (n - 2)
+            recomb_map = msprime.RecombinationMap(positions, rates)
+            ts = msprime.simulate(10, recombination_map=recomb_map)
+            self.assertEqual(ts.sequence_length, n - 1)
+            self.assertEqual(min(ts.tables.edges.left), 0.0)
+            self.assertEqual(max(ts.tables.edges.right), n - 1.0)
+
     def test_combining_recomb_map_and_rate_length(self):
         recomb_map = msprime.RecombinationMap([0, 1], [1, 0])
         self.assertRaises(


### PR DESCRIPTION
This hopefully fixes #715 (and also better documents `read_hapmap()`).

I've done it by just inserting a check into `recomb_map_genetic_to_phys()`, which seems the cleanest way to do it.  I've inserted a new test, also.  

But, I'm having trouble testing this right now, due to some tskit conflict.