### PR TITLE
Streamline DTWF tests and update test requirements

### DIFF
--- a/requirements/verification.txt
+++ b/requirements/verification.txt
@@ -4,5 +4,8 @@ dendropy
 matplotlib
 numpy
 pandas
-scipy
+scipy==1.2 # 1.3 deprecates scipy.misc.factorial imported by current statsmodels (0.9)
 statsmodels
+seaborn
+tqdm
+argparse


### PR DESCRIPTION
Removed largely redundant and long-running tests, and moved others into block run if `--extended` flag is set. Also added a few missing packages to `requirements/verification.txt`

DTWF tests now adjust growth rates so that populations do not shrink to zero individuals if coalescence is slow. Fixes #767.