### PR TITLE
adding statistical tests of sweeps (WIP)

### DIFF
--- a/lib/dev-tools/example.cfg
+++ b/lib/dev-tools/example.cfg
@@ -32,8 +32,8 @@ model = {
     #truncation_point = 1.0;
 
     # The discrete time Wright Fisher
-    /* name = "dtwf"; */
-    /* population_size = 10.0; */
+    # name = "dtwf"; 
+    # population_size = 10.0; 
 
     # The genic selection sweep model
     /* name = "sweep_genic_selection"; */ 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4415,15 +4415,6 @@ msp_run_sweep(msp_t *self)
             total_rate = sweep_pop_tot_rate;
             event_prob *= 1.0 - total_rate;
             curr_step++;
-            /* sanity check print statement */
-            //printf("p: %g p_coal_b: %g p_coal_B: %g p_rec_b: %g p_rec_B: %g total_rate: %g event_prob: %g event_rand:%g\n", allele_frequency[curr_step],p_coal_b, 
-            //        p_coal_B, p_rec_b, p_rec_B, total_rate, event_prob, event_rand);
-           // printf("curr_step: %ld num_steps: %ld\n", curr_step, num_steps);
-            //printf("sweep_pop_sizes: %g %g pop_size: %g\n", sweep_pop_sizes[0], sweep_pop_sizes[1], pop_size);
-            /* JK->Andy: is this what it means when the total_rate goes to 0? */
-            /* AK-> JK: it means that all of the alleles have coalesced onto a
-             * background and we can stop the structured phase of the
-             * simulation */
             sweep_over = total_rate == 0;
         }
         if (sweep_over) {
@@ -6249,10 +6240,6 @@ genic_selection_generate_trajectory(sweep_t *self, msp_t *simulator,
         num_steps++;
     }
     assert(num_steps < max_steps); /* num_steps + 1 above guarantees this */
-    /* JK: question to Andy: Does this bookending make sense?
-     * Seemed logical that we'd always have at least two steps
-     */
-    /* fine by me */
     time[num_steps] = t;
     allele_frequency[num_steps] = trajectory.start_frequency;
     num_steps++;
@@ -6564,7 +6551,7 @@ msp_set_simulation_model_beta(msp_t *self, double reference_size, double alpha,
 
     /* Numerical instability occurs for values above 2 - 0.0005. */
     if (alpha <= 1.0 || alpha >= 2.0) {
-        ret = MSP_ERR_BAD_ALPHA;
+        ret = MSP_ERR_BAD_BETA_MODEL_ALPHA;
         goto out;
     }
 
@@ -6652,7 +6639,7 @@ msp_set_simulation_model_sweep_genic_selection(msp_t *self, double reference_siz
         goto out;
     }
     if (alpha <= 0) {
-        ret = MSP_ERR_BAD_ALPHA;
+        ret = MSP_ERR_BAD_SWEEP_GENIC_SELECTION_ALPHA;
         goto out;
     }
 
@@ -6665,10 +6652,9 @@ msp_set_simulation_model_sweep_genic_selection(msp_t *self, double reference_siz
     model->params.sweep.print_state = genic_selection_print_state;
     trajectory->start_frequency = start_frequency;
     trajectory->end_frequency = end_frequency;
-    /* JK: question for Andy: what are the dimensions of alpha? Does it
-     * need to be rescaled into generations? */
-    /* AK: so alpha in discoal is scaled selection coefficient 2Ns
-     * i believe that for msprime we need to alter this to fit time change */
+    /* FIXME alpha must be rescaled here. See
+     * https://github.com/tskit-dev/msprime/issues/941
+     */
     trajectory->alpha = alpha;
     /* dt value is expressed in generations for consistency; translate to
      * model time. */

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -3362,7 +3362,7 @@ test_beta_coalescent_bad_parameters(void)
 
     for (j = 0; j < sizeof(alphas) / sizeof(*alphas); j++) {
         ret = msp_set_simulation_model_beta(&msp, 1, alphas[j], 1);
-        CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_ALPHA);
+        CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_BETA_MODEL_ALPHA);
     }
     for (j = 0; j < sizeof(truncation_points) / sizeof(*truncation_points); j++) {
         ret = msp_set_simulation_model_beta(&msp, 1, 1.5, truncation_points[j]);
@@ -4598,7 +4598,6 @@ verify_simple_genic_selection_trajectory(
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_set_simulation_model_sweep_genic_selection(
         &msp, 0.25, 0.5, start_frequency, end_frequency, alpha, dt);
-    printf("%d\n",ret);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4701,7 +4700,7 @@ test_sweep_genic_selection_bad_parameters(void)
 
     ret = msp_set_simulation_model_sweep_genic_selection(
         &msp, 1.0, 0.5, 0.1, 0.9, -666, 0.1);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ALPHA);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SWEEP_GENIC_SELECTION_ALPHA);
     /* The incorrect number of populations was specified */
     ret = msp_set_dimensions(&msp, 2, 2);
     CU_ASSERT_EQUAL(ret, 0);

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -4598,6 +4598,7 @@ verify_simple_genic_selection_trajectory(
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_set_simulation_model_sweep_genic_selection(
         &msp, 0.25, 0.5, start_frequency, end_frequency, alpha, dt);
+    printf("%d\n",ret);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4634,7 +4635,6 @@ test_genic_selection_trajectory(void)
     verify_simple_genic_selection_trajectory(0.1, 0.9, 0.01, 0.00125);
     verify_simple_genic_selection_trajectory(0.8999, 0.9, 0.1, 0.2);
     verify_simple_genic_selection_trajectory(0.1, 0.9, 100, 0.1);
-    verify_simple_genic_selection_trajectory(0.1, 0.9, -100, 0.1);
     verify_simple_genic_selection_trajectory(0.1, 0.9, 1, 10);
 }
 
@@ -4699,6 +4699,9 @@ test_sweep_genic_selection_bad_parameters(void)
         &msp, 1.0, 0.5, 0.1, 0.9, 0.1, 0.1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    ret = msp_set_simulation_model_sweep_genic_selection(
+        &msp, 1.0, 0.5, 0.1, 0.9, -666, 0.1);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ALPHA);
     /* The incorrect number of populations was specified */
     ret = msp_set_dimensions(&msp, 2, 2);
     CU_ASSERT_EQUAL(ret, 0);

