### PR TITLE
Add verification tests for recombination maps with msHOT

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -1,4 +1,4 @@
-all: scrm ms slim
+all: scrm ms msHOT slim
 
 slim:
 	rm -fR SLiM*
@@ -21,6 +21,11 @@ ms:
 	cp msdir/ms_summary_stats ./
 	cp msdir/sample_stats ./
 
+msHOT:
+	make -C msHOTdir
+	cp msHOTdir/msHOT ./
+	cp msHOTdir/msHOT_summary_stats ./
+
 discoal:
 	wget https://github.com/kern-lab/discoal/archive/v0.1.4.tar.gz
 	tar -xf v0.1.4.tar.gz
@@ -28,4 +33,4 @@ discoal:
 	cp discoal-0.1.4/discoal ./
 
 clean:
-	rm -fR scrm* ms ms_summary_stats sample_stats discoal* v0.1.4.tar.gz*
+	rm -fR scrm* ms ms_summary_stats msHOT msHOT_summary_stats sample_stats discoal* v0.1.4.tar.gz*

--- a/data/msHOTdir/Makefile
+++ b/data/msHOTdir/Makefile
@@ -1,0 +1,13 @@
+CC=gcc
+CFLAGS=-ansi -ggdb -Wno-unused-result -Wno-return-type
+SRC=msGCHOT.c streecGCHOT.c rand1.c
+all: msHOT msHOT_summary_stats
+
+msHOT_summary_stats: ${SRC}
+	${CC} ${CFLAGS} -DSUPPRESS_OUTPUT -DSUMMARY_STATS -o msHOT_summary_stats ${SRC} -lm
+
+msHOT: ${SRC}
+	${CC} ${CFLAGS} -o msHOT ${SRC} -lm
+
+clean:
+	rm msHOT msHOT_summary_stats

--- a/data/msHOTdir/README
+++ b/data/msHOTdir/README
@@ -1,0 +1,4 @@
+This is a copy of msHOT modified to obtain summary stats.
+The original version can be found at:
+
+https://uchicago.app.box.com/s/l3e5uf13tikfjm7e1il1eujitlsjdx13

--- a/data/msHOTdir/eca_funcsHOTmulti.h
+++ b/data/msHOTdir/eca_funcsHOTmulti.h
@@ -1,0 +1,43 @@
+#ifdef UN_EXTERN
+	#define GLOB
+#else
+	#define GLOB extern
+#endif
+
+
+/* function prototypes */
+
+int re_v(int nsam);  /* function that performs recombination, taking into account 
+						recombinational hotspots  */
+int cinr_V(int nsam, int nsite);
+
+int cleftr_V(int nsam);
+
+int crightr_V(int nsam);
+
+/*void fprint_coal_times(struct segl *seglist, int nsam, int nsegs, int nsites);
+  void pwise_coal_times(struct node *ptree, double **A, int nsam);*/
+
+/* Global variables */
+                  /* recombination:*/
+GLOB int *gHotSpotStart;
+GLOB int *gHotSpotEnd;
+
+GLOB int gNumHotSpots;  /* the number of recombination sites that have relative rates different
+							than one */
+GLOB double *gHSRates;
+/* the number of TIMES the background rate the crossover hotspot should be */
+
+                  /* gene conversion:*/
+GLOB int *gHotSpotStartGC;
+GLOB int *gHotSpotEndGC;
+
+//GLOB int gHotSpotStartGC;
+//GLOB int gHotSpotEndGC;
+
+GLOB int gNumHotSpotsGC;  /* the number of recombination sites that have relative rates different
+							than one */
+//GLOB double gHSRatesGC;
+GLOB double *gHSRatesGC;
+/* the number of TIMES the background rate the GC hotspot should be */
+

--- a/data/msHOTdir/ms.h
+++ b/data/msHOTdir/ms.h
@@ -1,0 +1,36 @@
+struct devent {
+	double time;
+	int popi;
+	int popj;
+	double paramv;
+	double **mat ;
+	char detype ;
+	struct devent *nextde;
+	} ;
+struct c_params {
+	int npop;
+	int nsam;
+	int *config;
+	double **mig_mat;
+	double r;
+	int nsites;
+	double f;
+	double track_len;
+	double *size;
+	double *alphag;
+	struct devent *deventlist ;
+	} ;
+struct m_params {
+	 double theta;
+	int segsitesin;
+	int treeflag;
+        int treelengthflag;
+	int mfreq;
+	 } ;
+struct params { 
+	struct c_params cp;
+	struct m_params mp;
+	int commandlineseedflag ;
+	};
+	
+

--- a/data/msHOTdir/msGCHOT.c
+++ b/data/msHOTdir/msGCHOT.c
@@ -1,15 +1,18 @@
+/* compile with gcc -o msHOT msGCHOT.c streecGCHOT.c rand1.c -lm */
+/*same as ms.c but with mutliple crossover and geneconv hotspots addition */
+
 /***** ms.c     ************************************************
 *
-*       Generates samples of gametes ( theta given or fixed number
+*       Generates samples of gametes ( theta given or fixed number 
 *						of segregating sites.)
-*	Usage is shown by typing ms without arguments.
+*	Usage is shown by typing ms without arguments.   
         usage: ms nsam howmany  -t  theta  [options]
 		or
-	       ms nsam howmany -s segsites  [options]
+	       ms nsam howmany -s segsites  [options] 
 
 	   nsam is the number of gametes per sample.
 	   howmany is the number of samples to produce.
-	   With -t the numbers of segregating sites will randomly vary
+	   With -t the numbers of segregating sites will randomly vary 
 		from one sample to the next.
 	   with -s segsites,  the number of segregating sites will be
 		segsites in each sample.
@@ -20,25 +23,25 @@
 *	  Arguments of the options are explained here:
 
            npop:  Number of subpopulations which make up the total population
-           ni:  the sample size from the i th subpopulation (all must be
+           ni:  the sample size from the i th subpopulation (all must be 
 		specified.) The output will have the gametes in order such that
 		the first n1 gametes are from the first island, the next n2 are
 		from the second island, etc.
            nsites: number of sites between which recombination can occur.
-           theta: 4No times the neutral mutation rate
+           theta: 4No times the neutral mutation rate 
            rho: recombination rate between ends of segment times 4No
 	   f: ratio of conversion rate to recombination rate. (Wiuf and Hein model.)
-	   track_len:  mean length of conversion track in units of sites.  The
+	   track_len:  mean length of conversion track in units of sites.  The 
 		       total number of sites is nsites, specified with the -r option.
            mig_rate: migration rate: the fraction of each subpop made up of
-                 migrants times 4No.
+                 migrants times 4No. 
            howmany: howmany samples to generate.
 
 	Note:  In the above definition, No is the total diploid population if
 		npop is one, otherwise, No is the diploid population size of each
-		subpopulation.
+		subpopulation. 
 	A seed file called "seedms" will be created  if it doesn't exist. The
-		seed(s) in this file will be modified by the program.
+		seed(s) in this file will be modified by the program. 
 		So subsequent runs
 		will produce new output.  The initial contents of seedms will be
 		printed on the second line of the output.
@@ -51,8 +54,8 @@
 		ones and ancestral alleles as zeros.
 	To compile:  cc -o ms  ms.c  streec.c  rand1.c -lm
 		or:  cc -o ms ms.c streec.c rand2.c -lm
-	 (Of course, gcc would be used instead of cc on some machines.  And -O3 or
-		some other optimization switches might be usefully employed with some
+	 (Of course, gcc would be used instead of cc on some machines.  And -O3 or 
+		some other optimization switches might be usefully employed with some 
 		compilers.) ( rand1.c uses drand48(), whereas rand2.c uses rand() ).
 
 *
@@ -74,7 +77,7 @@
 	Fixed bug which resulted in incorrect results for the case where
              rho = 0.0 and gene conversion rate > 0.0. This case was not handled
 	    correctly in early versions of the program. 5 Apr 2004.  (Thanks to
-	    Vincent Plagnol for pointing out this problem.)
+	    Vincent Plagnol for pointing out this problem.) 
 	Fixed bug in prtree().  Earlier versions may have produced garbage when the -T option was used.
 		 1 Jul 2004.
 	Fixed bug in -e. options that caused problems with -f option  13 Aug 2004.
@@ -84,25 +87,19 @@
 	    to Melissa Jane Todd-Hubisz for finding and reporting this bug.)
 	Added -seeds option 4 Nov 2006
 	Added "tbs" arguments feature 4 Nov 2006
-	Added -L option.  10 May 2007
-	Changed -ej option to set Mki = 0 pastward of the ej event.  See msdoc.pdf.  May 19 2007.
-	fixed bug with memory allocation when using -I option. This caused problems expecially on Windows
-          machines.  Thanks to several people, including Vitor Sousa and Stephane De Mita for help on this one.
-          Oct. 17, 2007.
-     Modified pickb() and pickbmf() to eliminate rare occurrence of fixed mutations Thanks to J. Liechty and K. Thornton. 4 Feb 2010.
-	Added -p n  switch to allow position output to be higher precision.  10 Nov 2012.
 ***************************************************************************/
 
 
-
+#define UN_EXTERN
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
 #include <assert.h>
 #include <string.h>
 #include "ms.h"
+#include "eca_funcsHOTmulti.h"
 
-#define SITESINC 10
+#define SITESINC 10 
 
 unsigned maxsites = SITESINC ;
 
@@ -120,8 +117,8 @@ struct segl {
 
 double *posit ;
 double segfac ;
-int count, ntbs, nseeds ;
-struct params pars ;
+int count, ntbs ;
+struct params pars ;	
 
 main(argc,argv)
         int argc;
@@ -130,14 +127,15 @@ main(argc,argv)
 	int i, k, howmany, segsites ;
 	char **list, **cmatrix(), **tbsparamstrs ;
 	FILE *pf, *fopen() ;
-	double probss, tmrca, ttot ;
+	double probss ;
 	void seedit( const char * ) ;
 	void getpars( int argc, char *argv[], int *howmany )  ;
-	int gensam( char **list, double *probss, double *ptmrca, double *pttot ) ;
+	int gensam( char **list, double *probss ) ;
 
 
 	ntbs = 0 ;   /* these next few lines are for reading in parameters from a file (for each sample) */
 	tbsparamstrs = (char **)malloc( argc*sizeof(char *) ) ;
+
 #ifndef SUPPRESS_OUTPUT
 	for( i=0; i<argc; i++) printf("%s ",argv[i]);
 #endif
@@ -145,12 +143,12 @@ main(argc,argv)
 	for( i =0; i<argc; i++) tbsparamstrs[i] = (char *)malloc(30*sizeof(char) ) ;
 	for( i = 1; i<argc ; i++)
 			if( strcmp( argv[i],"tbs") == 0 )  argv[i] = tbsparamstrs[ ntbs++] ;
-
+	
 	count=0;
 
 	if( ntbs > 0 )  for( k=0; k<ntbs; k++)  scanf(" %s", tbsparamstrs[k] );
 	getpars( argc, argv, &howmany) ;   /* results are stored in global variable, pars */
-
+	
 	if( !pars.commandlineseedflag ) seedit( "s");
 	pf = stdout ;
 
@@ -188,7 +186,7 @@ main(argc,argv)
 
     while( howmany-count++ ) {
 	   if( (ntbs > 0) && (count >1 ) ){
-	         for( k=0; k<ntbs; k++){
+	         for( k=0; k<ntbs; k++){ 
 			    if( scanf(" %s", tbsparamstrs[k]) == EOF ){
 			       if( !pars.commandlineseedflag ) seedit( "end" );
 				   exit(0);
@@ -196,7 +194,7 @@ main(argc,argv)
 			 }
 			 getpars( argc, argv, &howmany) ;
 	   }
-
+	   
 #ifndef SUPPRESS_OUTPUT
        fprintf(pf,"\n//");
 	   if( ntbs >0 ){
@@ -204,31 +202,29 @@ main(argc,argv)
 		}
 		printf("\n");
 #endif
-        segsites = gensam( list, &probss, &tmrca, &ttot ) ;
+        segsites = gensam( list, &probss ) ; 
 #ifndef SUPPRESS_OUTPUT
-  		if( pars.mp.timeflag ) fprintf(pf,"time:\t%lf\t%lf\n",tmrca, ttot ) ;
         if( (segsites > 0 ) || ( pars.mp.theta > 0.0 ) ) {
-   	       if( (pars.mp.segsitesin > 0 ) && ( pars.mp.theta > 0.0 ))
-		       fprintf(pf,"prob: %g\n", probss ) ;
            fprintf(pf,"segsites: %d\n",segsites);
-		   if( segsites > 0 )	fprintf(pf,"positions: ");
+	       if( (pars.mp.segsitesin > 0 ) && ( pars.mp.theta > 0.0 )) 
+		       fprintf(pf,"\nprob: %g", probss ) ;
+		   if( segsites > 0 )	fprintf(pf,"\npositions: ");
 		   for( i=0; i<segsites; i++)
-              fprintf(pf,"%6.*lf ", pars.output_precision,posit[i] );
+              fprintf(pf,"%6.4lf ",posit[i] );
            fprintf(pf,"\n");
-	       if( segsites > 0 )
+	       if( segsites > 0 ) 
 	          for(i=0;i<pars.cp.nsam; i++) { fprintf(pf,"%s\n", list[i] ); }
 	    }
 #endif
     }
 	if( !pars.commandlineseedflag ) seedit( "end" );
 
-    return 0;
 }
 
 
 
-	int
-gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
+	int 
+gensam( char **list, double *pprobss ) 
 {
 	int nsegs, h, i, k, j, seg, ns, start, end, len, segsit ;
 	struct segl *seglst, *segtre_mig(struct c_params *p, int *nsegs ) ; /* used to be: [MAXSEG];  */
@@ -246,7 +242,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 	nsites = pars.cp.nsites ;
 	nsinv = 1./nsites;
 	seglst = segtre_mig(&(pars.cp),  &nsegs ) ;
-
+	
 	nsam = pars.cp.nsam;
 	segsitesin = pars.mp.segsitesin ;
 	theta = pars.mp.theta ;
@@ -254,7 +250,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 
 	if( pars.mp.treeflag ) {
 	  	ns = 0 ;
-        for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+	    for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
 #ifndef SUPPRESS_OUTPUT
 	      if( (pars.cp.r > 0.0 ) || (pars.cp.f > 0.0) ){
 		     end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
@@ -264,32 +260,14 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 	      }
 	      prtree( seglst[seg].ptree, nsam ) ;
 #endif
-	      if( (segsitesin == 0) && ( theta == 0.0 ) && ( pars.mp.timeflag == 0 ) )
+	      if( (segsitesin == 0) && ( theta == 0.0 ) ) 
 	  	      free(seglst[seg].ptree) ;
 	    }
 	}
 
-	if( pars.mp.timeflag ) {
-      tt = 0.0 ;
-	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
-		if( mfreq > 1 ) ndes_setup( seglst[seg].ptree, nsam );
-		end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
-		start = seglst[seg].beg ;
-		if( (nsegs==1) || ( ( start <= nsites/2) && ( end >= nsites/2 ) ) )
-		  *ptmrca = (seglst[seg].ptree + 2*nsam-2) -> time ;
-		len = end - start + 1 ;
-		tseg = len/(double)nsites ;
-		if( mfreq == 1 ) tt += ttime(seglst[seg].ptree,nsam)*tseg ;
-		else tt += ttimemf(seglst[seg].ptree,nsam, mfreq)*tseg ;
-		if( (segsitesin == 0) && ( theta == 0.0 )  )
-	  	      free(seglst[seg].ptree) ;
-	    }
-		*pttot = tt ;
-	 }
-
     if( (segsitesin == 0) && ( theta > 0.0)   ) {
 	  ns = 0 ;
-	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
 		if( mfreq > 1 ) ndes_setup( seglst[seg].ptree, nsam );
 		end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
 		start = seglst[seg].beg ;
@@ -301,11 +279,11 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 		if( (segsit + ns) >= maxsites ) {
 			maxsites = segsit + ns + SITESINC ;
 			posit = (double *)realloc(posit, maxsites*sizeof(double) ) ;
-			  biggerlist(nsam, list) ;
+			  biggerlist(nsam, list) ; 
 		}
 		make_gametes(nsam,mfreq,seglst[seg].ptree,tt, segsit, ns, list );
 		free(seglst[seg].ptree) ;
-		locate(segsit,start*nsinv, len*nsinv,posit+ns);
+		locate(segsit,start*nsinv, len*nsinv,posit+ns);   
 		ns += segsit;
 	  }
     }
