### PR TITLE
Add census event(s) to msprime simulation

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -4170,6 +4170,7 @@ PyInit__msprime(void)
     PyModule_AddIntConstant(module, "NODE_IS_CA_EVENT", MSP_NODE_IS_CA_EVENT);
     PyModule_AddIntConstant(module, "NODE_IS_RE_EVENT", MSP_NODE_IS_RE_EVENT);
     PyModule_AddIntConstant(module, "NODE_IS_MIG_EVENT", MSP_NODE_IS_MIG_EVENT);
+    PyModule_AddIntConstant(module, "NODE_IS_CEN_EVENT", MSP_NODE_IS_CEN_EVENT);
 
     /* The function unset_gsl_error_handler should be called at import time,
      * ensuring we capture the value of the handler. However, just in case

--- a/algorithms.py
+++ b/algorithms.py
@@ -266,6 +266,14 @@ class Population(object):
         """
         return iter(self._ancestors[label])
 
+    def iter_ancestors(self):
+        """
+        Iterates over all ancestors in a population.
+        """
+        for ancestors in self._ancestors:
+            for ancestor in ancestors:
+                yield ancestor
+
     def find_indv(self, indv):
         """
         find the index of an ancestor in population
@@ -331,10 +339,10 @@ class Simulator(object):
             self, sample_size, num_loci, recombination_rate, migration_matrix,
             sample_configuration, population_growth_rates, population_sizes,
             population_growth_rate_changes, population_size_changes,
-            migration_matrix_element_changes, bottlenecks, model='hudson',
-            from_ts=None, max_segments=100, num_labels=1, sweep_trajectory=None,
-            full_arg=False, time_slice=None, gene_conversion_rate=0.0,
-            gene_conversion_length=1):
+            migration_matrix_element_changes, bottlenecks, census_times,
+            model='hudson', from_ts=None, max_segments=100, num_labels=1,
+            sweep_trajectory=None, full_arg=False, time_slice=None,
+            gene_conversion_rate=0.0, gene_conversion_length=1):
         # Must be a square matrix.
         N = len(migration_matrix)
         assert len(sample_configuration) == N
@@ -423,6 +431,8 @@ class Simulator(object):
         for time, pop_id, intensity in bottlenecks:
             self.modifier_events.append(
                 (time, self.bottleneck_event, (int(pop_id), 0, intensity)))
+        for time in census_times:
+            self.modifier_events.append((time[0], self.census_event, time))
         self.modifier_events.sort()
 
     def initialise_from_ts(self, ts):
@@ -1148,6 +1158,18 @@ class Simulator(object):
                 u = u.next
             print(s)
 
+    def census_event(self, time):
+        for pop in self.P:
+            for ancestor in pop.iter_ancestors():
+                seg = ancestor
+                self.flush_edges()
+                u = self.tables.nodes.add_row(time=time, flags=18, population=pop._id)
+                while seg is not None:
+                    # Add an edge joining the segment to the new node.
+                    self.store_edge(seg.left, seg.right, u, seg.node)
+                    seg.node = u
+                    seg = seg.next
+
     def bottleneck_event(self, pop_id, label, intensity):
         # self.print_state()
         # Merge some of the ancestors.
@@ -1525,7 +1547,7 @@ def run_simulate(args):
         population_sizes, args.population_growth_rate_change,
         args.population_size_change,
         args.migration_matrix_element_change,
-        args.bottleneck, args.model, from_ts=args.from_ts,
+        args.bottleneck, args.census_time, args.model, from_ts=args.from_ts,
         max_segments=10000, num_labels=num_labels, full_arg=args.full_arg,
         sweep_trajectory=sweep_trajectory, time_slice=args.time_slice,
         gene_conversion_rate=gamma, gene_conversion_length=mean_tracklength)
@@ -1571,6 +1593,8 @@ def add_simulator_arguments(parser):
         action="append", default=[])
     parser.add_argument(
         "--bottleneck", type=float, nargs=3, action="append", default=[])
+    parser.add_argument(
+        "--census-time", type=float, nargs=1, action="append", default=[])
     parser.add_argument(
         "--trajectory", type=float, nargs=3, default=None,
         help="Parameters for the allele frequency trajectory simulation")

--- a/algorithms.py
+++ b/algorithms.py
@@ -1163,7 +1163,8 @@ class Simulator(object):
             for ancestor in pop.iter_ancestors():
                 seg = ancestor
                 self.flush_edges()
-                u = self.tables.nodes.add_row(time=time, flags=18, population=pop._id)
+                u = self.tables.nodes.add_row(
+                        time=time, flags=msprime.NODE_IS_CEN_EVENT, population=pop._id)
                 while seg is not None:
                     # Add an edge joining the segment to the new node.
                     self.store_edge(seg.left, seg.right, u, seg.node)

--- a/docs/_static/ts_with_census_nodes.svg
+++ b/docs/_static/ts_with_census_nodes.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<svg baseProfile="full" height="200" version="1.1" width="800" xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <g id="tree_0">
+      <g fill="none" id="edges" stroke="black">
+        <path d="M 61.0 35.176255815431134 V 30.0 H 95.0" id="edge_0_9"/>
+        <path d="M 61.0 61.18923495843269 V 35.176255815431134 H 61.0" id="edge_0_5"/>
+        <path d="M 44.0 140.0 V 61.18923495843269 H 61.0" id="edge_0_1"/>
+        <path d="M 78.0 140.0 V 61.18923495843269 H 61.0" id="edge_0_3"/>
+        <path d="M 129.0 35.176255815431134 V 30.0 H 95.0" id="edge_0_12"/>
+        <path d="M 129.0 90.73101938631363 V 35.176255815431134 H 129.0" id="edge_0_4"/>
+        <path d="M 112.0 140.0 V 90.73101938631363 H 129.0" id="edge_0_0"/>
+        <path d="M 146.0 140.0 V 90.73101938631363 H 129.0" id="edge_0_2"/>
+      </g>
+      <g id="symbols">
+        <g class="nodes">
+          <circle cx="95.0" cy="30.0" id="node_0_14" r="3"/>
+          <circle cx="61.0" cy="35.176255815431134" id="node_0_9" r="3"/>
+          <circle cx="61.0" cy="61.18923495843269" id="node_0_5" r="3"/>
+          <circle cx="44.0" cy="140.0" id="node_0_1" r="3"/>
+          <circle cx="78.0" cy="140.0" id="node_0_3" r="3"/>
+          <circle cx="129.0" cy="35.176255815431134" id="node_0_12" r="3"/>
+          <circle cx="129.0" cy="90.73101938631363" id="node_0_4" r="3"/>
+          <circle cx="112.0" cy="140.0" id="node_0_0" r="3"/>
+          <circle cx="146.0" cy="140.0" id="node_0_2" r="3"/>
+        </g>
+        <g class="mutations" fill="red"/>
+      </g>
+      <g font-size="14" id="labels">
+        <g class="nodes">
+          <g text-anchor="start">
+            <text x="134.0" y="30.176255815431134">12</text>
+          </g>
+          <g text-anchor="middle">
+            <text x="95.0" y="25.0">14</text>
+            <text x="44.0" y="160.0">1</text>
+            <text x="78.0" y="160.0">3</text>
+            <text x="112.0" y="160.0">0</text>
+            <text x="146.0" y="160.0">2</text>
+          </g>
+          <g text-anchor="end">
+            <text x="56.0" y="30.176255815431134">9</text>
+            <text x="56.0" y="56.18923495843269">5</text>
+            <text x="124.0" y="85.73101938631363">4</text>
+          </g>
+        </g>
+        <g class="mutations" font-style="italic">
+          <g text-anchor="start"/>
+          <g text-anchor="end"/>
+        </g>
+      </g>
+    </g>
+    <g id="tree_1">
+      <g fill="none" id="edges" stroke="black">
+        <path d="M 44.0 35.176255815431134 V 30.0 H 73.75" id="edge_1_10"/>
+        <path d="M 44.0 140.0 V 35.176255815431134 H 44.0" id="edge_1_3"/>
+        <path d="M 103.5 35.176255815431134 V 30.0 H 73.75" id="edge_1_13"/>
+        <path d="M 103.5 51.214709608992834 V 35.176255815431134 H 103.5" id="edge_1_6"/>
+        <path d="M 78.0 140.0 V 51.214709608992834 H 103.5" id="edge_1_1"/>
+        <path d="M 129.0 90.73101938631363 V 51.214709608992834 H 103.5" id="edge_1_4"/>
+        <path d="M 112.0 140.0 V 90.73101938631363 H 129.0" id="edge_1_0"/>
+        <path d="M 146.0 140.0 V 90.73101938631363 H 129.0" id="edge_1_2"/>
+      </g>
+      <g id="symbols">
+        <g class="nodes">
+          <circle cx="73.75" cy="30.0" id="node_1_14" r="3"/>
+          <circle cx="44.0" cy="35.176255815431134" id="node_1_10" r="3"/>
+          <circle cx="44.0" cy="140.0" id="node_1_3" r="3"/>
+          <circle cx="103.5" cy="35.176255815431134" id="node_1_13" r="3"/>
+          <circle cx="103.5" cy="51.214709608992834" id="node_1_6" r="3"/>
+          <circle cx="78.0" cy="140.0" id="node_1_1" r="3"/>
+          <circle cx="129.0" cy="90.73101938631363" id="node_1_4" r="3"/>
+          <circle cx="112.0" cy="140.0" id="node_1_0" r="3"/>
+          <circle cx="146.0" cy="140.0" id="node_1_2" r="3"/>
+        </g>
+        <g class="mutations" fill="red"/>
+      </g>
+      <g font-size="14" id="labels">
+        <g class="nodes">
+          <g text-anchor="start">
+            <text x="108.5" y="30.176255815431134">13</text>
+            <text x="134.0" y="85.73101938631363">4</text>
+          </g>
+          <g text-anchor="middle">
+            <text x="73.75" y="25.0">14</text>
+            <text x="44.0" y="160.0">3</text>
+            <text x="78.0" y="160.0">1</text>
+            <text x="112.0" y="160.0">0</text>
+            <text x="146.0" y="160.0">2</text>
+          </g>
+          <g text-anchor="end">
+            <text x="39.0" y="30.176255815431134">10</text>
+            <text x="98.5" y="46.214709608992834">6</text>
+          </g>
+        </g>
+        <g class="mutations" font-style="italic">
+          <g text-anchor="start"/>
+          <g text-anchor="end"/>
+        </g>
+      </g>
+    </g>
+    <g id="tree_2">
+      <g fill="none" id="edges" stroke="black">
+        <path d="M 61.0 35.176255815431134 V 30.0 H 95.0" id="edge_2_13"/>
+        <path d="M 61.0 51.214709608992834 V 35.176255815431134 H 61.0" id="edge_2_6"/>
+        <path d="M 44.0 140.0 V 51.214709608992834 H 61.0" id="edge_2_1"/>
+        <path d="M 78.0 140.0 V 51.214709608992834 H 61.0" id="edge_2_0"/>
+        <path d="M 129.0 35.176255815431134 V 30.0 H 95.0" id="edge_2_11"/>
+        <path d="M 129.0 43.586495834035034 V 35.176255815431134 H 129.0" id="edge_2_7"/>
+        <path d="M 112.0 140.0 V 43.586495834035034 H 129.0" id="edge_2_2"/>
+        <path d="M 146.0 140.0 V 43.586495834035034 H 129.0" id="edge_2_3"/>
+      </g>
+      <g id="symbols">
+        <g class="nodes">
+          <circle cx="95.0" cy="30.0" id="node_2_14" r="3"/>
+          <circle cx="61.0" cy="35.176255815431134" id="node_2_13" r="3"/>
+          <circle cx="61.0" cy="51.214709608992834" id="node_2_6" r="3"/>
+          <circle cx="44.0" cy="140.0" id="node_2_1" r="3"/>
+          <circle cx="78.0" cy="140.0" id="node_2_0" r="3"/>
+          <circle cx="129.0" cy="35.176255815431134" id="node_2_11" r="3"/>
+          <circle cx="129.0" cy="43.586495834035034" id="node_2_7" r="3"/>
+          <circle cx="112.0" cy="140.0" id="node_2_2" r="3"/>
+          <circle cx="146.0" cy="140.0" id="node_2_3" r="3"/>
+        </g>
+        <g class="mutations" fill="red"/>
+      </g>
+      <g font-size="14" id="labels">
+        <g class="nodes">
+          <g text-anchor="start">
+            <text x="134.0" y="30.176255815431134">11</text>
+          </g>
+          <g text-anchor="middle">
+            <text x="95.0" y="25.0">14</text>
+            <text x="44.0" y="160.0">1</text>
+            <text x="78.0" y="160.0">0</text>
+            <text x="112.0" y="160.0">2</text>
+            <text x="146.0" y="160.0">3</text>
+          </g>
+          <g text-anchor="end">
+            <text x="56.0" y="30.176255815431134">13</text>
+            <text x="56.0" y="46.214709608992834">6</text>
+            <text x="124.0" y="38.586495834035034">7</text>
+          </g>
+        </g>
+        <g class="mutations" font-style="italic">
+          <g text-anchor="start"/>
+          <g text-anchor="end"/>
+        </g>
+      </g>
+    </g>
+    <g id="tree_3">
+      <g fill="none" id="edges" stroke="black">
+        <path d="M 61.0 72.9818431091519 V 30.0 H 95.0" id="edge_3_8"/>
+        <path d="M 61.0 83.23589023354155 V 72.9818431091519 H 61.0" id="edge_3_6"/>
+        <path d="M 44.0 140.0 V 83.23589023354155 H 61.0" id="edge_3_1"/>
+        <path d="M 78.0 140.0 V 83.23589023354155 H 61.0" id="edge_3_0"/>
+        <path d="M 129.0 72.9818431091519 V 30.0 H 95.0" id="edge_3_11"/>
+        <path d="M 129.0 78.35885753886026 V 72.9818431091519 H 129.0" id="edge_3_7"/>
+        <path d="M 112.0 140.0 V 78.35885753886026 H 129.0" id="edge_3_2"/>
+        <path d="M 146.0 140.0 V 78.35885753886026 H 129.0" id="edge_3_3"/>
+      </g>
+      <g id="symbols">
+        <g class="nodes">
+          <circle cx="95.0" cy="30.0" id="node_3_15" r="3"/>
+          <circle cx="61.0" cy="72.9818431091519" id="node_3_8" r="3"/>
+          <circle cx="61.0" cy="83.23589023354155" id="node_3_6" r="3"/>
+          <circle cx="44.0" cy="140.0" id="node_3_1" r="3"/>
+          <circle cx="78.0" cy="140.0" id="node_3_0" r="3"/>
+          <circle cx="129.0" cy="72.9818431091519" id="node_3_11" r="3"/>
+          <circle cx="129.0" cy="78.35885753886026" id="node_3_7" r="3"/>
+          <circle cx="112.0" cy="140.0" id="node_3_2" r="3"/>
+          <circle cx="146.0" cy="140.0" id="node_3_3" r="3"/>
+        </g>
+        <g class="mutations" fill="red"/>
+      </g>
+      <g font-size="14" id="labels">
+        <g class="nodes">
+          <g text-anchor="start">
+            <text x="134.0" y="67.9818431091519">11</text>
+          </g>
+          <g text-anchor="middle">
+            <text x="95.0" y="25.0">15</text>
+            <text x="44.0" y="160.0">1</text>
+            <text x="78.0" y="160.0">0</text>
+            <text x="112.0" y="160.0">2</text>
+            <text x="146.0" y="160.0">3</text>
+          </g>
+          <g text-anchor="end">
+            <text x="56.0" y="67.9818431091519">8</text>
+            <text x="56.0" y="78.23589023354155">6</text>
+            <text x="124.0" y="73.35885753886026">7</text>
+          </g>
+        </g>
+        <g class="mutations" font-style="italic">
+          <g text-anchor="start"/>
+          <g text-anchor="end"/>
+        </g>
+      </g>
+    </g>
+  </defs>
+  <use x="20" xlink:href="#tree_0" y="15"/>
+  <use x="210.0" xlink:href="#tree_1" y="15"/>
+  <use x="400.0" xlink:href="#tree_2" y="15"/>
+  <use x="590.0" xlink:href="#tree_3" y="15"/>
+  <line stroke="black" x1="20" x2="780" y1="180" y2="180"/>
+  <line stroke="black" x1="20" x2="20" y1="175" y2="185"/>
+  <text font-size="14" font-weight="bold" text-anchor="middle" x="20" y="200">0.00</text>
+  <line stroke="black" x1="210.0" x2="210.0" y1="175" y2="185"/>
+  <text font-size="14" font-weight="bold" text-anchor="middle" x="210.0" y="200">263.22</text>
+  <line stroke="black" x1="400.0" x2="400.0" y1="175" y2="185"/>
+  <text font-size="14" font-weight="bold" text-anchor="middle" x="400.0" y="200">677.81</text>
+  <line stroke="black" x1="590.0" x2="590.0" y1="175" y2="185"/>
+  <text font-size="14" font-weight="bold" text-anchor="middle" x="590.0" y="200">938.66</text>
+  <line stroke="black" x1="780.0" x2="780.0" y1="175" y2="185"/>
+  <text font-size="14" font-weight="bold" text-anchor="middle" x="780.0" y="200">1000.00</text>
+</svg>

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -111,6 +111,8 @@ more details on the migration rates.
 
 .. autoclass:: msprime.PopulationConfiguration
 
+.. _sec_api_demographic_events:
+
 ******************
 Demographic Events
 ******************
@@ -127,6 +129,9 @@ and all rates are per-generation.
 .. autoclass:: msprime.MigrationRateChange
 .. autoclass:: msprime.MassMigration
 .. autoclass:: msprime.SimulationModelChange
+
+.. _sec_api_demographic_events_census:
+
 .. autoclass:: msprime.CensusEvent
 
 ++++++++++++++++++++++++++++
@@ -355,7 +360,7 @@ flags values are defined:
 
 .. data:: msprime.NODE_IS_CEN_EVENT
 
-    The node was created by a `msprime.CensusEvent`.
+    The node was created by a :class:`msprime.CensusEvent`.
 
 
 ********************

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -127,6 +127,7 @@ and all rates are per-generation.
 .. autoclass:: msprime.MigrationRateChange
 .. autoclass:: msprime.MassMigration
 .. autoclass:: msprime.SimulationModelChange
+.. autoclass:: msprime.CensusEvent
 
 ++++++++++++++++++++++++++++
 Debugging demographic models
@@ -351,6 +352,10 @@ flags values are defined:
     The node is an ARG migration event identifying the individual that migrated.
     Can be used in combination with the ``record_migrations`` argument to
     :func:`.simulate`.
+
+.. data:: msprime.NODE_IS_CEN_EVENT
+
+    The node was created by a `msprime.CensusEvent`.
 
 
 ********************

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -618,6 +618,102 @@ Once you are satisfied that the demographic history that you have built
 is correct, it can then be simulated by calling the :func:`.simulate`
 function.
 
+-------------
+Census events
+-------------
+
+Census events allow you to add a node to each branch of the tree sequence at a given time during the simulation. This can be useful when you wish to study haplotypes that are ancestral to your simulated sample.
+
+For instance, the following code specifies a simulation with two samples drawn from each of two populations. There are two demographic events: a migration rate change and a census event. At generation 100 and earlier, the two populations exchange migrants at a rate of 0.05. At generation 5000, a census is performed.
+
+.. code-block:: python
+
+    >>> pop_config = msprime.PopulationConfiguration(sample_size=2, initial_size=1000)
+    >>> mig_rate_change = msprime.MigrationRateChange(time=100, rate=0.05)
+    >>> ts = msprime.simulate(
+                population_configurations=[pop_config, pop_config],
+                length=1000,
+                demographic_events=[mig_rate_change, msprime.CensusEvent(time=5000)],
+                recombination_rate=1e-7,
+                random_seed=141)
+
+The resulting tree sequence has nodes on each tree at the specified census time. These are the nodes with IDs 9, 10, 11, 12 and 13:
+
+.. code-block:: python
+
+    >>> for tree in ts.trees():
+        print(tree.draw(format="unicode"))
+
+      14   
+     ┏━┻━┓ 
+     9  12 
+     ┃   ┃ 
+     5   ┃ 
+    ┏┻┓  ┃ 
+    ┃ ┃  4 
+    ┃ ┃ ┏┻┓
+    1 3 0 2
+
+     14     
+    ┏━┻━┓   
+    10 13   
+    ┃   ┃   
+    ┃   6   
+    ┃  ┏┻━┓ 
+    ┃  ┃  4 
+    ┃  ┃ ┏┻┓
+    3  1 0 2
+
+      14   
+     ┏━┻━┓ 
+    13  11 
+     ┃   ┃ 
+     ┃   7 
+     ┃  ┏┻┓
+     6  ┃ ┃
+    ┏┻┓ ┃ ┃
+    1 0 2 3
+
+      15   
+     ┏━┻━┓ 
+     8  11 
+     ┃   ┃ 
+     ┃   7 
+     ┃  ┏┻┓
+     6  ┃ ┃
+    ┏┻┓ ┃ ┃
+    1 0 2 3
+
+This tells us that the genetic material ancestral to the present day sample was held within 5 haplotypes at time 5000. The node table shows us that three of these haplotypes (nodes 9, 10 and 11) were in population 0 at this time, and two of these haplotypes (nodes 12 and 13) were in population 1 at this time.
+
+.. code-block:: python
+
+    >>> print(ts.tables.nodes)
+    id  flags   population  individual  time    metadata
+    0   1       0   -1  0.00000000000000    
+    1   1       0   -1  0.00000000000000    
+    2   1       1   -1  0.00000000000000    
+    3   1       1   -1  0.00000000000000    
+    4   0       1   -1  2350.08685279051815 
+    5   0       1   -1  3759.20387382847684 
+    6   0       0   -1  4234.97992185234671 
+    7   0       1   -1  4598.83898042243527 
+    8   1048576 0   -1  5000.00000000000000 
+    9   1048576 0   -1  5000.00000000000000 
+    10  1048576 0   -1  5000.00000000000000 
+    11  1048576 0   -1  5000.00000000000000 
+    12  1048576 1   -1  5000.00000000000000 
+    13  1048576 1   -1  5000.00000000000000 
+    14  0       1   -1  5246.90282987397495 
+    15  0       0   -1  8206.73121309170347
+
+If we wish to study these ancestral haplotypes further, we can simplify the tree sequence with respect to the census nodes and perform subsequent analyses on this simplified tree sequence:
+
+.. code-block:: python
+
+    >>> nodes = [i.id for i in list(ts.nodes()) if i.flags==msprime.NODE_IS_CEN_EVENT]
+    >>> ts_anc = ts.simplify(samples=nodes)
+
 ******************
 Recombination maps
 ******************

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -618,13 +618,21 @@ Once you are satisfied that the demographic history that you have built
 is correct, it can then be simulated by calling the :func:`.simulate`
 function.
 
+.. _sec_tutorial_demography_census:
+
 -------------
 Census events
 -------------
 
-Census events allow you to add a node to each branch of the tree sequence at a given time during the simulation. This can be useful when you wish to study haplotypes that are ancestral to your simulated sample.
+Census events allow you to add a node to each branch of the tree sequence at a given time
+during the simulation. This can be useful when you wish to study haplotypes that are
+ancestral to your simulated sample, or when you wish to know which lineages were present in
+which populations at specified times.
 
-For instance, the following code specifies a simulation with two samples drawn from each of two populations. There are two demographic events: a migration rate change and a census event. At generation 100 and earlier, the two populations exchange migrants at a rate of 0.05. At generation 5000, a census is performed.
+For instance, the following code specifies a simulation with two samples drawn from each of
+two populations. There are two demographic events: a migration rate change and a census
+event. At generation 100 and earlier, the two populations exchange migrants at a rate of
+0.05. At generation 5000, a census is performed:
 
 .. code-block:: python
 
@@ -637,54 +645,18 @@ For instance, the following code specifies a simulation with two samples drawn f
                 recombination_rate=1e-7,
                 random_seed=141)
 
-The resulting tree sequence has nodes on each tree at the specified census time. These are the nodes with IDs 9, 10, 11, 12 and 13:
+The resulting tree sequence has nodes on each tree at the specified census time.
+These are the nodes with IDs 8, 9, 10, 11, 12 and 13:
 
 .. code-block:: python
 
-    >>> for tree in ts.trees():
-        print(tree.draw(format="unicode"))
+    >>> display(SVG(ts.draw_svg()))
 
-      14   
-     ┏━┻━┓ 
-     9  12 
-     ┃   ┃ 
-     5   ┃ 
-    ┏┻┓  ┃ 
-    ┃ ┃  4 
-    ┃ ┃ ┏┻┓
-    1 3 0 2
+.. image:: _static/ts_with_census_nodes.svg
+   :width: 800px
+   :alt: A tree sequence with census nodes.
 
-     14     
-    ┏━┻━┓   
-    10 13   
-    ┃   ┃   
-    ┃   6   
-    ┃  ┏┻━┓ 
-    ┃  ┃  4 
-    ┃  ┃ ┏┻┓
-    3  1 0 2
-
-      14   
-     ┏━┻━┓ 
-    13  11 
-     ┃   ┃ 
-     ┃   7 
-     ┃  ┏┻┓
-     6  ┃ ┃
-    ┏┻┓ ┃ ┃
-    1 0 2 3
-
-      15   
-     ┏━┻━┓ 
-     8  11 
-     ┃   ┃ 
-     ┃   7 
-     ┃  ┏┻┓
-     6  ┃ ┃
-    ┏┻┓ ┃ ┃
-    1 0 2 3
-
-This tells us that the genetic material ancestral to the present day sample was held within 5 haplotypes at time 5000. The node table shows us that three of these haplotypes (nodes 9, 10 and 11) were in population 0 at this time, and two of these haplotypes (nodes 12 and 13) were in population 1 at this time.
+This tells us that the genetic material ancestral to the present day sample was held within 5 haplotypes at time 5000. The node table shows us that four of these haplotypes (nodes 8, 9, 10 and 11) were in population 0 at this time, and two of these haplotypes (nodes 12 and 13) were in population 1 at this time.
 
 .. code-block:: python
 
@@ -707,12 +679,18 @@ This tells us that the genetic material ancestral to the present day sample was 
     14  0       1   -1  5246.90282987397495 
     15  0       0   -1  8206.73121309170347
 
-If we wish to study these ancestral haplotypes further, we can simplify the tree sequence with respect to the census nodes and perform subsequent analyses on this simplified tree sequence:
+If we wish to study these ancestral haplotypes further, we can simplify the tree sequence
+with respect to the census nodes and perform subsequent analyses on this simplified tree
+sequence.
+In this example, ``ts_anc`` is a tree sequence obtained from the original tree sequence
+``ts`` by labelling the census nodes as samples and removing all nodes and edges that are 
+not ancestral to these census nodes.
 
 .. code-block:: python
 
-    >>> nodes = [i.id for i in list(ts.nodes()) if i.flags==msprime.NODE_IS_CEN_EVENT]
+    >>> nodes = [i.id for i in ts.nodes() if i.flags==msprime.NODE_IS_CEN_EVENT]
     >>> ts_anc = ts.simplify(samples=nodes)
+
 
 ******************
 Recombination maps

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4249,7 +4249,7 @@ msp_census_event(msp_t *self, demographic_event_t *event)
             node = ancestors->head;
 
             while (node != NULL){
-                seg = node->item;
+                seg = (segment_t *) node->item;
 
                 while (seg != NULL) {
                     // Add an edge to the edge table.
@@ -4263,9 +4263,9 @@ msp_census_event(msp_t *self, demographic_event_t *event)
                     if (ret < 0) {
                         goto out;
                     }
-                    u = ret;
+                    u = (tsk_id_t) ret;
                     // Add an edge joining the segment to the new node.
-                    ret = msp_store_edge(self, seg->left, seg->right, ret, seg->value);
+                    ret = msp_store_edge(self, seg->left, seg->right, u, seg->value);
                     if (ret != 0) {
                         goto out;
                     }

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4260,19 +4260,24 @@ msp_census_event(msp_t *self, demographic_event_t *event)
                     ret = tsk_node_table_add_row(&self->tables->nodes,
                             MSP_NODE_IS_CEN_EVENT, time, (population_id_t) i, TSK_NULL,
                             NULL, 0);
+                    if (ret < 0) {
+                        goto out;
+                    }
                     u = ret;
                     // Add an edge joining the segment to the new node.
                     ret = msp_store_edge(self, seg->left, seg->right, ret, seg->value);
+                    if (ret != 0) {
+                        goto out;
+                    }
                     // Modify segment node id.
                     seg->value = u;
-                    ret = 0;
                     seg = seg->next;
                 }
                 node = node->next;
             }
         }
     }
-
+    ret = 0;
 out:
     return ret;
 }

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -49,6 +49,7 @@
 #define MSP_NODE_IS_RE_EVENT    (1u << 17)
 #define MSP_NODE_IS_CA_EVENT    (1u << 18)
 #define MSP_NODE_IS_MIG_EVENT   (1u << 19)
+#define MSP_NODE_IS_CEN_EVENT   (1u << 20)
 
 /* Alphabets for mutation generator */
 #define MSP_ALPHABET_BINARY     0
