### PR TITLE
adding discoal checks to verifaction.py

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -21,5 +21,11 @@ ms:
 	cp msdir/ms_summary_stats ./
 	cp msdir/sample_stats ./
 
+discoal:
+	wget https://github.com/kern-lab/discoal/archive/v0.1.4.tar.gz
+	tar -xf v0.1.4.tar.gz
+	cd discoal-0.1.4/ && make 
+	cp discoal-0.1.4/discoal ./
+
 clean:
-	rm -fR scrm* ms ms_summary_stats sample_stats
+	rm -fR scrm* ms ms_summary_stats sample_stats discoal* v0.1.4.tar.gz*


### PR DESCRIPTION
work in progress here, but i'm getting the following error with existing code and haven't debugged yet. here is the error:

```
$ python verification.py
admixture-1-pop1
admixture-1-pop1 1000 1000 -t 2.0 -es 0.1 1 0.5 -em 0.1 1 2 1
	 msprime: 1000 1000 -t 2.0 -es 0.1 1 0.5 -em 0.1 1 2 1
Traceback (most recent call last):
  File "verification.py", line 2209, in <module>
    main()
  File "verification.py", line 2205, in main
    verifier.run(keys)
  File "verification.py", line 273, in run
    runner()
  File "verification.py", line 281, in f
    self._run_coalescent_stats(key, command_line)
  File "verification.py", line 257, in _run_coalescent_stats
    df_msp = self._run_msprime_coalescent_stats(args)
  File "verification.py", line 224, in _run_msprime_coalescent_stats
    sim.run()
  File "/home/adkern/my_msprime/msprime/simulations.py", line 674, in run
    self.ll_sim = self.create_ll_instance()
  File "/home/adkern/my_msprime/msprime/simulations.py", line 666, in create_ll_instance
    node_mapping_block_size=self.node_mapping_block_size)
TypeError: function takes at most 14 keyword arguments (15 given)
```
so it looks like something is going wrong with the admixture example check of `ms` vs `msp`. Am I simply using `verification.py` wrong?

In addition I patched a bug in the `check_slim_version()` function that was choking on a slim version that looked like `3.2.1`