@@ -317,7 +295,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 
 
 	  tt = 0.0 ;
-	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
 		if( mfreq > 1 ) ndes_setup( seglst[seg].ptree, nsam );
 		end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
 		start = seglst[seg].beg ;
@@ -327,7 +305,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
                else pk[k] = ttimemf(seglst[seg].ptree,nsam, mfreq)*tseg ;
                  tt += pk[k] ;
 	  }
-	  if( theta > 0.0 ) {
+	  if( theta > 0.0 ) { 
 	    es = theta * tt ;
 	    *pprobss = exp( -es )*pow( es, (double) segsitesin) / segfac ;
 	  }
@@ -338,7 +316,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 	  else
             for( k=0; k<nsegs; k++) ss[k] = 0 ;
 	  ns = 0 ;
-	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+	  for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) { 
 		 end = ( k<nsegs-1 ? seglst[seglst[seg].next].beg -1 : nsites-1 );
 		 start = seglst[seg].beg ;
 		 len = end - start + 1 ;
@@ -346,7 +324,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 		 make_gametes(nsam,mfreq,seglst[seg].ptree,tt*pk[k]/tseg, ss[k], ns, list);
 
 		 free(seglst[seg].ptree) ;
-		 locate(ss[k],start*nsinv, len*nsinv,posit+ns);
+		 locate(ss[k],start*nsinv, len*nsinv,posit+ns);   
 		 ns += ss[k] ;
 	  }
 	  free(pk);
@@ -357,7 +335,7 @@ gensam( char **list, double *pprobss, double *ptmrca, double *pttot )
 	return( ns ) ;
 }
 
-	void
+	void 
 ndes_setup(struct node *ptree, int nsam )
 {
 	int i ;
@@ -375,13 +353,13 @@ biggerlist(nsam,  list )
 {
 	int i;
 
-/*  fprintf(stderr,"maxsites: %d\n",maxsites);  */
+/*  fprintf(stderr,"maxsites: %d\n",maxsites);  */	
 	for( i=0; i<nsam; i++){
 	   list[i] = (char *)realloc( list[i],maxsites*sizeof(char) ) ;
 	   if( list[i] == NULL ) perror( "realloc error. bigger");
 	   }
 }
-
+	   
 
 
 /* allocates space for gametes (character strings) */
@@ -416,21 +394,20 @@ locate(n,beg,len,ptr)
 
 }
 
-int NSEEDS = 3 ;
 
   void
 getpars(int argc, char *argv[], int *phowmany )
 {
 	int arg, i, j, sum , pop , argstart, npop , npop2, pop2 ;
 	double migr, mij, psize, palpha ;
-	void addtoelist( struct devent *pt, struct devent *elist );
-	void argcheck( int arg, int argc, char ** ) ;
-	int commandlineseed( char ** ) ;
+	//struct params p;
+	void addtoelist( struct devent *pt, struct devent *elist ); 
+	void argcheck( int arg, int argc, char ** ), commandlineseed( char ** ) ;
 	void free_eventlist( struct devent *pt, int npop );
 	struct devent *ptemp , *pt ;
 	FILE *pf ;
 	char ch3 ;
-
+	
 
   if( count == 0 ) {
 	if( argc < 4 ){ fprintf(stderr,"Too few command line arguments\n"); usage();}
@@ -439,17 +416,15 @@ getpars(int argc, char *argv[], int *phowmany )
 	*phowmany = atoi( argv[2] );
 	if( *phowmany  <= 0 ) { fprintf(stderr,"Second argument error. howmany <= 0. \n"); usage();}
 	pars.commandlineseedflag = 0 ;
-	  pars.output_precision = 4 ;
 	pars.cp.r = pars.mp.theta =  pars.cp.f = 0.0 ;
 	pars.cp.track_len = 0. ;
 	pars.cp.npop = npop = 1 ;
 	pars.cp.mig_mat = (double **)malloc( (unsigned) sizeof( double *) );
-	pars.cp.mig_mat[0] = (double *)malloc( (unsigned)sizeof(double ));
+	pars.cp.mig_mat[0] = (double *)malloc( (unsigned)sizeof(double *));
 	pars.cp.mig_mat[0][0] =  0.0 ;
 	pars.mp.segsitesin = 0 ;
 	pars.mp.treeflag = 0 ;
- 	pars.mp.timeflag = 0 ;
-       pars.mp.mfreq = 1 ;
+        pars.mp.mfreq = 1 ;
 	pars.cp.config = (int *) malloc( (unsigned)(( pars.cp.npop +1 ) *sizeof( int)) );
 	(pars.cp.config)[0] = pars.cp.nsam ;
 	pars.cp.size= (double *) malloc( (unsigned)( pars.cp.npop *sizeof( double )) );
@@ -463,6 +438,19 @@ getpars(int argc, char *argv[], int *phowmany )
 	free_eventlist( pars.cp.deventlist, npop );
   }
   	pars.cp.deventlist = NULL ;
+
+	/*  Eric's stuff for hotspots and ascertainment -- initializations */
+	gNumHotSpots = 0;
+	//gHotSpots = NULL;
+	//gHSRates = NULL;
+	gHSRates = NULL;
+	gHotSpotStart = NULL;
+	gHotSpotEnd = NULL;
+
+	gNumHotSpotsGC = 0;
+	gHSRatesGC = NULL;
+	gHotSpotStartGC = NULL;
+	gHotSpotEndGC = NULL;
 
 	arg = 3 ;
 
@@ -490,7 +478,7 @@ getpars(int argc, char *argv[], int *phowmany )
 				argc--;
 				arg = argstart ;
 				break;
-			case 'r' :
+			case 'r' : 
 				arg++;
 				argcheck( arg, argc, argv);
 				pars.cp.r = atof(  argv[arg++] );
@@ -500,13 +488,8 @@ getpars(int argc, char *argv[], int *phowmany )
 					fprintf(stderr,"with -r option must specify both rec_rate and nsites>1\n");
 					usage();
 					}
-				break;
-			case 'p' :
-				arg++;
-				argcheck(arg,argc,argv);
-				pars.output_precision = atoi( argv[arg++] ) ;
-				break;
-			case 'c' :
+				break;		
+			case 'c' : 
 				arg++;
 				argcheck( arg, argc, argv);
 				pars.cp.f = atof(  argv[arg++] );
@@ -516,25 +499,25 @@ getpars(int argc, char *argv[], int *phowmany )
 					fprintf(stderr,"with -c option must specify both f and track_len>0\n");
 					usage();
 					}
-				break;
-			case 't' :
+				break;		
+			case 't' : 
 				arg++;
 				argcheck( arg, argc, argv);
 				pars.mp.theta = atof(  argv[arg++] );
 				break;
-			case 's' :
+			case 's' : 
 				arg++;
 				argcheck( arg, argc, argv);
 				if( argv[arg-1][2] == 'e' ){  /* command line seeds */
 					pars.commandlineseedflag = 1 ;
-					if( count == 0 ) nseeds = commandlineseed(argv+arg );
-					arg += nseeds ;
+					if( count == 0 ) commandlineseed(argv+arg );
+					arg += 3 ;
 				}
 				else {
 				    pars.mp.segsitesin = atoi(  argv[arg++] );
 				}
 				break;
-			case 'F' :
+			case 'F' : 
 				arg++;
 				argcheck( arg, argc, argv);
 				pars.mp.mfreq = atoi(  argv[arg++] );
@@ -543,51 +526,43 @@ getpars(int argc, char *argv[], int *phowmany )
                                     usage();
                                     }
 				break;
-			case 'T' :
+			case 'T' : 
 				pars.mp.treeflag = 1 ;
 				arg++;
 				break;
-			case 'L' :
-				pars.mp.timeflag = 1 ;
+			case 'I' : 
 				arg++;
-				break;
-			case 'I' :
-			    arg++;
 			    if( count == 0 ) {
-				argcheck( arg, argc, argv);
-			       	pars.cp.npop = atoi( argv[arg]);
+				    argcheck( arg, argc, argv);
+					pars.cp.npop = atoi( argv[arg]);
 			        pars.cp.config = (int *) realloc( pars.cp.config, (unsigned)( pars.cp.npop*sizeof( int)));
-				npop = pars.cp.npop ;
+				    npop = pars.cp.npop ;
 				}
 			    arg++;
-			    for( i=0; i< pars.cp.npop; i++) {
-				argcheck( arg, argc, argv);
-				pars.cp.config[i] = atoi( argv[arg++]);
-				}
-			    if( count == 0 ){
-				pars.cp.mig_mat =
-                                        (double **)realloc(pars.cp.mig_mat, (unsigned)(pars.cp.npop*sizeof(double *) )) ;
-				pars.cp.mig_mat[0] =
-                                         (double *)realloc(pars.cp.mig_mat[0], (unsigned)( pars.cp.npop*sizeof(double)));
-				for(i=1; i<pars.cp.npop; i++) pars.cp.mig_mat[i] =
-                                         (double *)malloc( (unsigned)( pars.cp.npop*sizeof(double)));
-				pars.cp.size = (double *)realloc( pars.cp.size, (unsigned)( pars.cp.npop*sizeof( double )));
-				pars.cp.alphag =
-                                          (double *) realloc( pars.cp.alphag, (unsigned)( pars.cp.npop*sizeof( double )));
-			        for( i=1; i< pars.cp.npop ; i++) {
-				   (pars.cp.size)[i] = (pars.cp.size)[0]  ;
-				   (pars.cp.alphag)[i] = (pars.cp.alphag)[0] ;
+				for( i=0; i< pars.cp.npop; i++) {
+				   argcheck( arg, argc, argv);
+				   pars.cp.config[i] = atoi( argv[arg++]);
 				   }
-			        }
-			     if( (arg <argc) && ( argv[arg][0] != '-' ) ) {
-				argcheck( arg, argc, argv);
-				migr = atof(  argv[arg++] );
+				if( count == 0 ){
+				   pars.cp.mig_mat = (double **)realloc(pars.cp.mig_mat, (unsigned)(pars.cp.npop*sizeof(double *) )) ;
+				   for(i=0; i<pars.cp.npop; i++) pars.cp.mig_mat[i] = (double *)realloc(pars.cp.mig_mat[i],
+					   (unsigned)( pars.cp.npop*sizeof(double)));
+				   pars.cp.size = (double *) realloc( pars.cp.size, (unsigned)( pars.cp.npop*sizeof( double )));
+				   pars.cp.alphag = (double *) realloc( pars.cp.alphag, (unsigned)( pars.cp.npop*sizeof( double )));
 				}
-			     else migr = 0.0 ;
-			     for( i=0; i<pars.cp.npop; i++)
+				for( i=1; i< pars.cp.npop ; i++) {
+					 (pars.cp.size)[i] = (pars.cp.size)[0]  ;
+					(pars.cp.alphag)[i] = (pars.cp.alphag)[0] ;
+				}
+				if( (arg <argc) && ( argv[arg][0] != '-' ) ) {
+				  argcheck( arg, argc, argv);
+				  migr = atof(  argv[arg++] );
+				}
+				else migr = 0.0 ;
+				for( i=0; i<pars.cp.npop; i++) 
 				    for( j=0; j<pars.cp.npop; j++) pars.cp.mig_mat[i][j] = migr/(pars.cp.npop-1) ;
-			     for( i=0; i< pars.cp.npop; i++) pars.cp.mig_mat[i][i] = migr ;
-			     break;
+				for( i=0; i< pars.cp.npop; i++) pars.cp.mig_mat[i][i] = migr ;
+				break;
 			case 'm' :
 			     if( npop < 2 ) { fprintf(stderr,"Must use -I option first.\n"); usage();}
 			     if( argv[arg][2] == 'a' ) {
@@ -602,7 +577,7 @@ getpars(int argc, char *argv[], int *phowmany )
 					  for( pop2 = 0; pop2 < npop; pop2++){
 					    if( pop2 != pop ) pars.cp.mig_mat[pop][pop] += pars.cp.mig_mat[pop][pop2] ;
 					  }
-				    }
+				    }	
 				}
 			    else {
 		             arg++;
@@ -615,6 +590,78 @@ getpars(int argc, char *argv[], int *phowmany )
 		             pars.cp.mig_mat[i][i] += mij -  pars.cp.mig_mat[i][j]  ;
 		             pars.cp.mig_mat[i][j] = mij;
 			    }
