### PR TITLE
Debugging bizarre leak in ll module.

### DIFF
--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -260,6 +260,7 @@ def get_random_demographic_events(num_populations, num_events):
     return sorted_events
 
 
+@unittest.skip("tmp")
 class TestModule(tests.MsprimeTestCase):
     """
     Tests for module level stuff.
@@ -299,6 +300,7 @@ def get_random_population_models(n):
     return models
 
 
+@unittest.skip("tmp")
 class LowLevelTestCase(tests.MsprimeTestCase):
     """
     Superclass of tests for the low-level interface.
@@ -1929,6 +1931,7 @@ class TestMutationGenerator(unittest.TestCase):
             self.assertEqual(alphabet, mg.get_alphabet())
 
 
+# @unittest.skip("tmp")
 class TestDemographyDebugger(unittest.TestCase):
     """
     Tests for the demography debugging interface.
@@ -1940,23 +1943,24 @@ class TestDemographyDebugger(unittest.TestCase):
 
     def test_zero_events(self):
         sim = self.get_simulator([])
-        self.assertTrue(math.isinf(sim.debug_demography()))
+        # self.assertTrue(math.isinf(sim.debug_demography()))
 
-    def test_state_machine_errors(self):
-        sim = self.get_simulator([])
-        # It's an error to call debug_demography after run()
-        sim.run(1e-9)
-        self.assertRaises(_msprime.LibraryError, sim.debug_demography)
-        self.assertRaises(_msprime.LibraryError, sim.debug_demography)
-        sim.run()
-        # It's an error run after debug_demography
-        sim = self.get_simulator([])
-        self.assertTrue(math.isinf(sim.debug_demography()))
-        self.assertRaises(_msprime.LibraryError, sim.run)
-        self.assertRaises(_msprime.LibraryError, sim.run)
-        self.assertTrue(math.isinf(sim.debug_demography()))
+#     def test_state_machine_errors(self):
+#         sim = self.get_simulator([])
+#         # It's an error to call debug_demography after run()
+#         sim.run(1e-9)
+#         self.assertRaises(_msprime.LibraryError, sim.debug_demography)
+#         self.assertRaises(_msprime.LibraryError, sim.debug_demography)
+#         sim.run()
+#         # It's an error run after debug_demography
+#         sim = self.get_simulator([])
+#         self.assertTrue(math.isinf(sim.debug_demography()))
+#         self.assertRaises(_msprime.LibraryError, sim.run)
+#         self.assertRaises(_msprime.LibraryError, sim.run)
+#         self.assertTrue(math.isinf(sim.debug_demography()))
 
 
+# @unittest.skip("tmp")
 class TestLikelihood(unittest.TestCase):
     """
     Tests for the low-level likelihood calculation interface.


### PR DESCRIPTION
Opening a PR so I don't forget about this. This seems to be a minor and unpredictable memory leak, where we have to run the stress_lowlevel script several times for it to show up. Sometimes it runs and there's no memory leak; other times, the RSS keeps incrementing steadily. Weird.

It's not a serious leak, but we should track it down at some point.