--- a/lib/util.c
+++ b/lib/util.c
@@ -139,6 +139,9 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_TRAJECTORY_START_END:
             ret = "Start frequency must be less than end frequency";
             break;
+        case MSP_ERR_BAD_SWEEP_GENIC_SELECTION_ALPHA:
+            ret = "alpha must be > 0";
+            break;
         case MSP_ERR_EVENTS_DURING_SWEEP:
             ret = "Demographic and sampling events during a sweep "
                 "are not supported";
@@ -163,7 +166,7 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_PROPORTION:
             ret = "Proportion values must have 0 <= x <= 1";
             break;
-        case MSP_ERR_BAD_ALPHA:
+        case MSP_ERR_BAD_BETA_MODEL_ALPHA:
             ret = "Bad alpha. Must have 1 < alpha < 2";
             break;
         case MSP_ERR_BAD_TRUNCATION_POINT:

--- a/lib/util.h
+++ b/lib/util.h
@@ -69,21 +69,22 @@
 #define MSP_ERR_BAD_TIME_DELTA                                      -31
 #define MSP_ERR_BAD_ALLELE_FREQUENCY                                -32
 #define MSP_ERR_BAD_TRAJECTORY_START_END                            -33
-#define MSP_ERR_EVENTS_DURING_SWEEP                                 -34
-#define MSP_ERR_UNSUPPORTED_OPERATION                               -35
-#define MSP_ERR_DTWF_ZERO_POPULATION_SIZE                           -36
-#define MSP_ERR_DTWF_UNSUPPORTED_BOTTLENECK                         -37
-#define MSP_ERR_BAD_PROPORTION                                      -38
-#define MSP_ERR_BAD_PEDIGREE_NUM_SAMPLES                            -39
-#define MSP_ERR_BAD_PEDIGREE_ID                                     -40
-#define MSP_ERR_BAD_ALPHA                                           -41
-#define MSP_ERR_BAD_TRUNCATION_POINT                                -42
-#define MSP_ERR_BAD_MUTATION_MAP_RATE                               -43
-#define MSP_ERR_INCOMPATIBLE_MUTATION_MAP                           -44
-#define MSP_ERR_INSUFFICIENT_INTERVALS                              -45
-#define MSP_ERR_INTERVAL_MAP_START_NON_ZERO                         -46
-#define MSP_ERR_NEGATIVE_INTERVAL_POSITION                          -47
-#define MSP_ERR_INTERVAL_POSITIONS_UNSORTED                         -48
+#define MSP_ERR_BAD_SWEEP_GENIC_SELECTION_ALPHA                     -34
+#define MSP_ERR_EVENTS_DURING_SWEEP                                 -35
+#define MSP_ERR_UNSUPPORTED_OPERATION                               -36
+#define MSP_ERR_DTWF_ZERO_POPULATION_SIZE                           -37
+#define MSP_ERR_DTWF_UNSUPPORTED_BOTTLENECK                         -38
+#define MSP_ERR_BAD_PROPORTION                                      -39
+#define MSP_ERR_BAD_PEDIGREE_NUM_SAMPLES                            -40
+#define MSP_ERR_BAD_PEDIGREE_ID                                     -41
+#define MSP_ERR_BAD_BETA_MODEL_ALPHA                                -42
+#define MSP_ERR_BAD_TRUNCATION_POINT                                -43
+#define MSP_ERR_BAD_MUTATION_MAP_RATE                               -44
+#define MSP_ERR_INCOMPATIBLE_MUTATION_MAP                           -45
+#define MSP_ERR_INSUFFICIENT_INTERVALS                              -46
+#define MSP_ERR_INTERVAL_MAP_START_NON_ZERO                         -47
+#define MSP_ERR_NEGATIVE_INTERVAL_POSITION                          -48
+#define MSP_ERR_INTERVAL_POSITIONS_UNSORTED                         -49
 
 /* This bit is 0 for any errors originating from tskit */
 #define MSP_TSK_ERR_BIT 13

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -125,7 +125,8 @@ def model_factory(model, reference_size=1):
         "smc": SmcApproxCoalescent(reference_size),
         "smc_prime": SmcPrimeApproxCoalescent(reference_size),
         "dtwf": DiscreteTimeWrightFisher(reference_size),
