### PR TITLE
Fixed scalings in likelihood computation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ jobs:
             gcov -pb ./msprime@sta/recomb_map.c.gcno ../lib/recomb_map.c
             gcov -pb ./msprime@sta/interval_map.c.gcno ../lib/interval_map.c
             gcov -pb ./msprime@sta/util.c.gcno ../lib/util.c
+            gcov -pb ./msprime@sta/likelihood.c.gcno ../lib/likelihood.c
             cd ..
             codecov -X gcov -F C
 

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -4271,7 +4271,7 @@ msprime_log_likelihood_arg(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *ret = NULL;
     int err;
     LightweightTableCollection *tables = NULL;
-    double recombination_rate, Ne, ret_likelihood, rho;
+    double recombination_rate, Ne, ret_likelihood;
     static char *kwlist[] = {"tables", "Ne", "recombination_rate", NULL};
     tsk_treeseq_t ts;
 
@@ -4293,12 +4293,8 @@ msprime_log_likelihood_arg(PyObject *self, PyObject *args, PyObject *kwds)
         handle_tskit_library_error(err);
         goto out;
     }
-    /* Note: this should be done within the library probably because we'll
-     * need to rescale the branch lengths according to Ne also, right?
-     */
-    rho = 4 * Ne * recombination_rate;
 