@@ -342,6 +343,7 @@ int msp_add_simple_bottleneck(msp_t *self, double time, int population_id,
         double intensity);
 int msp_add_instantaneous_bottleneck(msp_t *self, double time, int population_id,
         double strength);
+int msp_add_census_event(msp_t *self, double time);
 
 int msp_initialise(msp_t *self);
 int msp_run(msp_t *self, double max_time, unsigned long max_events);

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -853,6 +853,12 @@ test_demographic_events(void)
             msp_add_simple_bottleneck(&msp, 10, -1, 0),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
 
+        CU_ASSERT_EQUAL(
+        	msp_add_census_event(&msp, -0.5),
+        	MSP_ERR_BAD_PARAM_VALUE);
+
+        ret = msp_add_census_event(&msp, 0.05);
+        CU_ASSERT_EQUAL(ret, 0);
         ret = msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_add_migration_rate_change(&msp, 0.2, 1, 2.0);
@@ -966,7 +972,7 @@ test_census_event(void)
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     recomb_map_t recomb_map;
     tsk_table_collection_t tables;
-    int no_census_nodes = 0;
+    int num_census_nodes = 0;
     int i;
 
     CU_ASSERT_FATAL(msp != NULL);
@@ -995,10 +1001,10 @@ test_census_event(void)
     /* Check there is more than 1 node at the census time. */
     for (i = 0; i < tables.nodes.num_rows; i++) {
         if (tables.nodes.time[i] == 0.5) {
-            no_census_nodes++;
+            num_census_nodes++;
         }
     }
