### PR TITLE
added two helpful functions to the DemographyDebugger class

### DIFF
--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -26,9 +26,9 @@ import math
 import random
 import sys
 import os
-import numpy
 
 import tskit
+import numpy as np
 
 from . import provenance
 import _msprime
@@ -1251,6 +1251,7 @@ class DemographyDebugger(object):
 
     def _make_epochs(self, simulator, demographic_events):
         self.epochs = []
+        self.num_populations = simulator.num_populations
         ll_sim = simulator.create_ll_instance()
         N = simulator.num_populations
         start_time = 0
@@ -1348,12 +1349,11 @@ class DemographyDebugger(object):
     @property
     def population_size_history(self):
         """
-        Returns a matrix of population sizes seen
-        by samples from each population at each
-        time defined by the epochs.
+        Returns a (num_pops, num_epochs) numpy array giving the starting population size
+        for each population in each epoch.
         """
         num_pops = len(self.epochs[0].populations)
-        pop_size = numpy.zeros((num_pops, len(self.epochs)))
+        pop_size = np.zeros((num_pops, len(self.epochs)))
         for j, epoch in enumerate(self.epochs):
             for k, pop in enumerate(epoch.populations):
                 pop_size[k, j] = epoch.populations[k].start_size
@@ -1362,7 +1362,13 @@ class DemographyDebugger(object):
     @property
     def epoch_times(self):
         """
-        Returns array of epoch times defined by
-        the demographic model
+        Returns array of epoch times defined by the demographic model
         """
-        return numpy.array([x.start_time for x in self.epochs])
+        return np.array([x.start_time for x in self.epochs])
+
+    @property
+    def num_epochs(self):
+        """
+        Returns the number of epochs defined by the demographic model.
+        """
+        return len(self.epochs)

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -26,6 +26,7 @@ import math
 import random
 import sys
 import os
+import numpy
 
 import tskit
 
@@ -1343,3 +1344,25 @@ class DemographyDebugger(object):
             print("=" * len(s), file=output)
             self._print_populations(epoch, output)
             print(file=output)
+
+    @property
+    def population_size_history(self):
+        """
+        Returns a matrix of population sizes seen
+        by samples from each population at each
+        time defined by the epochs.
+        """
+        num_pops = len(self.epochs[0].populations)
+        pop_size = numpy.zeros((num_pops, len(self.epochs)))
+        for j, epoch in enumerate(self.epochs):
+            for k, pop in enumerate(epoch.populations):
+                pop_size[k, j] = epoch.populations[k].start_size
+        return pop_size
+
+    @property
+    def epoch_times(self):
+        """
+        Returns array of epoch times defined by
+        the demographic model
+        """
+        return numpy.array([x.start_time for x in self.epochs])

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -332,6 +332,19 @@ class TestDemographyDebugger(unittest.TestCase):
     Tests for the demography debugger. Ensure that we compute the correct
     population sizes etc.
     """
+    def verify_arrays(self, dd):
+        """
+        Check that the array properties that we genereate are computed correctly.
+        """
+        pop_size = dd.population_size_history
+        times = dd.epoch_times
+        self.assertEqual(dd.num_epochs, times.shape[0])
+        self.assertEqual(dd.num_epochs, pop_size.shape[1])
+        self.assertEqual(dd.num_populations, pop_size.shape[0])
+        for j in range(dd.num_epochs):
+            self.assertEqual(dd.epochs[j].start_time, times[j])
+            for k in range(dd.num_populations):
+                self.assertEqual(dd.epochs[j].populations[k].start_size, pop_size[k, j])
 
     def test_equal_after(self):
         population_configurations = [
@@ -346,6 +359,7 @@ class TestDemographyDebugger(unittest.TestCase):
         dd = msprime.DemographyDebugger(
             population_configurations=[msprime.PopulationConfiguration()])
         self.assertEqual(len(dd.epochs), 1)
+        self.verify_arrays(dd)
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
         self.assertEqual(dd.epoch_times[0], 0)
@@ -364,6 +378,7 @@ class TestDemographyDebugger(unittest.TestCase):
             population_configurations=[
                 msprime.PopulationConfiguration(initial_size=10),
                 msprime.PopulationConfiguration(initial_size=20)])
+        self.verify_arrays(dd)
         self.assertEqual(len(dd.epochs), 1)
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
@@ -391,6 +406,7 @@ class TestDemographyDebugger(unittest.TestCase):
                 msprime.PopulationConfiguration(initial_size=20, growth_rate=g2)],
             demographic_events=[
                 msprime.PopulationParametersChange(time=10, growth_rate=0)])
+        self.verify_arrays(dd)
         # Make sure we're testing the __repr__ paths.
         s = repr(dd)
         self.assertGreater(len(s), 0)
@@ -432,6 +448,7 @@ class TestDemographyDebugger(unittest.TestCase):
                 msprime.MigrationRateChange(time=20, rate=1),
                 msprime.MigrationRateChange(time=22, rate=1.7, matrix_index=(0, 1))],
             migration_matrix=[[0, 0.25], [0, 0]])
+        self.verify_arrays(dd)
         self.assertEqual(len(dd.epochs), 3)
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
@@ -492,6 +509,7 @@ class TestDemographyDebugger(unittest.TestCase):
                     population=0, time=t2, growth_rate=-alpha),
                 # Both change growth_rate to 0 at t3.
                 msprime.PopulationParametersChange(time=t3, growth_rate=0)])
+        self.verify_arrays(dd)
 
         self.assertEqual(len(dd.epochs), 4)
         e = dd.epochs[0]

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -348,6 +348,8 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertEqual(len(dd.epochs), 1)
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
+        self.assertEqual(dd.epoch_times[0], 0)
+        self.assertEqual(dd.population_size_history.shape[0], 1)
         self.assertTrue(math.isinf(e.end_time))
         self.assertEqual(len(e.demographic_events), 0)
         self.assertEqual(len(e.populations), 1)
@@ -365,6 +367,9 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertEqual(len(dd.epochs), 1)
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
+        self.assertEqual(dd.population_size_history.shape[0], 2)
+        self.assertEqual(dd.population_size_history[0][0], 10)
+        self.assertEqual(dd.population_size_history[1][0], 20)
         self.assertTrue(math.isinf(e.end_time))
         self.assertEqual(len(e.demographic_events), 0)
         self.assertEqual(len(e.populations), 2)
@@ -492,6 +497,8 @@ class TestDemographyDebugger(unittest.TestCase):
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
         self.assertEqual(e.end_time, t1)
+        self.assertEqual(dd.epoch_times[0], 0)
+        self.assertEqual(dd.epoch_times[1], t1)
         self.assertEqual(len(e.demographic_events), 0)
         self.assertEqual(len(e.populations), 2)
         self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])


### PR DESCRIPTION
I wrote a function that will be helpful for tracing the population size histories of samples drawn from individual populations moving back in time. The idea here is that we may want to know the population size experienced by a given sample as it goes through both population size changes and population mergers (back in time). 

To go along with this a wrote a simple helper function that simply outputs the epoch start times for a given demographic model. This may be deemed superfluous. 