### PR TITLE
Fix memory leak in low-level module.

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -2861,6 +2861,7 @@ out:
     Py_XDECREF(instantaneous_bottleneck_s);
     Py_XDECREF(initial_size_s);
     Py_XDECREF(growth_rate_s);
+    Py_XDECREF(census_event_s);
     return ret;
 }
 


### PR DESCRIPTION
The census-event string was not decrefed and we therefore leaked memory.

This was not released, and the leak was pretty minor, so no big deal.