+				break;
+			case 'v' :  /* case added by Eric Anderson to allow specification of recombinational
+							hotspots of different intensities  */
+				arg++;
+			        argcheck( arg, argc, argv);
+				gNumHotSpots = atoi(argv[arg++]);
+				gHotSpotStart = (int *)calloc((size_t)gNumHotSpots, sizeof(int));
+				gHotSpotEnd = (int *)calloc((size_t)gNumHotSpots, sizeof(int));
+				gHSRates = (double *)calloc((size_t)gNumHotSpots, sizeof(double));
+
+				for (i = 0; i<gNumHotSpots; i++)
+				  {
+				    argcheck( arg, argc, argv);
+				    gHotSpotStart[i] = atoi(argv[arg++]);
+				    gHotSpotStart[i] = gHotSpotStart[i]-1;
+				    argcheck( arg, argc, argv);
+				    gHotSpotEnd[i] = atoi(argv[arg++]);
+				    gHotSpotEnd[i] = gHotSpotEnd[i]-1;
+				    argcheck( arg, argc, argv);
+				    gHSRates[i] = atof(argv[arg++]);
+				    //printf("\n\n%d\n\n",p.cp.nsites);
+				    if ((gHotSpotStart[i] < 0) || (gHotSpotEnd[i] >= pars.cp.nsites))
+			             {
+				        fprintf(stderr,"\n\n At least one crossover hotspot is not contained within the sequence. Exiting....\n\n");
+					usage();
+				     }
+				    if(i>0 && gHotSpotStart[i]<=gHotSpotEnd[i-1])  
+				      {
+					fprintf(stderr,"\n\nHot spots overlapping or not listed in order.  Abort!...\n\n");
+					usage();
+				      }
+				    if(gHotSpotStart[i] >= gHotSpotEnd[i])
+				      {
+					fprintf(stderr,"\n\nHotspot locations entered incorrectly.\n\n");
+				 	usage();
+                                      }
+				  }
+				break;
+			case 'V' :  /* case added by GRH to allow specification of a single gene conversion hotspot of specified intensity in specified area*/
+				arg++;
+			        argcheck( arg, argc, argv);
+				gNumHotSpotsGC = atoi(argv[arg++]);
+				gHotSpotStartGC = (int *)calloc((size_t)gNumHotSpotsGC, sizeof(int));
+				gHotSpotEndGC = (int *)calloc((size_t)gNumHotSpotsGC, sizeof(int));
+				gHSRatesGC = (double *)calloc((size_t)gNumHotSpotsGC, sizeof(double));
+
+				for (i = 0; i<gNumHotSpotsGC; i++)
+				  {
+			            argcheck( arg, argc, argv);
+				    gHotSpotStartGC[i] = atoi(argv[arg++]);
+				    gHotSpotStartGC[i] = gHotSpotStartGC[i]-1;
+			            argcheck( arg, argc, argv);
+				    gHotSpotEndGC[i] = atoi(argv[arg++]);
+				    gHotSpotEndGC[i] = gHotSpotEndGC[i]-1;
+			            argcheck( arg, argc, argv);
+				    gHSRatesGC[i] = atof(argv[arg++]);
+                                    if ((gHotSpotStartGC[i] < 0) || (gHotSpotEndGC[i] >= pars.cp.nsites))
+			             { 
+                                       fprintf(stderr,"\n\n At least one gene conversion hotspot is not contained within the sequence. Exiting....\n\n");
+  	                               usage();
+                                     }
+				    if(i>0 && gHotSpotStartGC[i]<=gHotSpotEndGC[i-1])  
+				      {
+					fprintf(stderr,"\n\nGene Conv Hot spots overlapping or not listed in order.  Abort!...\n\n");
+					usage();
+				      }
+                                    if(gHotSpotStartGC[i] >= gHotSpotEndGC[i])
+                                      {
+                                        fprintf(stderr,"\n\nHotspot locations entered incorrectly.\n\n");
+					usage();
+                                      }
+				  }
 				break;
 			case 'n' :
 			     if( npop < 2 ) { fprintf(stderr,"Must use -I option first.\n"); usage();}
@@ -638,7 +685,7 @@ getpars(int argc, char *argv[], int *phowmany )
 			    arg++;
 			    if( arg >= argc ) { fprintf(stderr,"Not enough arg's after -G.\n"); usage(); }
 			    palpha = atof( argv[arg++] );
-			    for( i=0; i<pars.cp.npop; i++)
+			    for( i=0; i<pars.cp.npop; i++) 
 			       pars.cp.alphag[i] = palpha ;
 			   break;
 			case 'e' :
@@ -649,13 +696,13 @@ getpars(int argc, char *argv[], int *phowmany )
 			    argcheck( arg, argc, argv);
 			    pt->time = atof( argv[arg++] ) ;
 			    pt->nextde = NULL ;
-			    if( pars.cp.deventlist == NULL )
+			    if( pars.cp.deventlist == NULL ) 
 				    pars.cp.deventlist = pt ;
-			    else if ( pt->time < pars.cp.deventlist->time ) {
+			    else if ( pt->time < pars.cp.deventlist->time ) { 
 				    ptemp = pars.cp.deventlist ;
 				    pars.cp.deventlist = pt ;
-				    pt->nextde = ptemp ;
-				}
+				    pt->nextde = ptemp ;	
+				}	
 			    else
 				   addtoelist( pt, pars.cp.deventlist ) ;
 			    switch( pt->detype ) {
@@ -692,7 +739,7 @@ getpars(int argc, char *argv[], int *phowmany )
 				case 'm' :
 				  if( ch3 == 'a' ) {
 				     pt->detype = 'a' ;
-				     argcheck( arg, argc, argv);
+					 argcheck( arg, argc, argv);
 				     npop2 = atoi( argv[arg++] ) ;
 				     pt->mat = (double **)malloc( (unsigned)npop2*sizeof( double *) ) ;
 				     for( pop =0; pop <npop2; pop++){
@@ -700,7 +747,7 @@ getpars(int argc, char *argv[], int *phowmany )
 					   for( i=0; i<npop2; i++){
 					     if( i == pop ) arg++;
 					     else {
-				               argcheck( arg, argc, argv);
+				           argcheck( arg, argc, argv); 
 					       (pt->mat)[pop][i] = atof( argv[arg++] ) ;
 					     }
 					   }
@@ -710,7 +757,7 @@ getpars(int argc, char *argv[], int *phowmany )
 					    for( pop2 = 0; pop2 < npop2; pop2++){
 					       if( pop2 != pop ) (pt->mat)[pop][pop] += (pt->mat)[pop][pop2] ;
 					    }
-				     }
+				     }	
 				  }
 				  else {
 			            argcheck( arg, argc, argv);
@@ -733,7 +780,7 @@ getpars(int argc, char *argv[], int *phowmany )
 			default: fprintf(stderr," option default\n");  usage() ;
 			}
 		}
-		if( (pars.mp.theta == 0.0) && ( pars.mp.segsitesin == 0 ) && ( pars.mp.treeflag == 0 ) && (pars.mp.timeflag == 0) ) {
+		if( (pars.mp.theta == 0.0) && ( pars.mp.segsitesin == 0 ) && ( pars.mp.treeflag == 0 ) ) {
 			fprintf(stderr," either -s or -t or -T option must be used. \n");
 			usage();
 			exit(1);
@@ -757,46 +804,47 @@ argcheck( int arg, int argc, char *argv[] )
 	   exit(0);
 	  }
 }
-
+	
 	int
 usage()
 {
 fprintf(stderr,"usage: ms nsam howmany \n");
-fprintf(stderr,"  Options: \n");
+fprintf(stderr,"  Options: \n"); 
 fprintf(stderr,"\t -t theta   (this option and/or the next must be used. Theta = 4*N0*u )\n");
 fprintf(stderr,"\t -s segsites   ( fixed number of segregating sites)\n");
 fprintf(stderr,"\t -T          (Output gene tree.)\n");
 fprintf(stderr,"\t -F minfreq     Output only sites with freq of minor allele >= minfreq.\n");
 fprintf(stderr,"\t -r rho nsites     (rho here is 4Nc)\n");
 fprintf(stderr,"\t\t -c f track_len   (f = ratio of conversion rate to rec rate. tracklen is mean length.) \n");
-fprintf(stderr,"\t\t\t if rho = 0.,  f = 4*N0*g, with g the gene conversion rate.\n");
-fprintf(stderr,"\t -G alpha  ( N(t) = N0*exp(-alpha*t) .  alpha = -log(Np/Nr)/t\n");
-fprintf(stderr,"\t -I npop n1 n2 ... [mig_rate] (all elements of mig matrix set to mig_rate/(npop-1) \n");
-fprintf(stderr,"\t\t -m i j m_ij    (i,j-th element of mig matrix set to m_ij.)\n");
-fprintf(stderr,"\t\t -ma m_11 m_12 m_13 m_21 m_22 m_23 ...(Assign values to elements of migration matrix.)\n");
+fprintf(stderr,"\t\t\t if rho = 0.,  f = 4*N0*g, with g the gene conversion rate.\n"); 
+fprintf(stderr,"\t -G alpha  ( N(t) = N0*exp(-alpha*t) .  alpha = -log(Np/Nr)/t\n");      
+fprintf(stderr,"\t -I npop n1 n2 ... [mig_rate] (all elements of mig matrix set to mig_rate/(npop-1) \n");    
+fprintf(stderr,"\t\t -m i j m_ij    (i,j-th element of mig matrix set to m_ij.)\n"); 
+fprintf(stderr,"\t\t -ma m_11 m_12 m_13 m_21 m_22 m_23 ...(Assign values to elements of migration matrix.)\n"); 
 fprintf(stderr,"\t\t -n i size_i   (popi has size set to size_i*N0 \n");
-fprintf(stderr,"\t\t -g i alpha_i  (If used must appear after -M option.)\n");
+fprintf(stderr,"\t\t -g i alpha_i  (If used must appear after -M option.)\n"); 
 fprintf(stderr,"\t   The following options modify parameters at the time 't' specified as the first argument:\n");
-fprintf(stderr,"\t -eG t alpha  (Modify growth rate of all pop's.)\n");
-fprintf(stderr,"\t -eg t i alpha_i  (Modify growth rate of pop i.) \n");
-fprintf(stderr,"\t -eM t mig_rate   (Modify the mig matrix so all elements are mig_rate/(npop-1)\n");
-fprintf(stderr,"\t -em t i j m_ij    (i,j-th element of mig matrix set to m_ij at time t )\n");
-fprintf(stderr,"\t -ema t npop  m_11 m_12 m_13 m_21 m_22 m_23 ...(Assign values to elements of migration matrix.)\n");
-fprintf(stderr,"\t -eN t size  (Modify pop sizes. New sizes = size*N0 ) \n");
+fprintf(stderr,"\t -eG t alpha  (Modify growth rate of all pop's.)\n");     
+fprintf(stderr,"\t -eg t i alpha_i  (Modify growth rate of pop i.) \n");    
+fprintf(stderr,"\t -eM t mig_rate   (Modify the mig matrix so all elements are mig_rate/(npop-1)\n"); 
+fprintf(stderr,"\t -em t i j m_ij    (i,j-th element of mig matrix set to m_ij at time t )\n"); 
+fprintf(stderr,"\t -ema t npop  m_11 m_12 m_13 m_21 m_22 m_23 ...(Assign values to elements of migration matrix.)\n");  
+fprintf(stderr,"\t -eN t size  (Modify pop sizes. New sizes = size*N0 ) \n");    
 fprintf(stderr,"\t -en t i size_i  (Modify pop size of pop i.  New size of popi = size_i*N0 .)\n");
-fprintf(stderr,"\t -es t i proportion  (Split: pop i -> pop-i + pop-npop, npop increases by 1.\n");
+fprintf(stderr,"\t -es t i proportion  (Split: pop i -> pop-i + pop-npop, npop increases by 1.\n");    
 fprintf(stderr,"\t\t proportion is probability that each lineage stays in pop-i. (p, 1-p are admixt. proport.\n");
 fprintf(stderr,"\t\t Size of pop npop is set to N0 and alpha = 0.0 , size and alpha of pop i are unchanged.\n");
 fprintf(stderr,"\t -ej t i j   ( Join lineages in pop i and pop j into pop j\n");
-fprintf(stderr,"\t\t  size, alpha and M are unchanged.\n");
-fprintf(stderr,"\t  -f filename     ( Read command line arguments from file filename.)\n");
-fprintf(stderr,"\t  -p n ( Specifies the precision of the position output.  n is the number of digits after the decimal.)\n");
+fprintf(stderr,"\t\t  size, alpha and M are unchanged.\n");  
+fprintf(stderr,"\t -v J a_1 b_1 I_1 ... a_J b_J I_J  ( Incorporate J crossover hotspots, each of intensity I_j on [a_j,b_j] )\n");
+fprintf(stderr,"\t -V K a_1 b_1 I_1 ... a_K b_K I_K  ( Incorporate K gene conversion hotspots, each of intensity I_k on [a_k,b_k] )\n");
+fprintf(stderr,"\t  -f filename     ( Read command line arguments from file filename.)\n");  
 fprintf(stderr," See msdoc.pdf for explanation of these parameters.\n");
 
 exit(1);
 }
 	void
-addtoelist( struct devent *pt, struct devent *elist )
+addtoelist( struct devent *pt, struct devent *elist ) 
 {
 	struct devent *plast, *pevent, *ptemp  ;
 
@@ -810,12 +858,12 @@ addtoelist( struct devent *pt, struct devent *elist )
 	pt->nextde = ptemp ;
 }
 
