### PR TITLE
single_sweep prototype implemented in C

### DIFF
--- a/lib/dev-tools/example.cfg
+++ b/lib/dev-tools/example.cfg
@@ -13,8 +13,8 @@ num_labels = 2;
 # other attributes.
 model = {
     # The standard coalescent
-    name = "hudson",
-    population_size = 100.0;
+    # name = "hudson",
+    # population_size = 100.0;
 
     # The SMC and SMC' variant.
     # name = "smc",
@@ -36,17 +36,17 @@ model = {
     /* population_size = 10.0; */
 
     # The single-sweep model
-    /* name = "single_sweep"; */
-    /* population_size = 100.0; */ 
-    /* locus = 5; /1* The zero indexed locus at which the sweep occurs *1/ */
+    name = "single_sweep"; 
+    population_size = 100.0;  
+    locus = 5; /* The zero indexed locus at which the sweep occurs */ 
     /* # The allele frequency trajectory for the sweep. Each element of this */
     /* # array is a (time, allele_frequency) tuple. */
-    /* trajectory = ( */
-    /*     [0.0, 0.5], */
-    /*     [0.1, 0.51], */
-    /*     [0.2, 0.55], */
-    /*     [0.3, 0.58] */
-    /* ); */
+    trajectory = ( 
+         [0.0, 0.95], 
+         [0.1, 0.85], 
+         [0.2, 0.75], 
+         [0.3, 0.5] 
+     ); 
 };
 
 # The recombination parameters. num_loci is the number of discrete loci that
@@ -78,7 +78,7 @@ samples  = (
     { population = 0; time = 0.0; },
     { population = 0; time = 0.0; },
     { population = 0; time = 0.0; },
-    { population = 0; time = 1.0; },
+    { population = 0; time = 0.0; },
     { population = 0; time = 0.0; },
     /* { population = 0; time = 0.0; }, */
     /* { population = 0; time = 0.0; }, */
@@ -152,7 +152,7 @@ store_migrations = 0;
 
 # Set to 1 to store the full ARG. This keeps track of all 
 # recombination and common ancestor nodes, as well as migration events.
-store_full_arg = 1;
+store_full_arg = 0;
 
 # Number of items that we allocate at once for each type.
 avl_node_block_size = 1000;

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -2960,7 +2960,7 @@ msp_run_single_sweep(msp_t *self, double max_time, unsigned long max_events)
     size_t curr_step = 0;
     double *allele_frequency = model->params.single_sweep.trajectory.allele_frequency;
     uint32_t sweep_locus = model->params.single_sweep.locus;
-    double sweep_dt = model->params.single_sweep.trajectory.sweep_dt;
+    double sweep_dt;
     size_t j = 0;
     int64_t num_links;
     unsigned long events = 0;
@@ -2970,6 +2970,7 @@ msp_run_single_sweep(msp_t *self, double max_time, unsigned long max_events)
     double sweep_pop_sizes[] = {0.0, 0.0};
     double event_prob, event_rand, tmp_rand, e_sum;
     double p_coal_b, p_coal_B, total_rate, sweep_pop_tot_rate;
+    double p_rec_b, p_rec_B;
 
     ret = msp_single_sweep_initialise(self, allele_frequency[0]);
     if (ret != 0) {
@@ -2985,7 +2986,7 @@ msp_run_single_sweep(msp_t *self, double max_time, unsigned long max_events)
             num_links = fenwick_get_total(&self->links[label]);
             ret = msp_sanity_check(self, num_links);
             sweep_pop_sizes[j] = (double) avl_count(&self->populations[0].ancestors[label]);
-            rec_rates[j] = (double) num_links * self->recombination_rate * sweep_dt;
+            rec_rates[j] = (double) num_links * self->recombination_rate;
             if (ret != 0) {
                 goto out;
             }
@@ -2994,6 +2995,7 @@ msp_run_single_sweep(msp_t *self, double max_time, unsigned long max_events)
         event_prob = 1.0;
         event_rand = gsl_rng_uniform(self->rng);
         while (event_prob > event_rand && curr_step < num_steps) {
+            sweep_dt = time[curr_step] - time[curr_step - 1];
             /* using pop sizes grabbed from get_population_size */
             p_coal_B = ((sweep_pop_sizes[1] * (sweep_pop_sizes[1] - 1) ) * 0.5)
                 / allele_frequency[curr_step]
@@ -3001,7 +3003,9 @@ msp_run_single_sweep(msp_t *self, double max_time, unsigned long max_events)
             p_coal_b = ((sweep_pop_sizes[0] * (sweep_pop_sizes[0] - 1) ) * 0.5)
                 / (1.0 - allele_frequency[curr_step])
                 * sweep_dt / get_population_size(&self->populations[0], time[curr_step]);
-            sweep_pop_tot_rate = p_coal_b + p_coal_B + rec_rates[0] + rec_rates[1];
+            p_rec_b = rec_rates[0] * sweep_dt;
+            p_rec_B = rec_rates[1] * sweep_dt;
+            sweep_pop_tot_rate = p_coal_b + p_coal_B + p_rec_b + p_rec_B;
             total_rate = sweep_pop_tot_rate; /* doing this to build in generality if we want >1 pop */
             if (total_rate == 0) {
                 goto out;

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -2382,6 +2382,21 @@ msp_get_population_size(msp_t *self, population_t *pop)
     return ret;
 }
 
+static double
+msp_get_population_size_time(population_t *pop, double t)
+{
+    double ret = 0;
+    double alpha = pop->growth_rate;
+    double dt;
+
+    if (alpha == 0.0) {
+        ret = pop->initial_size;
+    } else {
+        dt = t - pop->start_time;
+        ret = pop->initial_size * exp(-alpha * dt);
+    }
+    return ret;
+}
 /* Given the specified rate, return the waiting time until the next common ancestor
  * event for the specified population */
 static double
@@ -2695,7 +2710,6 @@ msp_store_simultaneous_migration_events(msp_t *self, avl_tree_t *nodes,
     node = avl_at(source, j);
     assert(node != NULL);
 
-    // Move to temp storage for actual migration later
     avl_unlink_node(source, node);
     node = avl_insert_node(nodes, node);
     assert(node != NULL);
@@ -2869,7 +2883,9 @@ msp_single_sweep_initialise(msp_t *self, double switch_proba)
     avl_node_t *node, *next;
     avl_tree_t *pop;
 
-    /* Move ancestors to new labels. */
+    /* Move ancestors to new labels.
+     * TODO probably need to limit model to single popn */
+    assert(self->num_populations == 1);
     for (j = 0; j < self->num_populations; j++) {
         assert(avl_count(&self->populations[j].ancestors[1]) == 0);
         pop = &self->populations[j].ancestors[0];
@@ -2905,48 +2921,67 @@ msp_change_label(msp_t *self, segment_t *ind, label_id_t label)
     return ret;
 }
 
-static int
+int
 msp_single_sweep_recombination_event(msp_t *self, label_id_t label,
-        uint32_t MSP_UNUSED(sweep_locus), double population_frequency)
+        uint32_t sweep_locus, double population_frequency)
 {
     int ret = 0;
     segment_t *lhs, *rhs;
     label_id_t new_label;
+    double r;
 
     ret = msp_recombination_event(self, label, &lhs, &rhs);
     if (ret != 0) {
         goto out;
     }
     /* NOTE: we can look at rhs->left when we compare to the sweep site. */
-
-    /* LHS and RHS are the two resulting individuals */
-    if (gsl_rng_uniform(self->rng) < population_frequency) {
-        new_label = (label + 1) % 2;
-        ret = msp_change_label(self, lhs, new_label);
-        if (ret != 0) {
-            goto out;
+    r = gsl_rng_uniform(self->rng);
+    if (sweep_locus < rhs->left) {
+        if (r < 1.0 - population_frequency) {
+            /* move rhs to other population */
+            new_label = (label + 1) % 2;
+            ret = msp_change_label(self, rhs, new_label);
+            if (ret != 0) {
+                goto out;
+            }
         }
-        /* TODO actual logic here --- obviously this is nonsense. But it should
-         * be possible to use calls to msp_change_label here for all you need
-         */
+    } else {
+        if (r < 1.0 - population_frequency) {
+            /* move lhs to other population */
+            new_label = (label + 1) % 2;
+            ret = msp_change_label(self, lhs, new_label);
+            if (ret != 0) {
+                goto out;
+            }
+        }
     }
-
 out:
     return ret;
 }
 
+/* big current assumption-- times that come in through
+ * trajectory array are ABSOLUTE with respect to the
+ * simulation. we may want to alter this in the future */
 static int
-msp_run_single_sweep(msp_t *self, double MSP_UNUSED(max_time),
-        unsigned long MSP_UNUSED(max_events))
+msp_run_single_sweep(msp_t *self, double max_time,
+        unsigned long max_events)
 {
     int ret = 0;
     simulation_model_t *model = &self->model;
     size_t num_steps = model->params.single_sweep.trajectory.num_steps;
+    size_t curr_step = 0;
     double *allele_frequency = model->params.single_sweep.trajectory.allele_frequency;
     uint32_t sweep_locus = model->params.single_sweep.locus;
-    size_t j;
-    /* double *time = model->params.single_sweep.trajectory.time; */
-
+    double sweep_dt = model->params.single_sweep.trajectory.sweep_dt;
+    size_t j = 0;
+    int64_t num_links;
+    unsigned long events = 0;
+    label_id_t label;
+    double *time = model->params.single_sweep.trajectory.time; 
+    double rec_rates[] = {0.0, 0.0};
+    double sweep_pop_sizes[] = {0.0, 0.0};
+    double event_prob, event_rand, tmp_rand, e_sum;
+    double p_coal_b, p_coal_B, total_rate, sweep_pop_tot_rate;
 
     assert(num_steps > 0);
     assert(self->num_labels == 2); /* just assuming 2 labels for now */
@@ -2954,25 +2989,85 @@ msp_run_single_sweep(msp_t *self, double MSP_UNUSED(max_time),
     if (ret != 0) {
         goto out;
     }
-    /* Obviously this is all utter rubbish, but hopefully these are the building
-     * blocks that you need??? */
-    for (j = 1; j < num_steps; j++) {
-        /* This will need to be some tiny value, or else the trees won't make sense */
-        self->time += 1e-6;
-        printf("j = %d ======================\n",(int)  j);
-        if (j % 3 == 1) {
-            /* Resolves to msp_std_common_ancestor_event(self, pop_id, label) */
-            ret = self->common_ancestor_event(self, 0, 1);
-        } else if (j % 3 == 2) {
-            ret = msp_single_sweep_recombination_event(self, 0, sweep_locus,
-                    allele_frequency[j]);
-        } else {
-            /* When we want to do an ordinary recombination event */
-            ret = msp_recombination_event(self, 0, NULL, NULL);
+
+    while (msp_get_num_ancestors(self) > 0 && self->time < max_time
+            && events < max_events && curr_step < num_steps) {
+        events++;
+        /* quick sanity check; also set pop sizes & rec_rates */
+        for (j = 0; j < self->num_labels; j++) {
+            label = (label_id_t) j;
+            num_links = fenwick_get_total(&self->links[label]);
+            ret = msp_sanity_check(self, num_links);
+            sweep_pop_sizes[j] = (double) avl_count(&self->populations[0].ancestors[label]);
+            rec_rates[j] = (double) num_links * self->recombination_rate * sweep_dt;
+            if (ret != 0) {
+                goto out;
+            }
         }
-        msp_verify(self);
+        curr_step++;
+        event_prob = 1.0;
+        event_rand = gsl_rng_uniform(self->rng);
+        while (event_prob > event_rand && curr_step < num_steps) {
+            /* using pop sizes grabbed from msp_get_population_size_time */
+            p_coal_B = ((sweep_pop_sizes[1] * (sweep_pop_sizes[1] - 1) ) * 0.5) / allele_frequency[curr_step] 
+                * sweep_dt / msp_get_population_size_time(&self->populations[0], time[curr_step]);
+            p_coal_b = ((sweep_pop_sizes[0] * (sweep_pop_sizes[0] - 1) ) * 0.5) / (1.0 - allele_frequency[curr_step]) 
+                * sweep_dt / msp_get_population_size_time(&self->populations[0], time[curr_step]);
+            sweep_pop_tot_rate = p_coal_b + p_coal_B + rec_rates[0] + rec_rates[1];
+            total_rate = sweep_pop_tot_rate; /* doing this to build in generality if we want >1 pop */
+            if (total_rate == 0) {
+                goto out;
+            }
+            /*printf("\ncoal probs: %g %g rec_rates: %g %g  event_prob: %g tot rate: %g \n", p_coal_b,*/
+                    /*p_coal_B, rec_rates[0], rec_rates[1], event_prob, sweep_pop_tot_rate);*/
+            event_prob *= 1.0 - total_rate;
+            curr_step++;
+        }
+        /* double check event happened and we haven't timed out */
+        if (curr_step >= num_steps || self->time >= max_time) {
+            goto out;
+        }
+
+        /*printf("\ncoal probs: %g %g rec_rates: %g %g  event_prob: %g tot rate: %g \n", p_coal_b,*/
+                /*p_coal_B, rec_rates[0], rec_rates[1], event_prob, sweep_pop_tot_rate);*/
+        /* passed check, choose event */
+        tmp_rand = gsl_rng_uniform(self->rng);
+        e_sum = p_coal_b;
+        self->time = time[curr_step - 1];
+        if (tmp_rand < e_sum / sweep_pop_tot_rate) {
+            /* coalescent in b background */
+            //printf("coal b\n");
+            ret = self->common_ancestor_event(self, 0, 0);
+        } else {
+            e_sum += p_coal_B;
+            if (tmp_rand < e_sum / sweep_pop_tot_rate) {
+                /* coalescent in B background */
+                //printf("coal B\n");
+                ret = self->common_ancestor_event(self, 0, 1);
+            } else {
+                e_sum += rec_rates[0];
+                if (tmp_rand < e_sum / sweep_pop_tot_rate) {
+                    /* recomb in b background */
+                    //printf("recomb event b\n");
+                    ret = msp_single_sweep_recombination_event(self, 0, sweep_locus,
+                        (1.0 - allele_frequency[curr_step - 1]));
+                } else {
+                    /* recomb in B background */
+                    //printf("recomb event B\n");
+                    ret = msp_single_sweep_recombination_event(self, 1, sweep_locus,
+                        allele_frequency[curr_step - 1]);
+                }
+            }
+        }
+        if (ret != 0){
+            goto out;
+        }
+        /*msp_print_state(self, stdout);*/
+        /*printf("step: %ld freq: %lf time: %lf num_anc: %ld sweep_pop_sizes[0]: %f sweep_pop_sizes[1]: %f\n",*/
+                /*curr_step, allele_frequency[curr_step - 1], self->time, msp_get_num_ancestors(self), sweep_pop_sizes[0],sweep_pop_sizes[1]);*/
+
     }
-    msp_print_state(self, stdout);
+    msp_verify(self);
 out:
     return ret;
 }

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -129,7 +129,7 @@ typedef struct {
         double *allele_frequency;
         double *time;
         size_t num_steps;
-	double sweep_dt;
+        double sweep_dt;
     } trajectory;
 } single_sweep_t;
 

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -129,7 +129,6 @@ typedef struct {
         double *allele_frequency;
         double *time;
         size_t num_steps;
-        double sweep_dt;
     } trajectory;
 } single_sweep_t;
 

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -129,6 +129,7 @@ typedef struct {
         double *allele_frequency;
         double *time;
         size_t num_steps;
+	double sweep_dt;
     } trajectory;
 } single_sweep_t;
 
@@ -391,7 +392,6 @@ int mutgen_set_time_interval(mutgen_t *self, double start_time, double end_time)
 int mutgen_free(mutgen_t *self);
 int mutgen_generate(mutgen_t *self, tsk_table_collection_t *tables, int flags);
 void mutgen_print_state(mutgen_t *self, FILE *out);
-
 /* Functions exposed here for unit testing. Not part of public API. */
 double compute_falling_factorial_log(unsigned int  m);
 double compute_dirac_coalescence_rate(unsigned int num_ancestors, double psi, double c);
@@ -400,4 +400,6 @@ int msp_beta_compute_coalescence_rate(msp_t *self, unsigned int num_ancestors, d
 
 int msp_multi_merger_common_ancestor_event(msp_t *self, double x, avl_tree_t *ancestors, avl_tree_t *Q);
 
+int msp_single_sweep_recombination_event(msp_t *self, label_id_t label,
+        uint32_t sweep_locus, double population_frequency);
 #endif /*__MSPRIME_H__*/

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -1022,7 +1022,6 @@ test_single_sweep(void)
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  49, num_steps, time, freqs);
         CU_ASSERT_EQUAL(ret, 0);
-        msp->model.params.single_sweep.trajectory.sweep_dt = dt;
         ret = msp_set_population_configuration(msp, 0, n, 0);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(msp);
@@ -1094,7 +1093,6 @@ test_single_sweep_growth(void)
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  1, num_steps, time, freqs);
         CU_ASSERT_EQUAL(ret, 0);
-        msp->model.params.single_sweep.trajectory.sweep_dt = dt;
         ret = msp_set_population_configuration(msp, 0, n, growth_rate);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(msp);
@@ -1167,7 +1165,6 @@ test_single_sweep_recomb(void)
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  1, num_steps, time, freqs);
         CU_ASSERT_EQUAL(ret, 0);
-        msp->model.params.single_sweep.trajectory.sweep_dt = dt;
         ret = msp_set_population_configuration(msp, 0, n, 0);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(msp);

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -888,15 +888,92 @@ get_num_children(size_t node, tsk_edge_table_t *edges)
 }
 
 /* deterministic sweep trajectory function */
-static double 
+static double
 single_sweep_fill_traj_test(double time)
 {
     double alpha = 1000.0; /* test value*/
     double epsilon, ts;
-    
+
     epsilon = 0.05 / alpha;
     ts = -2.0 * log(epsilon) / alpha;
     return epsilon / (epsilon + ((1.0 - epsilon)*exp(alpha * (time- ts))));
+}
+
+static void
+test_single_sweep_errors(void)
+{
+    int ret;
+    uint32_t n = 10;
+    uint32_t m = 100;
+    unsigned long seed = 133;
+    size_t num_steps = 2;
+    double time[] = {0.0, 0.0};
+    double freqs[] = {0.0, 0.0};
+    sample_t *samples = malloc(n * sizeof(sample_t));
+    msp_t *msp = malloc(sizeof(msp_t));
+    gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
+    tsk_table_collection_t tables;
+    recomb_map_t recomb_map;
+
+    CU_ASSERT_FATAL(msp != NULL);
+    CU_ASSERT_FATAL(samples != NULL);
+    CU_ASSERT_FATAL(rng != NULL);
+    CU_ASSERT_FATAL(time != NULL);
+    CU_ASSERT_FATAL(freqs != NULL);
+    ret = recomb_map_alloc_uniform(&recomb_map, m, 10.0, m);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    memset(samples, 0, n * sizeof(sample_t));
+    ret = tsk_table_collection_init(&tables, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    gsl_rng_set(rng, seed);
+    ret = msp_alloc(msp, n, samples, &recomb_map, &tables, rng);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    /* Errors in set simulation model */
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m, num_steps, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SWEEP_LOCUS);
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m + 1, num_steps, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_SWEEP_LOCUS);
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m / 2, 0, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_EMPTY_TRAJECTORY);
+    /* Bad trajectories */
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m / 2, num_steps, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_TRAJECTORY_TIME);
+    /* CU_ASSERT_EQUAL(ret, 0); */
+    time[1] = -1;
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m / 2, num_steps, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_TRAJECTORY_TIME);
+    time[1] = 1;
+
+    freqs[0] = 1.1;
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m / 2, num_steps, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_TRAJECTORY_ALLELE_FREQUENCY);
+    freqs[0] = -1.1;
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m / 2, num_steps, time, freqs);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_TRAJECTORY_ALLELE_FREQUENCY);
+
+    freqs[0] = 0.5;
+    freqs[1] = 0.5;
+
+    ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  m / 2, num_steps, time, freqs);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /* The incorrect number of populations was specified */
+    ret = msp_set_dimensions(msp, 2, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_run(msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_UNSUPPORTED_OPERATION);
+
+    msp_free(msp);
+    free(msp);
+    tsk_table_collection_free(&tables);
+    recomb_map_free(&recomb_map);
+    gsl_rng_free(rng);
+    free(samples);
 }
 
 static void
