### PR TITLE
Increase SLiM generations to 10x first coalescence time

### DIFF
--- a/verification.py
+++ b/verification.py
@@ -87,7 +87,7 @@ def write_slim_script(outfile, format_dict):
                 catn(sim.tag + ': COALESCED');
             }}
         }}
-        if (sim.generation == sim.tag * 2) {{
+        if (sim.generation == sim.tag * 10) {{
             sim.simulationFinished();
             catn('Ran a further ' + sim.tag * 10 + ' generations');
             sim.treeSeqOutput('{OUTFILE}');


### PR DESCRIPTION
Previously ran until coalescence then continuing for the same number of generations, but this still biased coalescence times in some scenarios. Now run for 10x the time to first coalescence.