-	void
+	void 
 free_eventlist( struct devent *pt, int npop )
 {
    struct devent *next ;
    int pop ;
-
+   
    while( pt != NULL){
 	  next = pt->nextde ;
 	  if( pt->detype == 'a' ) {
@@ -827,7 +875,7 @@ free_eventlist( struct devent *pt, int npop )
    }
 }
 
-
+	
 /************ make_gametes.c  *******************************************
 *
 *
@@ -840,7 +888,7 @@ free_eventlist( struct devent *pt, int npop )
 make_gametes(int nsam, int mfreq, struct node *ptree, double tt, int newsites, int ns, char **list )
 {
 	int  tip, j,  node ;
-        int pickb(int nsam, struct node *ptree, double tt),
+        int pickb(int nsam, struct node *ptree, double tt), 
             pickbmf(int nsam, int mfreq, struct node *ptree, double tt) ;
 
 	for(  j=ns; j< ns+newsites ;  j++ ) {
@@ -921,7 +969,7 @@ parens( struct node *ptree, int *descl, int *descr,  int noden)
 	parens( ptree, descl,descr, descl[noden] ) ;
 	printf(",");
 	parens(ptree, descl, descr, descr[noden] ) ;
-	if( (ptree+noden)->abv == 0 ) printf(");\n");
+	if( (ptree+noden)->abv == 0 ) printf(");\n"); 
 	else {
 	  time = (ptree + (ptree+noden)->abv )->time - (ptree+noden)->time ;
 	  printf("):%5.3lf", time );
@@ -947,7 +995,7 @@ pickb(nsam, ptree, tt)
 		y += (ptree + (ptree+i)->abv )->time - (ptree+i)->time ;
 		if( y >= x ) return( i ) ;
 		}
-	return( 2*nsam - 3  );  /* changed 4 Feb 2010 */
+	return( i );
 }
 
 	int
@@ -957,17 +1005,15 @@ pickbmf(nsam, mfreq, ptree, tt )
 	double tt;
 {
 	double x, y, ran1();
-	int i, lastbranch = 0 ;
+	int i;
 
 	x = ran1()*tt;
 	for( i=0, y=0; i < 2*nsam-2 ; i++) {
-	  if( ( (ptree+i)->ndes >= mfreq )  && ( (ptree+i)->ndes <= nsam-mfreq) ){
+	  if( ( (ptree+i)->ndes >= mfreq )  && ( (ptree+i)->ndes <= nsam-mfreq) )
 		y += (ptree + (ptree+i)->abv )->time - (ptree+i)->time ;
-		lastbranch = i ;    /* changed 4 Feb 2010 */
-	  }
 	  if( y >= x ) return( i ) ;
 	}
-	return( lastbranch );   /*  changed 4 Feb 2010 */
+	return( i );
 }
 
 /****  tdesn : returns 1 if tip is a descendant of node in *ptree, otherwise 0. **/