-        "wf_ped": WrightFisherPedigree(reference_size)
+        "wf_ped": WrightFisherPedigree(reference_size),
+        "sweep_genic_selection": SweepGenicSelection(reference_size)
     }
     if model is None:
         model_instance = StandardCoalescent(reference_size)
@@ -583,7 +584,8 @@ class Simulator(object):
     Class to simulate trees under a variety of population models.
     """
     def __init__(
-            self, samples, recombination_map, model="hudson", Ne=0.25, from_ts=None):
+            self, samples, recombination_map, model="hudson", Ne=0.25,
+            from_ts=None):
         if from_ts is None:
             if len(samples) < 2:
                 raise ValueError("Sample size must be >= 2")
@@ -1954,13 +1956,16 @@ class DiracCoalescent(ParametricSimulationModel):
 
 
 class SweepGenicSelection(ParametricSimulationModel):
-    # TODO document
+    """
+    Class representing a model with a single selective sweep
+    in the population history. Sweep ends (looking forward in time)
+    at the time of sampling
+    """
     name = "sweep_genic_selection"
 
-    # TODO: sensible defaults for some of these params?
     def __init__(
-            self, position, start_frequency, end_frequency, alpha, dt,
-            reference_size=1):
+            self, position=2, start_frequency=0.001, end_frequency=0.999,
+            alpha=1000, dt=0.01, reference_size=1):
         self.reference_size = reference_size
         self.position = position
         self.start_frequency = start_frequency

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -126,7 +126,6 @@ def model_factory(model, reference_size=1):
         "smc_prime": SmcPrimeApproxCoalescent(reference_size),
         "dtwf": DiscreteTimeWrightFisher(reference_size),
         "wf_ped": WrightFisherPedigree(reference_size),
-        "sweep_genic_selection": SweepGenicSelection(reference_size)
     }
     if model is None:
         model_instance = StandardCoalescent(reference_size)
@@ -1956,16 +1955,16 @@ class DiracCoalescent(ParametricSimulationModel):
 
 
 class SweepGenicSelection(ParametricSimulationModel):
-    """
-    Class representing a model with a single selective sweep
-    in the population history. Sweep ends (looking forward in time)
-    at the time of sampling
-    """
+    # TODO document
     name = "sweep_genic_selection"
 
     def __init__(
-            self, position=2, start_frequency=0.001, end_frequency=0.999,
-            alpha=1000, dt=0.01, reference_size=1):
+            self, position, start_frequency, end_frequency,
+            alpha, dt=None, reference_size=1):
+        # We might want to have a default dt value that depends on the other
+        # parameters.
+        if dt is None:
+            dt = 0.01
         self.reference_size = reference_size
         self.position = position
         self.start_frequency = start_frequency

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -626,6 +626,11 @@ class TestSweepGenicSelection(unittest.TestCase):
     """
     Tests for the single sweep model.
     """
+    def test_default_dt(self):
+        model = msprime.SweepGenicSelection(
+            position=0.5, start_frequency=0.1, end_frequency=0.9, alpha=0.1)
+        self.assertEqual(model.dt, 0.01)
+
     def test_incorrect_num_labels(self):
         model = msprime.SweepGenicSelection(
             position=0.5, start_frequency=0.1, end_frequency=0.9, alpha=0.1,


### PR DESCRIPTION
I added an example statistical test between the msprime implementation and my old discoal implementation. I'm not 100% confident that all the scaling conversions are good to go between discoal and msprime however. @petrelharp looked over my should a bit today and we got it pretty close but I'm not sure how to scale the selection coefficient between discoal and msprime. 

from playing with it way too much it looks like the \alpha_discoal * 2 = \alpha_msprime, but I'm scratching my head as to why. 