-    CU_ASSERT_TRUE(no_census_nodes > 1);
+    CU_ASSERT_TRUE(num_census_nodes > 1);
 
     /* Free things. */
     ret = msp_free(msp);

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -1201,6 +1201,21 @@ class InstantaneousBottleneck(DemographicEvent):
                 self.population, self.strength))
 
 
+class CensusEvent(DemographicEvent):
+
+    def __init__(self, time):
+        super().__init__("census_event", time)
+
+    def get_ll_representation(self, num_populations):
+        return {
+            "type": self.type,
+            "time": self.time,
+        }
+
+    def __str__(self):
+        return "Census event"
+
+
 class SimulationModel(object):
     """
     Abstract superclass of all simulation models.

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -1210,6 +1210,7 @@ class CensusEvent(DemographicEvent):
     haplotypes: for instance to trace the local ancestry of a sample back to a
     set of contemporaneous ancestors, or to assess whether a subset of samples
     has coalesced more recently than the census time.
+    See the :ref:`tutorial<sec_tutorial_demography_census>` for an example.
 
     :param float time: The time at which this event occurs in generations.
     """

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -39,6 +39,7 @@ import _msprime
 from _msprime import NODE_IS_CA_EVENT  # NOQA
 from _msprime import NODE_IS_RE_EVENT  # NOQA
 from _msprime import NODE_IS_MIG_EVENT  # NOQA
