### PR TITLE
Plumbing for the log likelihood C code.

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -4079,6 +4079,11 @@ msprime_log_likelihood_arg(PyObject *self, PyObject *args, PyObject *kwds)
         goto out;
     }
 
+    if (recombination_rate <= 0) {
+        PyErr_SetString(PyExc_ValueError, "recombination_rate must be > 0");
+        goto out;
+    }
+
     /* Note: this will be inefficient here if we're building indexes for large
      * tables. */
     err = tsk_treeseq_init(&ts, tables->tables, TSK_BUILD_INDEXES);

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -146,7 +146,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik) {
         lik -= rate * (nodes->time[parent] - sim_time);
         sim_time = nodes->time[parent];
         if (nodes->flags[parent] & MSP_NODE_IS_RE_EVENT) {
-            while (edge < (tsk_id_t)edges->num_rows 
+            while (edge < (tsk_id_t)edges->num_rows
                     && edges->parent[edge] == parent) {
                 edge++;
             }

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -112,8 +112,9 @@ out:
 }
 
 int
-msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik) {
-    int ret = 1;
+msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik)
+{
+    int ret = 0;
     tsk_id_t i;
     tsk_size_t lineages = tsk_treeseq_get_num_samples(ts);
     double sim_time = 0;
@@ -130,6 +131,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik) {
     first_parent_edge = malloc(nodes->num_rows * sizeof(tsk_id_t));
     last_parent_edge = malloc(nodes->num_rows * sizeof(tsk_id_t));
     if (first_parent_edge == NULL || last_parent_edge == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
     memset(first_parent_edge, TSK_NULL, sizeof(tsk_id_t) * nodes->num_rows);
@@ -157,9 +159,6 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik) {
             if (gap <= 0) {
                 // we evaluate the density rather than probability
                 gap = 1;
-            }
-            if (rho <= 0) {
-                lik = -DBL_MAX;
             }
             lik += log(rho * gap);
         } else {

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,8 @@ includes = [libdir, tskroot, tskdir, kasdir]
 configurator = PathConfigurator()
 msp_source_files = [
     "msprime.c", "fenwick.c", "avl.c", "util.c",
-    "object_heap.c", "recomb_map.c", "mutgen.c"
+    "object_heap.c", "recomb_map.c", "mutgen.c",
+    "likelihood.c"
 ]
 tsk_source_files = ["core.c", "tables.c", "trees.c"]
 kas_source_files = ["kastore.c"]

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -447,12 +447,10 @@ class TestSimulatedExamples(unittest.TestCase):
 
     def test_no_recombination(self):
         ts = msprime.simulate(10, random_seed=2)
-        self.verify(ts, recombination_rate=0)
         self.verify(ts, recombination_rate=1)
 
     def test_small_arg_no_mutation(self):
         ts = msprime.simulate(
             5, recombination_rate=1, random_seed=12, record_full_arg=True)
         self.assertGreater(ts.num_edges, 10)
-        self.verify(ts, recombination_rate=0)
         self.verify(ts, recombination_rate=1)

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1977,3 +1977,14 @@ class TestLikelihood(unittest.TestCase):
                 _msprime.log_likelihood_arg(tables, bad_float, 1)
             with self.assertRaises(TypeError):
                 _msprime.log_likelihood_arg(tables, 1, bad_float)
+
+        for bad_rec_rate in [0, -1]:
+            with self.assertRaises(ValueError):
+                _msprime.log_likelihood_arg(tables, 1, recombination_rate=bad_rec_rate)
+
+    def test_bad_tables(self):
+        # Pass in a table collection that can't be made into a tree
+        # sequence.
+        lw_tables = _msprime.LightweightTableCollection()
+        with self.assertRaises(_msprime.LibraryError):
+            _msprime.log_likelihood_arg(lw_tables, 1, 1)


### PR DESCRIPTION
Here's the plumbing for part of the log likelihood code @JereKoskela, can you take a look through please?

I didn't hook up the mutation code as it's not clear to me why we're separating the two at this point. It seems more user-friendly to have a single function that'll return a single likelihood value rather than breaking it up into two. When we're computing lots of these things on slightly modified tree sequences then yes, we'll need it to be modular, but for now I think simpler is better. (In that case, we'll want an object to maintain state anyway, so it'll need a different interface; we want the simple functional approach as a building block anyway though).

I'd suggest we merge this much anyway, and hopefully you can update it with what's needed for the mutation stuff as a follow-up.