@@ -951,7 +1028,7 @@ test_single_sweep(void)
         ret = msp_initialise(msp);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_run(msp, DBL_MAX, UINT32_MAX);
-        //CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_EQUAL(ret, 1);
         msp_verify(msp);
         ret = msp_finalise_tables(msp);
         CU_ASSERT_EQUAL(ret, 0);
@@ -2997,6 +3074,7 @@ main(int argc, char **argv)
         {"test_multi_locus_bottleneck_arg", test_multi_locus_bottleneck_arg},
         {"test_mixed_model_simulation", test_mixed_model_simulation},
         {"test_dtwf_deterministic", test_dtwf_deterministic},
+        {"test_single_sweep_errors", test_single_sweep_errors},
         {"test_single_sweep", test_single_sweep},
         {"test_single_sweep_growth", test_single_sweep_growth},
         {"test_single_sweep_recomb", test_single_sweep_recomb},

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -887,6 +887,238 @@ get_num_children(size_t node, tsk_edge_table_t *edges)
     return num_children;
 }
 
+/* deterministic sweep trajectory function */
+static double 
+single_sweep_fill_traj_test(double time)
+{
+    double alpha = 1000.0; /* test value*/
+    double epsilon, ts;
+    
+    epsilon = 0.05 / alpha;
+    ts = -2.0 * log(epsilon) / alpha;
+    return epsilon / (epsilon + ((1.0 - epsilon)*exp(alpha * (time- ts))));
+}
+
+static void
+test_single_sweep(void)
+{
+    int j, ret, last_pos;
+    uint32_t n = 10;
+    uint32_t m = 100;
+    unsigned long seed = 133;
+    size_t num_steps = 200;
+    double time[num_steps];
+    double freqs[num_steps];
+    double dt = 1e-4;
+    sample_t *samples = malloc(n * sizeof(sample_t));
+    msp_t *msp = malloc(sizeof(msp_t));
+    gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
+    tsk_table_collection_t tables[2];
+    recomb_map_t recomb_map;
+
+    CU_ASSERT_FATAL(msp != NULL);
+    CU_ASSERT_FATAL(samples != NULL);
+    CU_ASSERT_FATAL(rng != NULL);
+    CU_ASSERT_FATAL(time != NULL);
+    CU_ASSERT_FATAL(freqs != NULL);
+    ret = recomb_map_alloc_uniform(&recomb_map, m, 10.0, m);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /*initialize test trajectory*/
+    for (j = 0; j < num_steps; j++) {
+        time[j] = j * dt;
+        freqs[j] = single_sweep_fill_traj_test(time[j]);
+        if (freqs[j] > 1.0/1000.0) {
+            last_pos = j;
+        }
+    }
+    num_steps = (size_t) last_pos;
+    memset(samples, 0, n * sizeof(sample_t));
+    for (j = 0; j < 2; j++) {
+        ret = tsk_table_collection_init(&tables[j], 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+        gsl_rng_set(rng, seed);
+        ret = msp_alloc(msp, n, samples, &recomb_map, &tables[j], rng);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_set_dimensions(msp, 1, 2);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  49, num_steps, time, freqs);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp->model.params.single_sweep.trajectory.sweep_dt = dt;
+        ret = msp_set_population_configuration(msp, 0, n, 0);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_initialise(msp);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_run(msp, DBL_MAX, UINT32_MAX);
+        //CU_ASSERT_EQUAL(ret, 0);
+        msp_verify(msp);
+        ret = msp_finalise_tables(msp);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp_free(msp);
+        CU_ASSERT_EQUAL(tables[j].migrations.num_rows, 0);
+        CU_ASSERT(tables[j].nodes.num_rows > 0);
+        CU_ASSERT(tables[j].edges.num_rows > 0);
+
+    }
+    CU_ASSERT_TRUE(tsk_node_table_equals(&tables[0].nodes, &tables[1].nodes));
+    CU_ASSERT_TRUE(tsk_edge_table_equals(&tables[0].edges, &tables[1].edges));
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    free(msp);
+    free(samples);
+    for (j = 0; j < 2; j++) {
+        tsk_table_collection_free(&tables[j]);
+    }
+    recomb_map_free(&recomb_map);
+}
+
+static void
+test_single_sweep_growth(void)
+{
+    int j, ret;
+    uint32_t n = 8;
+    uint32_t m = 200;
+    unsigned long seed = 133;
+    size_t num_steps = 100;
+    double time[num_steps];
+    double freqs[num_steps];
+    double dt = 1e-4;
+    double growth_rate = 0.1;
+    sample_t *samples = malloc(n * sizeof(sample_t));
+    msp_t *msp = malloc(sizeof(msp_t));
+    gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
+    tsk_table_collection_t tables[2];
+    recomb_map_t recomb_map;
+
+    CU_ASSERT_FATAL(msp != NULL);
+    CU_ASSERT_FATAL(samples != NULL);
+    CU_ASSERT_FATAL(rng != NULL);
+    CU_ASSERT_FATAL(time != NULL);
+    CU_ASSERT_FATAL(freqs != NULL);
+    ret = recomb_map_alloc_uniform(&recomb_map, m, 1.0, m);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /*initialize test trajectory*/
+    for (j = 0; j < num_steps; j++) {
+        time[j] = j * dt;
+        freqs[j] = single_sweep_fill_traj_test(time[j]);
+        /*printf("%lf %lf\n",time[j],freqs[j]);*/
+    }
+    memset(samples, 0, n * sizeof(sample_t));
+    for (j = 0; j < 2; j++) {
+        ret = tsk_table_collection_init(&tables[j], 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+        gsl_rng_set(rng, seed);
+        ret = msp_alloc(msp, n, samples, &recomb_map, &tables[j], rng);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_set_dimensions(msp, 1, 2);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  1, num_steps, time, freqs);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp->model.params.single_sweep.trajectory.sweep_dt = dt;
+        ret = msp_set_population_configuration(msp, 0, n, growth_rate);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_initialise(msp);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_run(msp, DBL_MAX, UINT32_MAX);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp_verify(msp);
+        ret = msp_finalise_tables(msp);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp_free(msp);
+        CU_ASSERT_EQUAL(tables[j].migrations.num_rows, 0);
+        CU_ASSERT(tables[j].nodes.num_rows > 0);
+        CU_ASSERT(tables[j].edges.num_rows > 0);
+
+    }
+    CU_ASSERT_TRUE(tsk_node_table_equals(&tables[0].nodes, &tables[1].nodes));
+    CU_ASSERT_TRUE(tsk_edge_table_equals(&tables[0].edges, &tables[1].edges));
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    free(msp);
+    free(samples);
+    for (j = 0; j < 2; j++) {
+        tsk_table_collection_free(&tables[j]);
+    }
+    recomb_map_free(&recomb_map);
+}
+
+/* does a single recombination event; checks links */
+static void
+test_single_sweep_recomb(void)
+{
+    int j, ret;
+    uint32_t n = 2;
+    uint32_t m = 10;
+    unsigned long seed = 133;
+    uint32_t num_links1, num_links2;
+    size_t num_steps = 2;
+    double time[num_steps];
+    double freqs[num_steps];
+    double dt = 1e-4;
+    sample_t *samples = malloc(n * sizeof(sample_t));
+    msp_t *msp = malloc(sizeof(msp_t));
+    gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
+    tsk_table_collection_t tables[2];
+    recomb_map_t recomb_map;
+
+    CU_ASSERT_FATAL(msp != NULL);
+    CU_ASSERT_FATAL(samples != NULL);
+    CU_ASSERT_FATAL(rng != NULL);
+    CU_ASSERT_FATAL(time != NULL);
+    CU_ASSERT_FATAL(freqs != NULL);
+    ret = recomb_map_alloc_uniform(&recomb_map, m, 1.0, m);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+    /*initialize test trajectory*/
+    for (j = 0; j < num_steps; j++) {
+        time[j] = j * dt;
+        freqs[j] = single_sweep_fill_traj_test(time[j]);
+        /*printf("%lf %lf\n",time[j],freqs[j]);*/
+    }
+    memset(samples, 0, n * sizeof(sample_t));
+    for (j = 0; j < 2; j++) {
+        ret = tsk_table_collection_init(&tables[j], 0);
+        CU_ASSERT_EQUAL_FATAL(ret, 0);
+
+        gsl_rng_set(rng, seed);
+        ret = msp_alloc(msp, n, samples, &recomb_map, &tables[j], rng);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_set_dimensions(msp, 1, 2);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_set_simulation_model_single_sweep(msp, 1000.0,  1, num_steps, time, freqs);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp->model.params.single_sweep.trajectory.sweep_dt = dt;
+        ret = msp_set_population_configuration(msp, 0, n, 0);
+        CU_ASSERT_EQUAL(ret, 0);
+        ret = msp_initialise(msp);
+        CU_ASSERT_EQUAL(ret, 0);
+
+        num_links1 = fenwick_get_total(&msp->links[(label_id_t) 1]);
+        ret = msp_single_sweep_recombination_event(msp, 0, 1,0.0);
+        num_links2 = fenwick_get_total(&msp->links[(label_id_t) 1]);
+        CU_ASSERT_EQUAL(msp_get_num_recombination_events(msp), 1);
+        CU_ASSERT_TRUE(num_links1 < num_links2);
+        ret = msp_single_sweep_recombination_event(msp, 0, 10,0.0);
+        num_links1 =  avl_count(&msp->populations[0].ancestors[1]);
+        CU_ASSERT_TRUE(num_links1 == 2);
+        msp_verify(msp);
+        ret = msp_finalise_tables(msp);
+        CU_ASSERT_EQUAL(ret, 0);
+        msp_free(msp);
+
+    }
+    gsl_rng_free(rng);
+    free(msp);
+    free(samples);
+    for (j = 0; j < 2; j++) {
+        tsk_table_collection_free(&tables[j]);
+    }
+    recomb_map_free(&recomb_map);
+}
+
 static void
 test_dtwf_deterministic(void)
 {
@@ -2765,6 +2997,9 @@ main(int argc, char **argv)
         {"test_multi_locus_bottleneck_arg", test_multi_locus_bottleneck_arg},
         {"test_mixed_model_simulation", test_mixed_model_simulation},
         {"test_dtwf_deterministic", test_dtwf_deterministic},
+        {"test_single_sweep", test_single_sweep},
+        {"test_single_sweep_growth", test_single_sweep_growth},
+        {"test_single_sweep_recomb", test_single_sweep_recomb},
         {"test_dtwf_single_locus_simulation", test_dtwf_single_locus_simulation},
         {"test_multi_locus_simulation", test_multi_locus_simulation},
         {"test_dtwf_multi_locus_simulation", test_dtwf_multi_locus_simulation},


### PR DESCRIPTION
hey @jeromekelleher - so here is a work in progress PR. I've implemented most of the guts of the sweep routines in C and it's time for a few design decisions. In particular we need to decide how we will generate the trajectories that we will feed to `msp_run_single_sweep`. I've tried to implement this so that it can run in the mixed model run setting that I see in lib/tests/tests.c, so that constrains things a bit-- the times that we generate for the trajectory should probably be on the same scale as times outside of these loops (i.e. not relative to the start of the simulation). 

So take a look and tell me what I should do next! I think I've got my ahead well around the moving parts of the C side so would like to keep working on it while its fresh in my mind. 