+from _msprime import NODE_IS_CEN_EVENT  # NOQA
 
 # Make the low-level generator appear like its from this module
 # NOTE: Using these classes directly from client code is undocumented
@@ -1202,7 +1203,16 @@ class InstantaneousBottleneck(DemographicEvent):
 
 
 class CensusEvent(DemographicEvent):
+    """
+    An event that adds a node to each branch of every tree at a given time
+    during the simulation. This may be used to record all ancestral haplotypes
+    present at that time, and to extract other information related to these
+    haplotypes: for instance to trace the local ancestry of a sample back to a
+    set of contemporaneous ancestors, or to assess whether a subset of samples
+    has coalesced more recently than the census time.
 
+    :param float time: The time at which this event occurs in generations.
+    """
     def __init__(self, time):
         super().__init__("census_event", time)
 

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -340,7 +340,8 @@ class TestDemographyDebuggerOutput(unittest.TestCase):
             msprime.MigrationRateChange(0.2, rate=0),
             msprime.MigrationRateChange(0.4, matrix_index=(0, 1), rate=1),
             msprime.MigrationRateChange(0.4, matrix_index=(1, 0), rate=1),
-            msprime.InstantaneousBottleneck(0.5, population=0, strength=100)]
+            msprime.InstantaneousBottleneck(0.5, population=0, strength=100),
+            msprime.CensusEvent(0.55)]
         self.verify_debug(
             population_configurations, migration_matrix, demographic_events)
 

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -2524,14 +2524,16 @@ class TestCensusEvent(unittest.TestCase):
         """
         Verifies that a census event has been added correctly.
         """
-        # It would be better to get the census nodes using node flags.
-        census_ids = np.where(ts.tables.nodes.time == census_time)[0]
+        census_ids = np.where(ts.tables.nodes.flags == msprime.NODE_IS_CEN_EVENT)[0]
+        for u in census_ids:
+            self.assertEqual(ts.tables.nodes.time[u], census_time)
         self.assertGreater(len(census_ids), 1)
         # Check that all samples have a census ancestor on each tree.
         for tree in ts.trees():
             leaves = []
             census_nodes = [u for u in census_ids if u in list(tree.nodes())]
             for node in census_nodes:
+                self.assertEqual(len(tree.children(node)), 1)
                 le = list(tree.leaves(node))
                 leaves += le
             leaves.sort()


### PR DESCRIPTION
This is just a baby pull request I made so I can log some thoughts and issues as I go.

- `add_census_event()` will have to do something a little bit different in the case that `census_time` is the same as one of the randomly generated coalescence/migration/gene conversion etc. times.
- So far have been thinking about the Hudson simulator - might need to be modified if DTWF model is used instead.
 - Should make it so user can input a list of census times, rather than just a single time.