### PR TITLE
Recomb map

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -206,6 +206,7 @@ typedef struct {
     size_t size;            /* the total number of values in the map */
     double *positions;
     double *rates;
+    double *cumulative;
 } recomb_map_t;
 
 typedef struct _msp_t {

--- a/lib/util.c
+++ b/lib/util.c
@@ -209,3 +209,30 @@ __msp_safe_free(void **ptr) {
         }
     }
 }
+
+/* Find the `index` of the interval within `values` the `query` fits, such that
+ * values[index-1] < query <= values[index]
+ * Will find the leftmost such index
+ * Assumes `values` are sorted
+ */
+size_t
+msp_binary_interval_search(double query, double *values, size_t n_values)
+{
+    if (n_values == 0) {
+        return 0;
+    }
+    size_t l = 0;
+    size_t r = n_values - 1;
+    size_t m;
+
+    while (l < r) {
+        m = (l + r) / 2UL;
+
+        if (values[m] < query) {
+            l = m + 1;
+        } else {
+            r = m;
+        }
+    }
+    return l;
+}

--- a/lib/util.h
+++ b/lib/util.h
@@ -20,6 +20,7 @@
 #define __UTIL_H__
 
 #include <stdbool.h>
+#include <math.h>
 
 #ifdef __GNUC__
     /*
@@ -86,5 +87,7 @@ const char * msp_strerror(int err);
 void __msp_safe_free(void **ptr);
 
 #define msp_safe_free(pointer) __msp_safe_free((void **) &(pointer))
+
+size_t msp_binary_interval_search(double query, double *values, size_t n_values);
 
 #endif /*__UTIL_H__*/


### PR DESCRIPTION
This should resolve #798.
Now the simulation with a recombination map have comparable runtimes to those with a fixed recomb rate.

Added a binary search for the recombination map positions in `recomb_map_genetic_to_phys`. Also needed to add a `cumulative` member to `recomb_map_t` that keeps track of the total recombination distance up to a position - this is what `s` was referring to [here](https://github.com/tskit-dev/msprime/blob/873a2124f0b6a5dd4295d5b8cf3ecf7597531abe/lib/recomb_map.c#L236) 