-    err = msp_log_likelihood_arg(&ts, rho, &ret_likelihood);
+    err = msp_log_likelihood_arg(&ts, recombination_rate, Ne, &ret_likelihood);
     if (err != 0) {
         handle_library_error(err);
         goto out;

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -46,7 +46,7 @@ get_total_material(tsk_treeseq_t *ts) {
 }
 
 int
-msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double theta,
+msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
                                     double *r_lik) {
     int ret = 1;
     tsk_size_t j;
@@ -62,9 +62,9 @@ msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double theta,
     if (ret != 0) {
         goto out;
     }
-    if (theta > 0) {
-        lik = num_mutations * log(total_material * theta) -
-            total_material * theta;
+    if (mu > 0) {
+        lik = num_mutations * log(total_material * mu) -
+            total_material * mu;
         for (it = tsk_tree_first(&tree); it == 1; it = tsk_tree_next(&tree)) {
             for (j = 0; j < tree.sites_length; j++) {
                 if (tree.sites[j].mutations_length != 1) {
@@ -112,7 +112,7 @@ out:
 }
 
 int
-msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik)
+msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
 {
     int ret = 0;
     tsk_id_t i;
@@ -143,7 +143,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik)
         last_parent_edge[edges->child[i]] = i;
     }
     while (lineages > 0) {
-        rate = lineages * (lineages - 1) / 2 + material * rho;
+        rate = lineages * (lineages - 1) / (4 * Ne) + material * r;
         parent = edges->parent[edge];
         lik -= rate * (nodes->time[parent] - sim_time);
         sim_time = nodes->time[parent];
@@ -160,7 +160,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *r_lik)
                 // we evaluate the density rather than probability
                 gap = 1;
             }
-            lik += log(rho * gap);
+            lik += log(r * gap);
         } else {
             material_in_children = -edges->left[edge];
             edge = last_parent_edge[edges->child[edge]];

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -178,6 +178,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
                 lineages--;
                 material -= material_in_children - material_in_parent;
             }
+            lik -= log(2 * Ne);
         }
         if (lineages > 0) {
             edge++;

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2019 University of Oxford
+** Copyright (C) 2019-2020 University of Oxford
 **
 ** This file is part of msprime.
 **
@@ -31,8 +31,8 @@ static double
 get_total_material(tsk_treeseq_t *ts) {
     double ret = 0;
     tsk_size_t j;
-    tsk_edge_table_t *edges = &ts->tables->edges;
-    tsk_node_table_t *nodes = &ts->tables->nodes;
+    const tsk_edge_table_t *edges = &ts->tables->edges;
+    const tsk_node_table_t *nodes = &ts->tables->nodes;
     tsk_id_t parent;
     tsk_id_t child;
 
@@ -48,7 +48,7 @@ get_total_material(tsk_treeseq_t *ts) {
 int
 msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
                                     double *r_lik) {
-    int ret = 1;
+    int ret = 0;
     tsk_size_t j;
     tsk_mutation_t mut;
     tsk_size_t num_mutations = tsk_treeseq_get_num_mutations(ts);
@@ -62,9 +62,8 @@ msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
     if (ret != 0) {
         goto out;
     }
-    if (mu > 0) {
-        lik = num_mutations * log(total_material * mu) -
-            total_material * mu;
+    if (total_material > 0 && mu > 0) {
+        lik = num_mutations * log(total_material * mu) - total_material * mu;
         for (it = tsk_tree_first(&tree); it == 1; it = tsk_tree_next(&tree)) {
             for (j = 0; j < tree.sites_length; j++) {
                 if (tree.sites[j].mutations_length != 1) {
@@ -121,12 +120,17 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
     double material = lineages * tsk_treeseq_get_sequence_length(ts);
     double material_in_children, material_in_parent, rate, gap;
     double lik = 0;
-    tsk_edge_table_t *edges = &ts->tables->edges;
-    tsk_node_table_t *nodes = &ts->tables->nodes;
+    const tsk_edge_table_t *edges = &ts->tables->edges;
+    const tsk_node_table_t *nodes = &ts->tables->nodes;
     tsk_id_t *first_parent_edge = NULL;
     tsk_id_t *last_parent_edge = NULL;
     tsk_id_t edge = 0;
     tsk_id_t parent;
+
+    if (Ne <= 0) {
+        ret = MSP_ERR_BAD_POPULATION_SIZE;
+        goto out;
+    }
 
     first_parent_edge = malloc(nodes->num_rows * sizeof(tsk_id_t));
     last_parent_edge = malloc(nodes->num_rows * sizeof(tsk_id_t));
@@ -142,7 +146,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
         }
         last_parent_edge[edges->child[i]] = i;
     }
-    while (lineages > 0) {
+    while (edge < (tsk_id_t) edges->num_rows && lineages > 0) {
         rate = lineages * (lineages - 1) / (4 * Ne) + material * r;
         parent = edges->parent[edge];
         lik -= rate * (nodes->time[parent] - sim_time);

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -152,6 +152,11 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
         lik -= rate * (nodes->time[parent] - sim_time);
         sim_time = nodes->time[parent];
         if (nodes->flags[parent] & MSP_NODE_IS_RE_EVENT) {
+            if (r <= 0) {
+                *r_lik = -DBL_MAX;
+                ret = 0;
+                goto out;
+            }
             while (edge < (tsk_id_t)edges->num_rows
                     && edges->parent[edge] == parent) {
                 edge++;

--- a/lib/likelihood.h
+++ b/lib/likelihood.h
@@ -23,8 +23,9 @@
 #include <stdio.h>
 #include <tskit.h>
 
-int msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double theta,
+int msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
                                         double *lik);
-int msp_log_likelihood_arg(tsk_treeseq_t *ts, double rho, double *lik);
+int msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne,
+                           double *lik);
 
 #endif /*__LIKELIHOOD_H__*/

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -2189,8 +2189,8 @@ test_likelihood_zero_edges(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(lik, 0);
 
-    /* TODO why do we need this special case? Is it an error or does this
-     * return value have some significance? */
+    /* Zero mutation rate gives a likelihood of zero when there are mutations in
+     * the ARG */
     ret = msp_unnormalised_log_likelihood_mut(&ts, 0, &lik);
     CU_ASSERT_EQUAL_FATAL(lik, -DBL_MAX);
     ret = msp_unnormalised_log_likelihood_mut(&ts, 1, &lik);

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -2170,7 +2170,7 @@ test_likelihood_three_leaves(void)
         ll_exact -= (6 + 3 * rho[i]) * 0.15;
         ll_exact -= (3 + 2.5 * rho[i]) * 0.25;
         ll_exact -= (1 + 2 * rho[i]) * 0.5;
-        ret = msp_log_likelihood_arg(&ts, rho[i], &lik);
+        ret = msp_log_likelihood_arg(&ts, rho[i], 0.5, &lik);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_DOUBLE_EQUAL(ll_exact, lik, tol);
     }
@@ -2266,7 +2266,7 @@ test_likelihood_two_mrcas(void)
         ll_exact += log(rho[i]) - (3 + 2 * rho[i]) * 0.05;
         ll_exact -= (6 + 2 * rho[i]) * 0.35;
         ll_exact -= (1 + rho[i]) * 0.5;
-        ret = msp_log_likelihood_arg(&ts, rho[i], &lik);
+        ret = msp_log_likelihood_arg(&ts, rho[i], 0.5, &lik);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_DOUBLE_EQUAL(ll_exact, lik, tol);
     }
@@ -2368,7 +2368,7 @@ test_likelihood_material_overhang(void)
         ll_exact -= (6 + 2 * rho[i]) * 0.35;
         ll_exact -= (3 + rho[i]) * 0.5;
         ll_exact -= (1 + 0.4 * rho[i]) * 0.3;
-        ret = msp_log_likelihood_arg(&ts, rho[i], &lik);
+        ret = msp_log_likelihood_arg(&ts, rho[i], 0.5, &lik);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_DOUBLE_EQUAL(ll_exact, lik, tol);
     }
@@ -2481,7 +2481,7 @@ test_likelihood_material_gap(void)
         ll_exact -= (6 + 2 * rho[i]) * 0.1;
         ll_exact -= (3 + 2.2 * rho[i]) * 0.1;
         ll_exact -= (1 + 0.4 * rho[i]) * 0.1;
-        ret = msp_log_likelihood_arg(&ts, rho[i], &lik);
+        ret = msp_log_likelihood_arg(&ts, rho[i], 0.5, &lik);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_DOUBLE_EQUAL(ll_exact, lik, tol);
     }
@@ -2605,7 +2605,7 @@ test_likelihood_recombination_in_material_gap(void)
         ll_exact -= (6 + 2 * rho[i]) * 0.1;
         ll_exact -= (3 + 2 * rho[i]) * 0.1;
         ll_exact -= (1 + 1.4 * rho[i]) * 0.1;
-        ret = msp_log_likelihood_arg(&ts, rho[i], &lik);
+        ret = msp_log_likelihood_arg(&ts, rho[i], 0.5, &lik);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         CU_ASSERT_DOUBLE_EQUAL(ll_exact, lik, tol);
     }

--- a/msprime/likelihood.py
+++ b/msprime/likelihood.py
@@ -60,10 +60,7 @@ def unnormalised_log_mutation_likelihood(arg, mu):
     return ret
 
 
-def log_arg_likelihood(arg, recombination_rate, Ne=0.5):
-    # TODO: Ne should default to 1 for compatability with msprime.simulate. Setting
-    # to 1/2 now to keep the tests working.
-
+def log_arg_likelihood(arg, recombination_rate, Ne=1):
     # Get the tables into the format we need to interchange with the low-level code.
     lw_tables = _msprime.LightweightTableCollection()
     lw_tables.fromdict(arg.tables.asdict())

--- a/msprime/likelihood.py
+++ b/msprime/likelihood.py
@@ -42,21 +42,22 @@ def unnormalised_log_mutation_likelihood(arg, mu):
     else:
         ret = (number_of_mutations * math.log(total_material * mu) -
                total_material * mu)
-    for tree in arg.trees():
-        for site in tree.sites():
-            mutation = site.mutations[0]
-            child = mutation.node
-            parent = tree.parent(child)
-            potential_branch_length = tree.branch_length(child)
-            while tree.parent(parent) is not None and len(tree.children(parent)) == 1:
-                child = parent
+        for tree in arg.trees():
+            for site in tree.sites():
+                mutation = site.mutations[0]
+                child = mutation.node
                 parent = tree.parent(child)
-                potential_branch_length += tree.branch_length(child)
-            child = mutation.node
-            while len(tree.children(child)) == 1:
-                child = tree.children(child)[0]
-                potential_branch_length += tree.branch_length(child)
-            ret += math.log(potential_branch_length / total_material)
+                potential_branch_length = tree.branch_length(child)
+                while tree.parent(parent) is not None \
+                        and len(tree.children(parent)) == 1:
+                    child = parent
+                    parent = tree.parent(child)
+                    potential_branch_length += tree.branch_length(child)
+                child = mutation.node
+                while len(tree.children(child)) == 1:
+                    child = tree.children(child)[0]
+                    potential_branch_length += tree.branch_length(child)
+                ret += math.log(potential_branch_length / total_material)
     return ret
 
 

--- a/msprime/likelihood.py
+++ b/msprime/likelihood.py
@@ -24,7 +24,7 @@ import math
 import _msprime
 
 
-def unnormalised_log_mutation_likelihood(arg, theta):
+def unnormalised_log_mutation_likelihood(arg, mu):
     # log_likelihood of mutations on a given ARG up to a normalising constant
     # that depends on the pattern of observed mutations, but not on the ARG
     # or the mutation rate
@@ -34,14 +34,14 @@ def unnormalised_log_mutation_likelihood(arg, theta):
     for e in tables.edges:
         total_material += (e.right - e.left) * (time[e.parent] - time[e.child])
     number_of_mutations = len(tables.mutations)
-    if theta == 0:
+    if mu == 0:
         if number_of_mutations == 0:
             ret = 0
         else:
             ret = -float("inf")
     else:
-        ret = (number_of_mutations * math.log(total_material * theta) -
-               total_material * theta)
+        ret = (number_of_mutations * math.log(total_material * mu) -
+               total_material * mu)
     for tree in arg.trees():
         for site in tree.sites():
             mutation = site.mutations[0]
@@ -60,9 +60,9 @@ def unnormalised_log_mutation_likelihood(arg, theta):
     return ret
 
 
-def log_arg_likelihood(arg, recombination_rate, Ne=0.25):
+def log_arg_likelihood(arg, recombination_rate, Ne=0.5):
     # TODO: Ne should default to 1 for compatability with msprime.simulate. Setting
-    # to 1/4 now to keep the tests working.
+    # to 1/2 now to keep the tests working.
 
     # Get the tables into the format we need to interchange with the low-level code.
     lw_tables = _msprime.LightweightTableCollection()

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2241,6 +2241,10 @@ class TestLikelihood(unittest.TestCase):
             with self.assertRaises(ValueError):
                 _msprime.log_likelihood_arg(tables, 1, recombination_rate=bad_rec_rate)
 
+        for bad_Ne in [0, -1]:
+            with self.assertRaises(_msprime.LibraryError):
+                _msprime.log_likelihood_arg(tables, bad_Ne, recombination_rate=1)
+
     def test_bad_tables(self):
         # Pass in a table collection that can't be made into a tree
         # sequence.


### PR DESCRIPTION
I've fixed the scaling inconsistency that Ali pointed out. The likelihood function arguments are now per-generation mutation and recombination probabilities, as well as Ne, and everything is calculated in generations. 

I think I've kept everything consistent with your overall plumbing and all tests pass in both C and python, but let me know if you spot anything that looks out of place @jeromekelleher.