@@ -1070,20 +1116,15 @@ ranvec(n,pbuf)
 poisso(u)
 	double u;
 {
-	double  cump, ru, ran1(), p, gasdev(double, double) ;
+	double  cump, ru, ran1(), p, gasdev() ;
 	int i=1;
 
-	if( u > 30. ){
-	    i =  (int)(0.5 + gasdev(u,u)) ;
-	    if( i < 0 ) return( 0 ) ;
-	    else return( i ) ;
-	  }
-
+	if( u > 30. ) return( (int)(0.5 + gasdev(u,u)) );
 	ru = ran1();
 	p = exp(-u);
 	if( ru < p) return(0);
 	cump = p;
-
+	
 	while( ru > ( cump += (p *= u/i ) ) )
 		i++;
 	return(i);

--- a/data/msHOTdir/rand1.c
+++ b/data/msHOTdir/rand1.c
@@ -1,0 +1,58 @@
+/*  Link in this file for random number generation using drand48() */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+         double
+ran1()
+{
+        double drand48();
+        return( drand48() );
+}               
+
+
+	void seedit( char *flag )
+{
+	FILE *fopen(), *pfseed;
+	unsigned short seedv[3], seedv2[3],  *seed48(), *pseed ;
+	int i;
+
+	if( flag[0] == 's' ) {
+	   pfseed = fopen("seedms","r");
+	   if( pfseed == NULL ) {
+           seedv[0] = 3579 ; seedv[1] = 27011; seedv[2] = 59243; 
+	   }
+	   else {
+	       seedv2[0] = 3579; seedv2[1] = 27011; seedv2[2] = 59243; 
+           for(i=0;i<3;i++){ 
+		       if(  fscanf(pfseed," %hd",seedv+i) < 1 )
+		            seedv[i] = seedv2[i] ;
+		   }
+	       fclose( pfseed);
+	   }
+	   seed48( seedv );   
+
+       // DG: suppress output
+       //printf("\n%d %d %d\n", seedv[0], seedv[1], seedv[2] );
+	}
+	else {
+	     pfseed = fopen("seedms","w");
+         pseed = seed48(seedv);
+         fprintf(pfseed,"%d %d %d\n",pseed[0], pseed[1],pseed[2]);     
+	}
+}
+
+	void
+commandlineseed( char **seeds)
+{
+	unsigned short seedv[3], *seed48();
+	int i ;
+
+	seedv[0] = atoi( seeds[0] );
+	seedv[1] = atoi( seeds[1] );
+	seedv[2] = atoi( seeds[2] );
+    // DG: suppress output
+	//printf("\n%d %d %d\n", seedv[0], seedv[1], seedv[2] );
+
+	seed48(seedv);
+}

--- a/data/msHOTdir/rand1t.c
+++ b/data/msHOTdir/rand1t.c
@@ -1,0 +1,28 @@
+/*  Link in this file for random number generation using drand48() */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+         double
+ran1()
+{
+        double drand48();
+        return( drand48() );
+}               
+
+
+	void seedit( char *flag )
+{
+	FILE *fopen(), *pfseed;
+	unsigned short seedv[3], seedv2[3],  *seed48(), *pseed ;
+	int i;
+
+
+	if( flag[0] == 's' ){
+	  seedv[0] =  (unsigned short)time( NULL ) ;
+            seedv[1] = 27011; seedv[2] = 59243; 
+          seed48( seedv );   
+
+       printf("\n%d %d %d\n", seedv[0], seedv[1], seedv[2] );    
+	}
+}

--- a/data/msHOTdir/rand2.c
+++ b/data/msHOTdir/rand2.c
@@ -1,0 +1,36 @@
+/*  Link in this file for random number generation with rand() */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+	double
+ran1()
+{
+	int rand();
+	return( rand()/(RAND_MAX+1.0)  );
+}
+
+
+	void seedit( const char *flag)
+{
+	FILE *fopen(), *pfseed;
+	unsigned int seed2 ;
+
+  if( flag[0] == 's' ) {
+    pfseed = fopen("seedms","r");
+        if( pfseed == NULL ) {
+           seed2 = 59243; }
+        else {
+          fscanf(pfseed," %d",&seed2);
+          fclose( pfseed);
+          }
+          srand( seed2) ;
+
+        printf("\n%d\n", seed2 );    
+	}
+   else {
+	pfseed = fopen("seedms","w");
+        fprintf(pfseed,"%d \n",rand());  
+
+	}
+}

--- a/data/msHOTdir/rand2t.c
+++ b/data/msHOTdir/rand2t.c
@@ -1,0 +1,25 @@
+/*  Link in this file for random number generation with rand()
+     and seeding from the clock  */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+	double
+ran1()
+{
+	int rand();
+	return( rand()/(RAND_MAX+1.0)  );
+}
+
+
+	void seedit( const char *flag)
+{
+	FILE *fopen(), *pfseed;
+	unsigned int seed2 ;
+
+  if( flag[0] == 's' ) {
+	srand( seed2 = time(NULL) ) ;
+        printf("\n%d\n", seed2 );    
+	}
+
+}

--- a/data/msHOTdir/streecGCHOT.c
+++ b/data/msHOTdir/streecGCHOT.c
@@ -1,0 +1,1401 @@
+/*just like streecGCHOT.c but allows for multiple geneconv hotspots*/
+/* NOTE: track length must be entered by user as EITHER right or left length*/
+/* compile with gcc -o msHOTmulti msGCHOTmulti.c streecGCHOTmulti.c rand1.c -lm */
+
+/**********  segtre_mig.c **********************************
+*
+*	This subroutine uses a Monte Carlo algorithm described in
+*	Hudson,R. 1983. Theor.Pop.Biol. 23: 183-201, to produce
+*	a history of a random sample of gametes under a neutral
+*	Wright-Fisher model with recombination and geographic structure. 
+*	Input parameters
+*	are the sample size (nsam), the number of sites between
+*	which recombination can occur (nsites), and the recombination
+*	rate between the ends of the gametes (r). The function returns
+*	nsegs, the number of segments the gametes were broken into
+*	in tracing back the history of the gametes.  The histories of
+*	these segments are passed back to the calling function in the
+*	array of structures seglst[]. An element of this array,  seglst[i],
+* 	consists of three parts: (1) beg, the starting point of
+*	of segment i, (2) ptree, which points to the first node of the
+*	tree representing the history of the segment, (3) next, which
+*	is the index number of the next segment.
+*	     A tree is a contiguous set of 2*nsam nodes. The first nsam
+*	nodes are the tips of the tree, the sampled gametes.  The other
+*	nodes are the nodes ancestral to the sampled gametes. Each node
+*	consists of an "abv" which is the number of the node ancestral to
+*	that node, an "ndes", which is not used or assigned to in this routine,
+*	and a "time", which is the time (in units of 4N generations) of the
+*	node. For the tips, time equals zero.
+*	Returns a pointer to an array of segments, seglst.
+
+**************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "ms.h"
+#include "eca_funcsHOTmulti.h"
+#define NL putchar('\n')
+#define size_t unsigned
+
+#define MIN(x, y) ( (x)<(y) ? (x) : (y) )
+
+#define ERROR(message) fprintf(stderr,message),NL,exit(1)
+
+#define SEGINC 80 
+
+extern int flag;
+
+int nchrom, begs, nsegs;
+long nlinks ;
+static int *nnodes = NULL ;  
+double t, cleft , cleftHOT, cright, crightHOT, pc, lnpc ;
+
+static unsigned seglimit = SEGINC ;
+static unsigned maxchr ;
+
+struct seg{
+	int beg;
+	int end;
+	int desc;
+	};
+
+struct chromo{
+	int nseg;
+	int pop;
+	struct seg  *pseg;
+	} ;
+
+static struct chromo *chrom = NULL ;
+
+struct node{
+	int abv;
+	int ndes;
+	float time;
+	} *ptree1, *ptree2;
+
+struct segl {
+	int beg;
+	struct node *ptree;
+	int next;
+	}  ;
+static struct segl *seglst = NULL ;
+
+	struct segl *
+segtre_mig(struct c_params *cp, int *pnsegs ) 
+{
+  int i, j, k, seg, dec, pop, pop2, c1, c2, ind, rchrom, intn , hot ;
+	int migrant, source_pop, *config, flagint ;
+	double  ran1(), sum, x, tcoal, ttemp, rft, clefta,  crighta, tmin, p  ;
+	double prec, cin,  prect, nnm1, nnm0, mig, ran, coal_prob, prob, rdum , arg ;
+	char c, event, subevent ;
+	int re(), xover(), cinr(), cleftr(), crightr(), eflag, cpop, ic  ;
+	int nsam, npop, nsites, nintn, *inconfig ;
+	double r,  f, rf,  track_len, *nrec, *npast, *tpast, **migm ;
+	double *size, *alphag, *tlast ;
+	struct devent *nextevent ;
+
+	double TotWeight=0.0, del;
+	double TotWeightGC = 0.0, delGC;
+        struct seg *pseg ;
+	int  el, lsg, lsgm1;
+	//int count = 1;
+	int z, sumlinks;
+
+#ifdef SUMMARY_STATS
+    unsigned int jk_pop_j, jk_pop_k;
+    unsigned int recombination_events = 0;
+    unsigned int conversion_events = 0;
+    unsigned int coancestry_events = 0;
+    int N = cp->npop;
+	struct devent *e;
+
+    for (e= cp->deventlist; e != NULL; e = e->nextde) {
+        if (e->detype == 's') {
+            N++;
+        }
+    }
+    unsigned int *migration_events = calloc(N * N, sizeof(unsigned int));
+#endif
+
+	nsam = cp->nsam;
+	npop = cp->npop;
+	nsites = cp->nsites;
+	inconfig = cp->config;
+	r = cp->r ;
+	f = cp->f ;
+	track_len = cp->track_len ;
+	migm = (double **)malloc( (unsigned)npop*sizeof(double *) ) ;
+	for( i=0; i<npop; i++) {
+	  migm[i] = (double *)malloc( (unsigned)npop*sizeof( double) ) ;
+	  for( j=0; j<npop; j++) migm[i][j] = (cp->mig_mat)[i][j] ;
+	  }
+	nextevent = cp->deventlist ;
+	
+/* Initialization */
+	if( chrom == NULL ) {
+	   maxchr = nsam + 20 ;
+	   chrom = (struct chromo *)malloc( (unsigned)( maxchr*sizeof( struct chromo) )) ;
+	  if( chrom == NULL ) perror( "malloc error. segtre");
+	  }
+	if( nnodes == NULL ){
+		nnodes = (int*) malloc((unsigned)(seglimit*sizeof(int)))  ;
+		if( nnodes == NULL ) perror("malloc error. segtre_mig");
+		}
+	if( seglst == NULL ) {
+		seglst = (struct segl *)malloc((unsigned)(seglimit*sizeof(struct segl)) ) ;
+		if( seglst == NULL ) perror("malloc error. segtre_mig.c 2");
+		}
+
+	config = (int *)malloc( (unsigned) ((npop+1)*sizeof(int) )) ;
+	if( config == NULL ) perror("malloc error. segtre.");
+	size = (double *)malloc( (unsigned) ((npop)*sizeof(double) )) ;
+	if( size == NULL ) perror("malloc error. segtre.");
+	alphag = (double *)malloc( (unsigned) ((npop)*sizeof(double) )) ;
+	if( alphag == NULL ) perror("malloc error. segtre.");
+	tlast = (double *)malloc( (unsigned) ((npop)*sizeof(double) )) ;
+	if( alphag == NULL ) perror("malloc error. segtre.");
+	for(pop=0;pop<npop;pop++) {
+	   config[pop] = inconfig[pop] ;
+	   size[pop] = (cp->size)[pop] ;
+	   alphag[pop] = (cp->alphag)[pop] ;
+	   tlast[pop] = 0.0 ;
+	}
+	for(pop=ind=0;pop<npop;pop++)
+		for(j=0; j<inconfig[pop];j++,ind++) {
+			
+			chrom[ind].nseg = 1;
+			if( !(chrom[ind].pseg = (struct seg*)malloc((unsigned)sizeof(struct seg)) ))
+			  ERROR("calloc error. se1");
+
+			(chrom[ind].pseg)->beg = 0;
+			(chrom[ind].pseg)->end = nsites-1;
+			(chrom[ind].pseg)->desc = ind ;
+			chrom[ind].pop = pop ;
+			}
+	seglst[0].beg = 0;
+	if( !(seglst[0].ptree = (struct node *)calloc((unsigned)(2*nsam),sizeof(struct node)) ))
+		 perror("calloc error. se2");
+
+
+
+	nnodes[0] = nsam - 1 ;
+	nchrom=nsam;
+	nlinks = ((long)(nsam))*(nsites-1) ;
+	nsegs=1;
+	t = 0.;
+	r /= (nsites-1);
+	if( f > 0.0 ) 	pc = (track_len -1.0)/track_len ;
+	else pc = 1.0 ;
+	lnpc = log( pc ) ;
+	cleft = nsam* ( 1.0 - pow( pc, (double)(nsites-1) ) ) ;
+	cright = nsam* ( 1.0 - pow( pc, (double)(nsites-1) ) ) ;
+	if( r > 0.0 ) rf = r*f ;
+	else rf = f /(nsites-1) ;
+	rft = rf*track_len ;
+	flagint = 0 ;
+
+/* Main loop */
+
+	int county = 1;
+	while( nchrom > 1 ) {
+	/* first, cycle over all the chromosome and add up the relative recomb intensity 
+	   over all extant material on the chromosomes*/
+	  if((gNumHotSpots > 0) || (gNumHotSpotsGC > 0))
+	    {
+	      TotWeight = 0.0;
+	      TotWeightGC = 0.0;
+	      cleftHOT = 0.0;
+	      crightHOT = 0.0;
+	      for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;   
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);
+		del = (double)el;
+		delGC = (double)el;
+		//printf("el = %d, del = %f  ", el, del);
+		if (gNumHotSpots > 0)
+		  {
+		    for (hot = 0; hot<gNumHotSpots; hot++)
+		      {
+			if(pseg->beg <= gHotSpotStart[hot] && (pseg+lsgm1)->end >= gHotSpotEnd[hot])
+			  del += (gHSRates[hot]-1.) * (gHotSpotEnd[hot] - gHotSpotStart[hot]);
+			if((pseg->beg > gHotSpotStart[hot]) && ((pseg+lsgm1)->end < gHotSpotEnd[hot]))
+			  del += (gHSRates[hot] - 1) * ((pseg+lsgm1)->end - pseg->beg);
+			if(pseg->beg > gHotSpotEnd[hot] || (pseg+lsgm1)->end < gHotSpotStart[hot])
+			  del = del;
+			else if(pseg->beg > gHotSpotStart[hot] && (pseg+lsgm1)->end >= gHotSpotEnd[hot])
+			  del += (gHSRates[hot]-1) * (gHotSpotEnd[hot] - pseg->beg);
+			else if(pseg->beg <= gHotSpotStart[hot] && (pseg+lsgm1)->end < gHotSpotEnd[hot])
+			  del += (gHSRates[hot]-1) * ((pseg+lsgm1)->end - gHotSpotStart[hot]);
+		      }		 
+			TotWeight += del;
+		  }
+		if (gNumHotSpotsGC > 0)
+		  {
+	              //for cin_V:
+		    for (hot = 0; hot<gNumHotSpotsGC; hot++)
+		      {
+                        //printf("chrom=(%d,%d),hot=(%d,%d)\n",(pseg->beg),(pseg+lsgm1)->end,gHotSpotStartGC[hot],gHotSpotEndGC[hot]);
+
+		       	if(pseg->beg <= gHotSpotStartGC[hot] && (pseg+lsgm1)->end >= gHotSpotEndGC[hot])
+			{
+			  delGC += (gHSRatesGC[hot]-1.0) * (gHotSpotEndGC[hot] - gHotSpotStartGC[hot]);
+			}
+
+			if((pseg->beg > gHotSpotStartGC[hot]) && ((pseg+lsgm1)->end < gHotSpotEndGC[hot]))
+			{
+			  delGC += (gHSRatesGC[hot] - 1.0) * ((pseg+lsgm1)->end - pseg->beg);
+			}
+			if(pseg->beg > gHotSpotEndGC[hot] || (pseg+lsgm1)->end < gHotSpotStartGC[hot])
+			{
+			  delGC = delGC;
+			}
+			else if(pseg->beg > gHotSpotStartGC[hot] && (pseg+lsgm1)->end >= gHotSpotEndGC[hot])
+			{
+			  delGC += (gHSRatesGC[hot]-1.0) * (gHotSpotEndGC[hot] - pseg->beg);
+			}
+			else if(pseg->beg <= gHotSpotStartGC[hot] && (pseg+lsgm1)->end < gHotSpotEndGC[hot])
+			{
+			  delGC += (gHSRatesGC[hot]-1.0) * ((pseg+lsgm1)->end - gHotSpotStartGC[hot]);
+			}
+		      }
+		    TotWeightGC += delGC;
+
+		              //for cleftr_V:
+		        // (0) See if hotspots are all right of pseg->beg:
+		    if(pseg->beg <= gHotSpotStartGC[0]) 
+		      cleftHOT += 1-pow(pc, links(ic));
+		    if (pseg->beg > gHotSpotStartGC[0])
+		      {
+			// (I) Add up all within-hotspot rates for hotspots to left of pseg->beg:
+			for (hot = 0; hot<gNumHotSpotsGC; hot++)
+			  {
+			    if (pseg->beg <= gHotSpotStartGC[hot]) break;
+			    if (pseg->beg > gHotSpotStartGC[hot])
+			      {
+				if((pseg->beg > gHotSpotStartGC[hot]) && (pseg->beg <= gHotSpotEndGC[hot]))
+				  cleftHOT += (1 - pow(pc, links(ic))) * gHSRatesGC[hot]*(1 - pow(pc, (pseg->beg - gHotSpotStartGC[hot] + 1)));
+			    
+			    if(pseg->beg > gHotSpotEndGC[hot])
+			      cleftHOT += (1 - pow(pc, links(ic))) * gHSRatesGC[hot]*(pow(pc,(pseg->beg - gHotSpotEndGC[hot]+1)) - pow(pc,(pseg->beg - gHotSpotStartGC[hot]+1)));	    
+			      }
+			  }
+
+		        // (II) Add up all between-hotspot rates for hotspots to left of pseg->beg:
+			for (i = 0; i < (hot-1); i++)
+			  cleftHOT += (1 - pow(pc, links(ic))) * (pow(pc, (pseg->beg - gHotSpotStartGC[(i+1)])) - pow(pc, (pseg->beg - gHotSpotEndGC[i] + 1.0)));
+
+			// (III) Add up rest (to left of start of first hotspot to infty & to right of end of last hotspot until pseg->beg) 
+			cleftHOT += (1 - pow(pc, links(ic))) * pow(pc, (pseg->beg - gHotSpotStartGC[0] + 1));
+			if (pseg->beg > gHotSpotEndGC[(hot-1)])
+			  cleftHOT += (1 - pow(pc, links(ic))) * (1.0 - pow(pc, (pseg->beg - gHotSpotEndGC[(hot-1)] + 1)));
+		      }
+
+		    //for crightr_V:
+		         // (0) See if hotspots are all left of (pseg+lsgm1)->end:
+		    if((pseg+lsgm1)->end >= gHotSpotEndGC[(gNumHotSpotsGC-1)])
+		      crightHOT += 1-pow(pc, links(ic));
+		    if((pseg+lsgm1)->end < gHotSpotEndGC[(gNumHotSpotsGC-1)]) 
+		      {
+			// (I) Add up all within-hotspot rates for hotspots to right of (pseg+lsgm1)->end:
+			for (hot = (gNumHotSpotsGC-1); hot >= 0; hot--)
+			  {
+			    if ((pseg+lsgm1)->end >= gHotSpotEndGC[hot]) break;
+			    if ((pseg+lsgm1)->end < gHotSpotEndGC[hot])
+			      {
+
+				if(((pseg+lsgm1)->end >= gHotSpotStartGC[hot]) && ((pseg+lsgm1)->end <= gHotSpotEndGC[hot]))
+				  crightHOT += (1-pow(pc, links(ic))) * gHSRatesGC[hot] * (1.0 - pow(pc, (gHotSpotEndGC[hot] - (pseg+lsgm1)->end + 1)));
+
+				if ((pseg+lsgm1)->end < gHotSpotStartGC[hot])
+				  crightHOT += (1-pow(pc, links(ic))) * gHSRatesGC[hot] * (pow(pc,(gHotSpotStartGC[hot] - (pseg+lsgm1)->end + 1)) - pow(pc,(gHotSpotEndGC[hot] - (pseg+lsgm1)->end + 1)));
+			      }
+			  }
+
+			// (II) Add up all between-hotspot rates for hotspots to right of (pseg+lsgm1)->end:
+			for (i = (gNumHotSpotsGC-1); i > (hot+1); i--)
+			  crightHOT += (1.0 - pow(pc, links(ic))) * (pow(pc,(gHotSpotEndGC[(i-1)] - (pseg+lsgm1)->end + 1)) - pow(pc,(gHotSpotStartGC[i] - (pseg+lsgm1)->end + 1)));
+
+			// (III) Add up rest (to left of start of first hotspot to (pseg+lsgm1)->end & to right of end of last hotspot to infty) 
+			crightHOT += (1.0 - pow(pc, links(ic))) * pow(pc,(gHotSpotEndGC[(gNumHotSpotsGC-1)] - (pseg+lsgm1)->end + 1));
+			if ((pseg+lsgm1)->end < gHotSpotStartGC[(hot+1)])
+			  crightHOT += (1.0 - pow(pc, links(ic))) * (1.0 - pow(pc,(gHotSpotStartGC[(hot+1)] - (pseg+lsgm1)->end + 1.0)));
+		      }			      
+		  }
+	      }
+	      if (gNumHotSpots > 0) prec = TotWeight*r;
+	      if (gNumHotSpotsGC > 0) 
+		{
+		  cin = TotWeightGC*rf;
+		  clefta = cleftHOT*rft;
+		  crighta = crightHOT*rft;
+		}
+	    }
+	
+
+		 if (gNumHotSpots == 0) prec = nlinks*r;
+	      if (gNumHotSpotsGC == 0) 
+		{
+		  cin = nlinks*rf;
+		  clefta = cleft*rft;
+		  crighta = cright*rft;
+		}
+	      //cin = nlinks*rf ;
+	      //clefta = cleft*rft ;
+	      //prect = prec + cin + clefta ;
+	      prect = prec + cin + clefta + crighta;
+		mig = 0.0;
+		for( i=0; i<npop; i++) mig += config[i]*migm[i][i] ;
+		if( (npop > 1) && ( mig == 0.0) && ( nextevent == NULL)) {
+		   i = 0;
+		   for( j=0; j<npop; j++) 
+			if( config[j] > 0 ) i++;
+		   if( i > 1 ) {
+			fprintf(stderr," Infinite coalescent time. No migration.\n");
+			exit(1);
+		   }
+		}
+		eflag = 0 ;
+
+		if( prect > 0.0 ) {      /* cross-over or gene conversion */
+		  while( (rdum = ran1() )  == 0.0 ) ;
+		  ttemp = -log( rdum)/prect ;
+		  if( (eflag == 0) || (ttemp < tmin ) ){
+		    tmin = ttemp;
+		    event = 'r' ;
+		    eflag = 1;
+		  }
+	        }
+		if(mig > 0.0 ) {         /* migration   */
+		  while( (rdum = ran1() ) == 0.0 ) ;
+		  ttemp = -log( rdum)/mig ;
+		  if( (eflag == 0) || (ttemp < tmin ) ){
+		    tmin = ttemp;
+		    event = 'm' ;
+		    eflag = 1 ;
+		  }
+	        }
+		
+	    for(pop=0; pop<npop ; pop++) {     /* coalescent */
+		coal_prob = ((double)config[pop])*(config[pop]-1.) ;
+	        if( coal_prob > 0.0 ) {
+		   while( ( rdum = ran1() )  == .0 ) ;
+	  	   if( alphag[pop] == 0 ){
+			 ttemp = -log( rdum )*size[pop] /coal_prob ;
+		         if( (eflag == 0) || (ttemp < tmin ) ){
+		            tmin = ttemp;
+		            event = 'c' ;
+		            eflag = 1 ;
+			    cpop = pop;
+			 }
+		    }
+	  	   else {
+		     arg  = 1. - alphag[pop]*size[pop]*exp(-alphag[pop]*(t - tlast[pop] ) )* log(rdum) / coal_prob     ;
+		     if( arg > 0.0 ) {                          /*if arg <= 0,  no coalescent within interval */ 
+		         ttemp = log( arg ) / alphag[pop]  ;
+		         if( (eflag == 0) || (ttemp < tmin ) ){
+		            tmin = ttemp;
+		            event = 'c' ;
+		            eflag = 1 ;
+			    cpop = pop ;
+			 }
+		     }
+		   }
+	         }		
+ 	      }
+
+	    if( (eflag == 0) && ( nextevent == NULL) ) {
+	      fprintf(stderr,
+               " infinite time to next event. Negative growth rate in last time interval or non-communicating subpops.\n");
+	      exit( 0);
+	    }
+	if( ( ( eflag == 0) && (nextevent != NULL))|| ( (nextevent != NULL) &&  ( (t+tmin) >=  nextevent->time)) ) {
+	    t = nextevent->time ;
+	    switch(  nextevent->detype ) {
+		case 'N' :
+		   for(pop =0; pop <npop; pop++){
+			 size[pop]= nextevent->paramv ;
+			 alphag[pop] = 0.0 ;
+			}
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'n' :
+		   size[nextevent->popi]= nextevent->paramv ;
+		   alphag[nextevent->popi] = 0.0 ;
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'G' :
+		   for(pop =0; pop <npop; pop++){
+		     size[pop] = size[pop]*exp( -alphag[pop]*(t - tlast[pop]) ) ;
+		     alphag[pop]= nextevent->paramv ;
+		     tlast[pop] = t ;
+		   }
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'g' :
+		     pop = nextevent->popi ;
+		     size[pop] = size[pop]*exp( - alphag[pop]*(t-tlast[pop]) ) ;
+		     alphag[pop]= nextevent->paramv ;
+		     tlast[pop] = t ;
+		     nextevent = nextevent->nextde ;
+		     break;
+		case 'M' :
+		   for(pop =0; pop <npop; pop++)
+		     for( pop2 = 0; pop2 <npop; pop2++) migm[pop][pop2] = (nextevent->paramv) /(npop-1.0) ;
+		   for( pop = 0; pop <npop; pop++)
+		     migm[pop][pop]= nextevent->paramv ;
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'a' :
+		   for(pop =0; pop <npop; pop++)
+		     for( pop2 = 0; pop2 <npop; pop2++) migm[pop][pop2] = (nextevent->mat)[pop][pop2]  ;
+		   nextevent = nextevent->nextde ;
+		   break;
+		case 'm' :
+		  i = nextevent->popi ;
+		  j = nextevent->popj ;
+		  migm[i][i] += nextevent->paramv - migm[i][j];
+		   migm[i][j]= nextevent->paramv ;
+		   nextevent = nextevent->nextde ;
+		   break;
+	        case 'j' :         /* merge pop i into pop j  (join) */
+		  i = nextevent->popi ;
+		  j = nextevent->popj ;
+		  config[j] += config[i] ;
+		  config[i] = 0 ;
+		  for( ic = 0; ic<nchrom; ic++) if( chrom[ic].pop == i ) chrom[ic].pop = j ;
+		   nextevent = nextevent->nextde ;
+		   break;
+	        case 's' :         /*split  pop i into two;p is the proportion from pop i, and 1-p from pop n+1  */
+		  i = nextevent->popi ;
+		  p = nextevent->paramv ;
+		  npop++;
+		  config = (int *)realloc( config, (unsigned)(npop*sizeof( int) )); 
+		  size = (double *)realloc(size, (unsigned)(npop*sizeof(double) ));
+		  alphag = (double *)realloc(alphag, (unsigned)(npop*sizeof(double) ));
+		  tlast = (double *)realloc(tlast,(unsigned)(npop*sizeof(double) ) ) ;
+		  tlast[npop-1] = t ;
+		  size[npop-1] = 1.0 ;
+		  alphag[npop-1] = 0.0 ;
+		  migm = (double **)realloc(migm, (unsigned)(npop*sizeof( double *)));
+		  for( j=0; j< npop-1; j++)
+			 migm[j] = (double *)realloc(migm[j],(unsigned)(npop*sizeof(double)));
+		  migm[npop-1] = (double *)malloc( (unsigned)(npop*sizeof( double) ) ) ;
+		  for( j=0; j<npop; j++) migm[npop-1][j] = migm[j][npop-1] = 0.0 ;
+		  config[npop-1] = 0 ;
+		  config[i] = 0 ;
+		  for( ic = 0; ic<nchrom; ic++){
+		    if( chrom[ic].pop == i ) {
+		      if( ran1() < p ) config[i]++;
+		      else {
+			 chrom[ic].pop = npop-1 ;
+			 config[npop-1]++;
+		      }
+		    }
+		  }
+		   nextevent = nextevent->nextde ;
+		   break;
+		}
+ 	   } 
+	else {
+		   t += tmin ;	
+		   if( event == 'r' ) {   
+		      if( (ran = ran1()) < ( prec / prect ) ){ /*recombination*/
+			if(gNumHotSpots == 0) 
+			  {
+			    //printf("re?\n");
+			    rchrom = re(nsam);			    
+			  }
+			else
+			  {
+			    //printf("rev?\n");
+			    rchrom = re_v(nsam);			    
+			  }
+			  config[ chrom[rchrom].pop ] += 1 ;
+          subevent = 'r';
+		      }
+		      else if( ran < (prec + clefta)/(prect) ){    /*  cleft event */
+			if (gNumHotSpotsGC == 0)
+			{
+			  //printf("cleftr?\n");
+			  rchrom = cleftr(nsam);
+			}
+			else 
+			  {
+			    //printf("cleft_V?\n");
+			    rchrom = cleftr_V(nsam);
+			  }
+			 config[ chrom[rchrom].pop ] += 1 ;
+          subevent = 'g';
+		      }
+		      else if( ran < (prec + clefta + crighta)/(prect) ){    /*  cright event */
+			if (gNumHotSpotsGC == 0)
+			{
+			  //printf("crightr?\n");
+			  rchrom = crightr(nsam);
+			}
+			else 
+			  {
+			    //printf("cright_V?\n");
+			    rchrom = crightr_V(nsam);
+			  }
+			config[ chrom[rchrom].pop ] += 1 ;
+		      }		      
+		      else  {         /* cin event */
+			if (gNumHotSpotsGC == 0)
+			{
+				rchrom = cinr(nsam,nsites);
+			}
+			else
+			  {
+			    county = county +1;
+                            //printf("cin_V? %d\n",county);
+			    rchrom = cinr_V(nsam,nsites);
+			  }
+			 if( rchrom >= 0 ) config[ chrom[rchrom].pop ] += 1 ;
+          subevent = 'g';
+		      }
+		   }
+	           else if ( event == 'm' ) {  /* migration event */
+			x = mig*ran1();
+			sum = 0.0 ;
+			for( i=0; i<nchrom; i++) {
+			  sum += migm[chrom[i].pop][chrom[i].pop] ;
+			  if( x <sum ) break;
+			  }
+			migrant = i ;
+			x = ran1()*migm[chrom[i].pop][chrom[i].pop];
+			sum = 0.0;
+			for(i=0; i<npop; i++){
+			  if( i != chrom[migrant].pop ){
+			    sum += migm[chrom[migrant].pop][i];
+			    if( x < sum ) break;
+			   }
+			}
+#ifdef SUMMARY_STATS
+                jk_pop_j = chrom[migrant].pop;
+                jk_pop_k = i;
+#endif
+			source_pop = i;
+			  config[chrom[migrant].pop] -= 1;
+			  config[source_pop] += 1;
+			  chrom[migrant].pop = source_pop ;
+	           }
+		   else { 								 /* coalescent event */
+			/* pick the two, c1, c2  */
+			pick2_chrom( cpop, config, &c1,&c2);  /* c1 and c2 are chrom's to coalesce */
+			dec = ca(nsam,nsites,c1,c2 );
+			config[cpop] -= dec ;
+		   }
+#ifdef SUMMARY_STATS
+            /* verify that the events are what we think and count*/
+            if (event == 'r') {
+                if (subevent == 'r'){
+                    recombination_events++;
+                }
+                if (subevent == 'g'){
+                    conversion_events++;
+                }
+
+            } else if (event == 'c') {
+                coancestry_events++;
+            } else if (event == 'm') {
+                migration_events[jk_pop_j * N + jk_pop_k]++;
+            } else {
+                printf("ERROR!: %c\n", event);
+                exit(1);
+            }
+#endif
+		 }
+	     }  
+#ifdef SUMMARY_STATS
+    /* print out the events */
+    printf("%f\t%d\t%d\t%d\t%d", t, nsegs, recombination_events, coancestry_events, conversion_events);
+    for (i = 0; i < N * N; i++) {
+        printf("\t%d", migration_events[i]);
+    }
+    int end;
+    printf("\t[");
+    for(seg=0, k=0; k<nsegs - 2; seg=seglst[seg].next, k++) {
+		    end = seglst[seglst[seg].next].beg - 1;
+        printf("%.1f, ", (float) end);
+    }
+		end = seglst[seglst[seg].next].beg - 1;
+    printf("%.1f]", (float) end);
+    printf("\n");
+#endif
+	*pnsegs = nsegs ;
+	free(config); 
+	free( size ) ;
+	free( alphag );
+	free( tlast );
+	for( i=0; i<npop; i++) free ( migm[i] ) ;
+	free( migm ) ;
+	return( seglst );
+}
+
+/******  recombination subroutine ***************************
+   Picks a chromosome and splits it in two parts. If the x-over point
+   is in a new spot, a new segment is added to seglst and a tree set up
+   for it.   ****/
+
+
+	int
+re(nsam)
+	int nsam;
+{
+	struct seg *pseg ;
+	int  el, lsg, lsgm1,  ic,  is, in, spot;
+	double ran1();
+
+
+/* First generate a random x-over spot, then locate it as to chrom and seg. */
+
+	spot = nlinks*ran1() + 1.;
+
+    /* get chromosome # (ic)  */
+
+	for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);
+		if( spot <= el ) break;
+		spot -= el ;
+		}
+	is = pseg->beg + spot -1;
+	xover(nsam, ic, is);
+	return(ic);	
+}
+
+/******  recombination subroutine with hotspots  ***************************
+   Picks a chromosome and splits it in two parts. If the x-over point
+   is in a new spot, a new segment is added to seglst and a tree set up
+   for it.  Does so while also accounting for the variable rates at which the
+   different sites recombine   ****/
+
+
+	int
+re_v(nsam)
+	int nsam;
+{
+	struct seg *pseg ;
+	int  el, lsg, lsgm1,  ic,  is, in, spot,i, hot;
+	double ran1();
+	double TotWeight=0.0, del,point;
+	
+	/* first, cycle over all the chromosome and add up the relative recomb intensity 
+		over all extant material on the chromosomes */
+	for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;   /*  just "lsg minus 1" as implied by the name  */
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);  /* this is the number of links between the first and the last
+													"active" segment of a chromosome.  Some of the links in there
+													may be what Wiuf and Hein call "Trapped Ancestal Material."  This
+													seems to be the step where that trapped ancestral material is
+													accounted for  */
+													
+		/*    at this point, el contains the weight that the chromosome would have if all the sites
+		 had (relative) intensity of 1.  If any hot spots were contained within the chromosome, then
+		 their contribution must be added in as well  */
+		 del = (double)el;
+		 for (hot = 0; hot < gNumHotSpots; hot++)
+		   {
+	  
+		     if(pseg->beg <= gHotSpotStart[hot] && (pseg+lsgm1)->end >= gHotSpotEnd[hot])
+		       del += (gHSRates[hot]-1.) * (gHotSpotEnd[hot] - gHotSpotStart[hot]);
+		     if((pseg->beg > gHotSpotStart[hot]) && ((pseg+lsgm1)->end < gHotSpotEnd[hot]))
+		       del += (gHSRates[hot] - 1) * ((pseg+lsgm1)->end - pseg->beg);
+		     if(pseg->beg > gHotSpotEnd[hot] || (pseg+lsgm1)->end < gHotSpotStart[hot])
+			 del = del;
+		     else if(pseg->beg > gHotSpotStart[hot] && (pseg+lsgm1)->end >= gHotSpotEnd[hot])
+			 del += (gHSRates[hot]-1) * (gHotSpotEnd[hot] - pseg->beg);
+		     else if(pseg->beg <= gHotSpotStart[hot] && (pseg+lsgm1)->end < gHotSpotEnd[hot])
+			 del += (gHSRates[hot]-1) * ((pseg+lsgm1)->end - gHotSpotStart[hot]);
+		   }
+		     TotWeight += del;
+	}
+	
+	/* now generate a random point between 0 and TotWeight, re-doing if it is exactly TotWeight */
+	while( (point = TotWeight * ran1()) == TotWeight);
+	
+	/*  now, cycle over and find the chromosome on which point is located and leave things set up to 
+	   easily find which link on the chromosome is implicated */
+	for(TotWeight=0.0, ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;   /*  just "lsg minus 1" as implied by the name  */
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);  /* this is the number of links between the first and the last
+													"active" segment of a chromosome.  Some of the links in there
+													may be what Wiuf and Hein call "Trapped Ancestal Material."  This
+													seems to be the step where that trapped ancestral material is
+													accounted for  */
+													
+		/*    at this point, el contains the weight that the chromosome would have if all the sites
+		 had (relative) intensity of 1.  If any hot spots were contained within the chromosome, then
+		 their contribution must be added in as well   */
+		 del = (double)el;
+		 for(hot=0; hot<gNumHotSpots; hot++)
+		   {	
+		     if(pseg->beg <= gHotSpotStart[hot] && (pseg+lsgm1)->end >= gHotSpotEnd[hot])
+		       del += (gHSRates[hot]-1.) * (gHotSpotEnd[hot] - gHotSpotStart[hot]);
+		     if((pseg->beg > gHotSpotStart[hot]) && ((pseg+lsgm1)->end < gHotSpotEnd[hot]))
+		       del += (gHSRates[hot] - 1) * ((pseg+lsgm1)->end - pseg->beg);
+		     if(pseg->beg > gHotSpotEnd[hot] || (pseg+lsgm1)->end < gHotSpotStart[hot])
+		       del = del;
+		     else if(pseg->beg > gHotSpotStart[hot] && (pseg+lsgm1)->end >= gHotSpotEnd[hot])
+		       del += (gHSRates[hot]-1) * (gHotSpotEnd[hot] - pseg->beg);
+		     else if(pseg->beg <= gHotSpotStart[hot] && (pseg+lsgm1)->end < gHotSpotEnd[hot])
+		       del += (gHSRates[hot]-1) * ((pseg+lsgm1)->end - gHotSpotStart[hot]);
+
+		   }
+		     if(TotWeight+del > point)
+		       break;
+		     else 
+		       TotWeight += del;
+	}
+	
+	/* now, at this point, ic is what it needs to be, but we need to determine the spot on the chromosome where
+	 it occurs---is.  Do this by cycling over all the possible spots on the chromosome  */
+	point -= TotWeight;
+	is=pseg->beg;
+/* set i to the first value in gHotSpots greater than
+																	or equal to pseg->beg  */
+	for(TotWeight = 0.0, is=pseg->beg; is<(pseg+lsgm1)->end; is++)  {
+	  TotWeight += 1.0;
+	  for (hot=0; hot<gNumHotSpots; hot++)
+	    {
+	      if(is >= gHotSpotStart[hot] && is < gHotSpotEnd[hot])
+		TotWeight += gHSRates[hot] - 1.0;
+	    }
+	  if(TotWeight > point) 
+	    break;
+	}
+	/* now is has the value that it should, too  */
+	
+	/*  ECA: added this in order to count the number of recombinations that occur at
+	    the different links */
+	//gNumRecAtSpot[is]++;  
+	
+	/* now that the chromosome and location are determined, the recombination can be performed  */
+
+	xover(nsam, ic, is);
+	
+	return(ic);	
+}
+
+	int
+cleftr( int nsam)
+{
+	struct seg *pseg ;
+	int   lsg, lsgm1,  ic,  is, in, spot;
+	double ran1(), x, sum, len  ;
+	int xover(int, int, int);
+
+while( (x = cleft*ran1() )== 0.0 )  ;
+	sum = 0.0 ;
+	ic = -1 ;
+	while ( sum < x ) {
+		sum +=  1.0 - pow( pc, links(++ic) )  ;
+		}
+	pseg = chrom[ic].pseg;
+	len = links(ic) ;
+	is = pseg->beg + floor( 1.0 + log( 1.0 - (1.0- pow( pc, len))*ran1() )/lnpc  ) -1  ;
+	xover( nsam, ic, is);
+	return( ic) ;
+}
+
+int cleftr_V(int nsam)
+{
+	struct seg *pseg ;
+	int  hot, lsg, lsgm1,  ic,  is, in, i;
+	double ran1(), x, sum, len, ic_sum, spot, sum_along_chrom;
+	int xover(int, int, int);
+
+	while( (x = cleftHOT*ran1() )== 0.0 )  ;
+	sum = 0.0;
+
+	for( ic=0; ic<nchrom ; ic++) {
+	  lsg = chrom[ic].nseg ;
+	  lsgm1 = lsg - 1;   
+	  pseg = chrom[ic].pseg;
+
+	  // (0) See if hotspots are all right of pseg->beg:
+	  if(pseg->beg <= gHotSpotStartGC[0]) 
+	    ic_sum = 1-pow(pc, links(ic));
+	  if (pseg->beg > gHotSpotStartGC[0])
+	    {
+	      ic_sum = 0.0;
+	      // (I) Add up all within-hotspot rates for hotspots to left of pseg->beg:
+	      for (hot = 0; hot<gNumHotSpotsGC; hot++)
+		{	  
+		  if (pseg->beg <= gHotSpotStartGC[hot]) break;
+		  if (pseg->beg > gHotSpotStartGC[hot])
+		    {
+		      if((pseg->beg > gHotSpotStartGC[hot]) && (pseg->beg <= gHotSpotEndGC[hot]))
+			ic_sum += (1 - pow(pc, links(ic))) * gHSRatesGC[hot]*(1 - pow(pc, (pseg->beg - gHotSpotStartGC[hot] + 1)));
+			    
+		  if(pseg->beg > gHotSpotEndGC[hot])
+		    ic_sum += (1 - pow(pc, links(ic))) * gHSRatesGC[hot]*(pow(pc,(pseg->beg - gHotSpotEndGC[hot]+1)) - pow(pc,(pseg->beg - gHotSpotStartGC[hot]+1)));	    
+		    }
+		}
+
+	  // (II) Add up all between-hotspot rates for hotspots to left of pseg->beg:
+	  for (i = 0; i < (hot-1); i++)
+	    ic_sum += (1 - pow(pc, links(ic))) * (pow(pc, (pseg->beg - gHotSpotStartGC[(i+1)])) - pow(pc, (pseg->beg - gHotSpotEndGC[i] + 1.0)));
+
+	  // (III) Add up rest (to left of start of first hotspot to infty & to right of end of last hotspot until pseg->beg) 
+	  ic_sum += (1 - pow(pc, links(ic))) * pow(pc, (pseg->beg - gHotSpotStartGC[0] + 1));
+	  if (pseg->beg > gHotSpotEndGC[(hot-1)])
+	    ic_sum += (1 - pow(pc, links(ic))) * (1.0 - pow(pc, (pseg->beg - gHotSpotEndGC[(hot-1)] + 1)));
+
+	    }
+
+	  sum += ic_sum;
+	  if (sum > x) break;
+	}
+
+	len = links(ic) ;
+	is = pseg->beg + floor( 1.0 + log( 1.0 - (1.0- pow( pc, len))*ran1() )/lnpc  ) -1  ;
+
+	xover( nsam, ic, is);
+	return( ic) ;
+
+}
+
+	int
+crightr( int nsam)
+{
+	struct seg *pseg ;
+	int   lsg, lsgm1,  ic,  is, in, spot     ;
+	double ran1(), x, sum, len, rando;
+	int xover(int, int, int);
+
+
+while( (x = cright*ran1() )== 0.0 )  ;
+	sum = 0.0 ;
+	ic = -1 ;
+	while ( sum < x ) {
+	  sum +=  1.0 - pow( pc, links(++ic) );  
+		}
+	pseg = chrom[ic].pseg;
+	lsg = chrom[ic].nseg;
+	lsgm1 = lsg - 1;
+	len = links(ic) ;
+
+	//is = pseg->end - floor( 1.0 + log( 1.0 - (1.0- pow( pc, len))*(rando = ran1()) )/lnpc  ) -1  ;
+	is = (pseg+lsgm1)->end - floor( 1.0 + log( 1.0 - (1.0- pow( pc, len))*(rando = ran1()) )/lnpc  ) + 1.0 ;   //??  -- I removed the '-1' from 'cleftr'  ??
+
+	xover( nsam, ic, is);
+
+	return( ic) ;
+}
+
+int crightr_V(int nsam)
+{
+	struct seg *pseg ;
+	int   hot, lsg, lsgm1,  ic,  is, in, i;
+	double ran1(), x, sum, len, rando, spot, ic_sum, sum_along_chrom;
+	int xover(int, int, int);
+
+
+	while( (x = crightHOT*ran1() )== 0.0 )  ;
+	sum = 0.0 ;
+	for( ic=0; ic<nchrom ; ic++) {
+	  lsg = chrom[ic].nseg ;
+	  lsgm1 = lsg - 1;   
+	  pseg = chrom[ic].pseg;
+
+	     // (0) See if hotspots are all left of (pseg+lsgm1)->end:
+	  if((pseg+lsgm1)->end >= gHotSpotEndGC[(gNumHotSpotsGC-1)])
+	    ic_sum = 1-pow(pc, links(ic));
+	  if((pseg+lsgm1)->end < gHotSpotEndGC[(gNumHotSpotsGC-1)]) 
+	    {
+	      ic_sum = 0.0;
+	         // (I) Add up all within-hotspot rates for hotspots to right of (pseg+lsgm1)->end:
+	      for (hot = (gNumHotSpotsGC-1); hot >= 0; hot--)
+		{
+		  if ((pseg+lsgm1)->end >= gHotSpotEndGC[hot]) break;
+		  if ((pseg+lsgm1)->end < gHotSpotEndGC[hot])
+		    {
+		      if(((pseg+lsgm1)->end >= gHotSpotStartGC[hot]) && ((pseg+lsgm1)->end <= gHotSpotEndGC[hot]))
+			ic_sum += (1-pow(pc, links(ic))) * gHSRatesGC[hot] * (1.0 - pow(pc, (gHotSpotEndGC[hot] - (pseg+lsgm1)->end + 1)));
+
+		      if ((pseg+lsgm1)->end < gHotSpotStartGC[hot])
+			ic_sum += (1-pow(pc, links(ic))) * gHSRatesGC[hot] * (pow(pc,(gHotSpotStartGC[hot] - (pseg+lsgm1)->end + 1)) - pow(pc,(gHotSpotEndGC[hot] - (pseg+lsgm1)->end + 1)));
+		    }
+		}
+
+	      // (II) Add up all between-hotspot rates for hotspots to right of (pseg+lsgm1)->end:
+	      for (i = (gNumHotSpotsGC-1); i > (hot+1); i--)
+		ic_sum += (1.0 - pow(pc, links(ic))) * (pow(pc,(gHotSpotEndGC[(i-1)] - (pseg+lsgm1)->end + 1)) - pow(pc,(gHotSpotStartGC[i] - (pseg+lsgm1)->end + 1)));
+
+	      // (III) Add up rest (to left of start of first hotspot to (pseg+lsgm1)->end & to right of end of last hotspot to infty) 
+	      ic_sum += (1.0 - pow(pc, links(ic))) * pow(pc,(gHotSpotEndGC[(gNumHotSpotsGC-1)] - (pseg+lsgm1)->end + 1));
+	      if ((pseg+lsgm1)->end < gHotSpotStartGC[(hot+1)])
+		ic_sum += (1.0 - pow(pc, links(ic))) * (1.0 - pow(pc,(gHotSpotStartGC[(hot+1)] - (pseg+lsgm1)->end + 1.0)));
+	    }			      
+
+	  sum += ic_sum;
+	  if (sum > x) break;
+
+	}
+
+	len = links(ic) ;
+
+	is = (pseg+lsgm1)->end - floor( 1.0 + log( 1.0 - (1.0- pow( pc, len))*(rando = ran1()) )/lnpc  ) +1.0 ;   
+
+	xover( nsam, ic, is);
+
+	return( ic) ;
+}
+
+	int
+cinr( int nsam, int nsites)
+{
+	struct seg *pseg ;
+	int len_left, len_right, el, lsg, lsgm1,  ic,  is, in, spot, begic, endic ;
+	double ran1();
+	int xover(), ca() ;
+	int leftgc = 1;
+	int rightgc = 1;
+
+/* First generate a random x-over spot, then locate it as to chrom and seg. */
+
+	spot = nlinks*ran1() + 1.;
+
+    /* get chromosome # (ic)  */
+
+	for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);
+		if( spot <= el ) break;
+		spot -= el ;
+		}
+	is = pseg->beg + spot -1;
+	begic = pseg->beg;              //GRH add (could be wrong)
+	endic = (pseg+lsgm1)->end ;
+	//xover(nsam, ic, is);
+
+	len_left = floor( 1.0 + log( ran1() )/lnpc ) ;
+	len_right = floor( 1.0 + log( ran1() )/lnpc ) ;
+
+	if ((is - len_left) <= begic) leftgc = 0;
+	if ((is + len_right) >= endic) rightgc = 0;
+
+	//  ????????????
+	/*if( is+len_right < (chrom[nchrom-1].pseg)->beg ){
+	   ca( nsam, nsites, ic, nchrom-1);
+	    return(-1) ;
+	    }*/
+	//   ????????????? 
+
+	if ((leftgc == 0) && (rightgc == 0)) return(-1);
+	if (leftgc == 1) 
+	  {
+	    xover(nsam, ic, (is-len_left));
+	    if (rightgc == 1) 
+	      {
+
+		if( is+len_right < (chrom[nchrom-1].pseg)->beg ){
+		  ca( nsam, nsites, ic, nchrom-1);
+		  return(-1) ;
+		}
+		xover(nsam, (nchrom-1), (is+len_right));
+		ca(nsam, nsites, ic, (nchrom - 1));
+	      }
+	  }
+	if ((rightgc == 1) && (leftgc == 0)) 
+	  {
+	    xover(nsam, ic, (is+len_right));
+	  }
+
+	//xover( nsam, nchrom-1, is+len ) ;
+	//ca( nsam,nsites, ic,  nchrom-1);
+	return(ic);	
+
+}
+
+	int
+cinr_V( int nsam, int nsites)
+{
+	struct seg *pseg ;
+	int len, hot, len_left, len_right, el, lsg, lsgm1,  ic,  is, in, spot, begic, endic ;
+	double ran1();
+	int xover(), ca() ;
+
+	double TotWeightGC=0.0, del,point;
+	int leftgc = 1;
+	int rightgc = 1;
+
+	/* first, cycle over all the chromosome and add up the relative recomb intensity 
+		over all extant material on the chromosomes */
+	for( ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;   /*  just "lsg minus 1" as implied by the name  */
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);  
+		del = (double)el;
+		for (hot = 0; hot<gNumHotSpotsGC; hot++)
+		  {
+		    if(pseg->beg <= gHotSpotStartGC[hot] && (pseg+lsgm1)->end >= gHotSpotEndGC[hot])
+		      del += (gHSRatesGC[hot]-1.) * (gHotSpotEndGC[hot] - gHotSpotStartGC[hot]);
+		if((pseg->beg > gHotSpotStartGC[hot]) && ((pseg+lsgm1)->end < gHotSpotEndGC[hot]))
+		  del += (gHSRatesGC[hot] - 1) * ((pseg+lsgm1)->end - pseg->beg);
+		if(pseg->beg > gHotSpotEndGC[hot] || (pseg+lsgm1)->end < gHotSpotStartGC[hot])
+		  del = del;
+		else if(pseg->beg > gHotSpotStartGC[hot] && (pseg+lsgm1)->end >= gHotSpotEndGC[hot])
+		  del += (gHSRatesGC[hot]-1) * (gHotSpotEndGC[hot] - pseg->beg);
+		else if(pseg->beg <= gHotSpotStartGC[hot] && (pseg+lsgm1)->end < gHotSpotEndGC[hot])
+		  del += (gHSRatesGC[hot]-1) * ((pseg+lsgm1)->end - gHotSpotStartGC[hot]);
+		  }
+		TotWeightGC += del;
+	}
+
+	/* now generate a random point between 0 and TotWeight, re-doing if it is exactly TotWeight */
+	while( (point = TotWeightGC * ran1()) == TotWeightGC);
+
+	/*  now, cycle over and find the chromosome on which point is located and leave things set up to 
+	   easily find which link on the chromosome is implicated */
+	//for(TotWeightGC=0.0, ic=0; ic<nchrom ; ic++) {
+	TotWeightGC=0.0;
+	for(ic=0; ic<nchrom ; ic++) {
+		lsg = chrom[ic].nseg ;
+		lsgm1 = lsg - 1;   
+		pseg = chrom[ic].pseg;
+		el = ( (pseg+lsgm1)->end ) - (pseg->beg);  	
+		del = (double)el;
+		for (hot = 0; hot < gNumHotSpotsGC; hot++)
+		  {
+		    if(pseg->beg <= gHotSpotStartGC[hot] && (pseg+lsgm1)->end >= gHotSpotEndGC[hot])
+		      del += (gHSRatesGC[hot]-1.) * (gHotSpotEndGC[hot] - gHotSpotStartGC[hot]);
+		    if((pseg->beg > gHotSpotStartGC[hot]) && ((pseg+lsgm1)->end < gHotSpotEndGC[hot]))
+		      del += (gHSRatesGC[hot] - 1) * ((pseg+lsgm1)->end - pseg->beg);
+		    if(pseg->beg > gHotSpotEndGC[hot] || (pseg+lsgm1)->end < gHotSpotStartGC[hot])
+		      del = del;
+		    else if(pseg->beg > gHotSpotStartGC[hot] && (pseg+lsgm1)->end >= gHotSpotEndGC[hot])
+		      del += (gHSRatesGC[hot]-1) * (gHotSpotEndGC[hot] - pseg->beg);
+		    else if(pseg->beg <= gHotSpotStartGC[hot] && (pseg+lsgm1)->end < gHotSpotEndGC[hot])
+		      del += (gHSRatesGC[hot]-1) * ((pseg+lsgm1)->end - gHotSpotStartGC[hot]);
+		  }
+
+		 if(TotWeightGC+del > point)
+		   {
+		 	break;
+		   }
+		 else 
+		 	TotWeightGC += del;
+	}
+	
+	/* now, at this point, ic is what it needs to be, but we need to determine the spot on the chromosome where
+	 it occurs---is.  Do this by cycling over all the possible spots on the chromosome  */
+	point -= TotWeightGC;
+	//point = del;
+	is=pseg->beg;
+/* set i to the first value in gHotSpots greater than
+																	or equal to pseg->beg  */
+	TotWeightGC=0.0;
+	//for(TotWeightGC = 0.0, is=pseg->beg; is<(pseg+lsgm1)->end; is++)  {
+	for(is=pseg->beg; is<(pseg+lsgm1)->end; is++)  {
+	  TotWeightGC += 1.0;
+	  for (hot = 0; hot < gNumHotSpotsGC; hot++)
+	    {
+	      if(is >= gHotSpotStartGC[hot] && is < gHotSpotEndGC[hot])
+		TotWeightGC += (gHSRatesGC[hot]-1.0);
+	    }
+	      //else
+	      //TotWeightGC += 1.0;
+	      if(TotWeightGC > point) 
+		{
+		  break;
+		}
+	    
+	}
+
+	//printf("gc locations = %d\n",is);
+	begic = pseg->beg;              //GRH add (could be wrong)
+	endic = (pseg+lsgm1)->end ;
+
+
+	len_left = floor( 1.0 + log( ran1() )/lnpc ) ;
+	len_right = floor( 1.0 + log( ran1() )/lnpc ) ;
+
+	if ((is - len_left) <= begic) leftgc = 0;
+	if ((is + len_right) >= endic) rightgc = 0;
+
+	if ((leftgc == 0) && (rightgc == 0)) return(-1);
+	if (leftgc == 1) 
+	  {
+	    xover(nsam, ic, (is-len_left));
+	    if (rightgc == 1) 
+	      {
+		if( is+len_right < (chrom[nchrom-1].pseg)->beg ){
+		  ca( nsam, nsites, ic, nchrom-1);
+		  return(-1) ;
+		}
+		xover(nsam, (nchrom-1), (is+len_right));
+		ca(nsam, nsites, ic, (nchrom - 1));
+	      }
+	  }
+	if ((rightgc == 1) && (leftgc == 0)) 
+	  {
+	    xover(nsam, ic, (is+len_right));
+	  }
+
+	return(ic);	
+}
+
+	int
+xover(int nsam,int ic, int is)
+{
+	struct seg *pseg, *pseg2;
+	int i,  lsg, lsgm1, newsg,  jseg, k,  in, spot;
+	double ran1(), len ;
+	//int ind = 0;
+
+	pseg = chrom[ic].pseg ;
+	lsg = chrom[ic].nseg ;
+	len = (pseg + lsg -1)->end - pseg->beg ;
+
+	if (is < pseg->beg) printf("\n\n !!!! \n\n");
+
+	cleft -= 1 - pow(pc,len) ;
+	cright -= 1 - pow(pc, len);
+   /* get seg # (jseg)  */
+
+	for( jseg=0; is >= (pseg+jseg)->end ; jseg++)
+	  if (is == (pseg+jseg)->end) break;    //GRH add
+	if( is >= (pseg+jseg)->beg ) in=1;
+	else in=0;
+	newsg = lsg - jseg ;
+
+   /* copy last part of chrom to nchrom  */
+	nchrom++;
+	if( nchrom >= maxchr ) {
+	    maxchr += 20 ;
+	    chrom = (struct chromo *)realloc( chrom, (unsigned)(maxchr*sizeof(struct chromo))) ;
+	    if( chrom == NULL ) perror( "malloc error. segtre2");
+	    }
+	if( !( pseg2 = chrom[nchrom-1].pseg = (struct seg *)calloc((unsigned)newsg,sizeof(struct seg)) ) )
+		ERROR(" alloc error. re1");
+	chrom[nchrom-1].nseg = newsg;
+	chrom[nchrom-1].pop = chrom[ic].pop ;
+	pseg2->end = (pseg+jseg)->end ;
+	if( in ) {
+		pseg2->beg = is + 1 ;
+		(pseg+jseg)->end = is;
+		}
+	else pseg2->beg = (pseg+jseg)->beg ;
+	pseg2->desc = (pseg+jseg)->desc ;
+	for( k=1; k < newsg; k++ ) {
+		(pseg2+k)->beg = (pseg+jseg+k)->beg;
+		(pseg2+k)->end = (pseg+jseg+k)->end;
+		(pseg2+k)->desc = (pseg+jseg+k)->desc;
+		}
+
+	lsg = chrom[ic].nseg = lsg-newsg + in ;
+	lsgm1 = lsg - 1 ;
+	nlinks -= pseg2->beg - (pseg+lsgm1)->end ;
+
+	len = (pseg+lsgm1)->end - (pseg->beg) ;
+
+	cleft += 1.0 - pow( pc, len) ;
+	cright += 1.0 - pow(pc, len);
+	len = (pseg2 + newsg-1)->end - pseg2->beg ;
+	cleft += 1.0 - pow(pc, len) ;
+	cright += 1.0 - pow(pc, len);
+if( !(chrom[ic].pseg = 
+     (struct seg *)realloc(chrom[ic].pseg,(unsigned)(lsg*sizeof(struct seg)) )) )
+		perror( " realloc error. re2");
+	if( in ) {
+		begs = pseg2->beg;
+		for( i=0,k=0; (k<nsegs-1)&&(begs > seglst[seglst[i].next].beg-1);
+		   i=seglst[i].next, k++) ;
+		if( begs != seglst[i].beg ) {
+						/* new tree  */
+
+	   	   if( nsegs >= seglimit ) {  
+	   	   	  seglimit += SEGINC ;
+	   	      nnodes = (int *)realloc( nnodes,(unsigned)(sizeof(int)*seglimit)) ; 
+	   	      if( nnodes == NULL) perror("realloc error. 1. segtre_mig.c");
+	   	      seglst =
+	   	      	 (struct segl *)realloc( seglst,(unsigned)(sizeof(struct segl)*seglimit));
+	   	      if(seglst == NULL ) perror("realloc error. 2. segtre_mig.c");
+	   	      /*  printf("seglimit: %d\n",seglimit);  */
+	   	      } 
+	   	   seglst[nsegs].next = seglst[i].next;
+	   	   seglst[i].next = nsegs;
+	   	   seglst[nsegs].beg = begs ;
+		   if( !(seglst[nsegs].ptree = (struct node *)calloc((unsigned)(2*nsam), sizeof(struct node)) )) perror("calloc error. re3.");
+		   nnodes[nsegs] = nnodes[i];
+		   ptree1 = seglst[i].ptree;
+		   ptree2 = seglst[nsegs].ptree;
+		   nsegs++ ;
+		   for( k=0; k<=nnodes[i]; k++) {
+		      (ptree2+k)->abv = (ptree1+k)->abv ;
+		      (ptree2+k)->time = (ptree1+k)->time;
+		      }
+		   }
+	}
+	return(ic) ;
+}
+
+/***** common ancestor subroutine **********************
+   Pick two chromosomes and merge them. Update trees if necessary. **/
+
+	int
+ca(nsam, nsites,c1,c2)
+	int nsam,c1,c2;
+	int  nsites;
+{
+	int yes1, yes2, seg1, seg2, seg ;
+	int tseg, start, end, desc, k;
+	struct seg *pseg;
+	struct node *ptree;
+
+
+
+	seg1=0;
+	seg2=0;
+
+
+	if( !(pseg = (struct seg *)calloc((unsigned)nsegs,sizeof(struct seg) ))) perror("alloc error.ca1");
+
+
+	tseg = -1 ;
+	for( seg=0, k=0; k<nsegs; seg=seglst[seg].next, k++) {
+		start = seglst[seg].beg;
+		yes1 = isseg(start, c1, &seg1);
+		yes2 = isseg(start, c2, &seg2);
+		if( yes1 || yes2 ) {
+			tseg++;
+			(pseg+tseg)->beg=seglst[seg].beg;
+			end = ( k< nsegs-1 ? seglst[seglst[seg].next].beg-1 : nsites-1 ) ;
+			(pseg+tseg)->end = end ;
+
+			if( yes1 && yes2 ) {
+				nnodes[seg]++;
+				//temp_pseg = pseg;
+				if( nnodes[seg] >= (2*nsam-2) ) tseg--;
+				else
+					(pseg+tseg)->desc = nnodes[seg];
+				ptree=seglst[seg].ptree;
+				desc = (chrom[c1].pseg + seg1) ->desc;
+				(ptree+desc)->abv = nnodes[seg];
+				desc = (chrom[c2].pseg + seg2) -> desc;
+				(ptree+desc)->abv = nnodes[seg];
+				(ptree+nnodes[seg])->time = t;
+				//pseg = temp_pseg;
+				}
+			else {
+				(pseg+tseg)->desc = ( yes1 ?
+				   (chrom[c1].pseg + seg1)->desc :
+				  (chrom[c2].pseg + seg2)->desc);
+				}
+			}
+		}
+
+	nlinks -= links(c1);
+	cleft -= 1.0 - pow(pc, (double)links(c1));
+	cright -= 1.0 - pow(pc, (double)links(c1));
+	free(chrom[c1].pseg) ;
+	if( tseg < 0 ) {
+		free(pseg) ;
+		chrom[c1].pseg = chrom[nchrom-1].pseg;
+		chrom[c1].nseg = chrom[nchrom-1].nseg;
+		chrom[c1].pop = chrom[nchrom-1].pop ;
+		if( c2 == nchrom-1 ) c2 = c1;
+		nchrom--;
+		}
+	else {
+		if( !(pseg = (struct seg *)realloc(pseg,(unsigned)((tseg+1)*sizeof(struct seg)))))
+			perror(" realloc error. ca1");
+		chrom[c1].pseg = pseg;
+		chrom[c1].nseg = tseg + 1 ;
+		nlinks += links(c1);
+	   	cleft += 1.0 - pow(pc, (double)links(c1));
+		cright += 1.0 - pow(pc, (double)links(c1));
+		}
+	nlinks -= links(c2);
+	cleft -= 1.0 - pow(pc, (double)links(c2));
+	cright -= 1.0 - pow(pc, (double)links(c2));
+	free(chrom[c2].pseg) ;
+	chrom[c2].pseg = chrom[nchrom-1].pseg;
+	chrom[c2].nseg = chrom[nchrom-1].nseg;
+	chrom[c2].pop = chrom[nchrom-1].pop ;
+	nchrom--;
+	if(tseg<0) return( 2 );  /* decrease of nchrom is two */
+	else return( 1 ) ;
+}
+
+/*** Isseg: Does chromosome c contain the segment on seglst which starts at
+	    start? *psg is the segment of chrom[c] at which one is to begin 
+	    looking.  **/
+
+	int
+isseg(start, c, psg)
+	int start, c, *psg;
+{
+	int ns;
+	struct seg *pseg;
+
+	ns = chrom[c].nseg;
+	pseg = chrom[c].pseg;
+
+/*  changed order of test conditions in following line on 6 Dec 2004 */
+	for(  ; ((*psg) < ns ) && ( (pseg+(*psg))->beg <= start ) ; ++(*psg) )
+		if( (pseg+(*psg))->end >= start ) return(1);
+	return(0);
+}
+	
+
+
+	int
+pick2_chrom(pop,config,pc1,pc2)
+	int pop, *pc1, *pc2, config[];
+{
+	int c1, c2, cs,cb,i, count;
+	
+	pick2(config[pop],&c1,&c2);
+	cs = (c1>c2) ? c2 : c1;
+	cb = (c1>c2) ? c1 : c2 ;
+	i=count=0;
+	for(;;){
+		while( chrom[i].pop != pop ) i++;
+		if( count == cs ) break;
+		count++;
+		i++;
+		}
+	*pc1 = i;
+	i++;
+	count++;
+	for(;;){
+		while( chrom[i].pop != pop ) i++;
+		if( count == cb ) break;
+		count++;
+		i++;
+		}
+	*pc2 = i ;
+}
+	
+	
+
+/****  links(c): returns the number of links between beginning and end of chrom **/
+
+	int
+links(c)
+	int c;
+{
+	int ns;
+
+	ns = chrom[c].nseg - 1 ;
+
+	return( (chrom[c].pseg + ns)->end - (chrom[c].pseg)->beg);
+}
+

