### PR TITLE
Improve handling of sampling events and tests.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,14 @@
 ********************
+[0.8.0] - 2019-XX-XX
+********************
+
+**Breaking changes**
+
+- The random trajectory has been changed slightly to improve handling
+  of ancient sampling events (:pr:`782`). Thus, simulations for a given
+  random seed will not be identical to previous versions.
+
+********************
 [0.7.1] - 2019-06-08
 ********************
 


### PR DESCRIPTION
Put in all historical samples that occur at a given time at once rather than retesting for new events each loop.

Note: this will change the random trajectory for users with ancient samples, so that simulations won't be reproducible across versions.