--- a/data/msdir/Makefile
+++ b/data/msdir/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-ggdb -Wno-unused-result
+CFLAGS=-ansi -ggdb -Wno-unused-result -Wno-return-type
 SRC=ms.c streec.c rand1.c
 all: ms ms_summary_stats sample_stats
 

--- a/data/msdir/streec.c
+++ b/data/msdir/streec.c
@@ -407,7 +407,7 @@ segtre_mig(struct c_params *cp, int *pnsegs )
             /* verify that the events are what we think and count*/
             if (event == 'r') {
                 if (subevent == 'r'){
-                    recombination_events++;                    
+                    recombination_events++;
                 }
                 if (subevent == 'g'){
                     conversion_events++;
@@ -431,6 +431,14 @@ segtre_mig(struct c_params *cp, int *pnsegs )
     for (i = 0; i < N * N; i++) {
         printf("\t%d", migration_events[i]);
     }
+    int end;
+    printf("\t[");
+    for(seg=0, k=0; k<nsegs - 2; seg=seglst[seg].next, k++) {
+		    end = seglst[seglst[seg].next].beg - 1;
+        printf("%.1f, ", (float) end);
+    }
+		end = seglst[seglst[seg].next].beg - 1;
+    printf("%.1f]", (float) end);
     printf("\n");
 #endif
 	*pnsegs = nsegs ;


### PR DESCRIPTION
Pulled in msHOT and modified it to produce summary stats just like with the ms installation. Added an option to `mspms` that allows the specification of recombination "hotspots" identical to the msHOT cli. Added the following tests to the verification suite:
- simple sanity check test that msHOT and ms produce the same result on a simulation with uniform recombination rate
- simulation from the [msHOT documentation](https://uchicago.app.box.com/s/l3e5uf13tikfjm7e1il1eujitlsjdx13/file/68787014053) with recombination hotspots. This test checks out both on master and my other current [PR](https://github.com/tskit-dev/msprime/pull/862) that computes in physical space
- a hotspot with a recombination rate of 0
- multiple recombination hotspots across the sequence, with varying rates of recombination, some zero