### PR TITLE
Store left and right endpoint masses in segments

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -89,6 +89,8 @@ typedef struct segment_t_t {
     /* During simulation we use genetic coordinates */
     double left;
     double right;
+    double left_mass;
+    double right_mass;
     node_id_t value;
     size_t id;
     struct segment_t_t *prev;
@@ -451,6 +453,7 @@ int recomb_map_alloc(recomb_map_t *self,
 int recomb_map_free(recomb_map_t *self);
 uint32_t recomb_map_get_num_loci(recomb_map_t *self);
 double recomb_map_get_sequence_length(recomb_map_t *self);
+bool recomb_map_get_discrete(recomb_map_t *self);
 double recomb_map_get_per_locus_recombination_rate(recomb_map_t *self);
 double recomb_map_get_total_recombination_rate(recomb_map_t *self);
 double recomb_map_genetic_to_phys(recomb_map_t *self, double genetic_x);

--- a/lib/recomb_map.c
+++ b/lib/recomb_map.c
@@ -139,6 +139,11 @@ recomb_map_get_sequence_length(recomb_map_t *self)
     return self->sequence_length;
 }
 
+bool recomb_map_get_discrete(recomb_map_t *self)
+{
+    return self->discrete;
+}
+
 double
 recomb_map_mass_between(recomb_map_t *self, double left, double right)
 {


### PR DESCRIPTION
- Add the masses of left and right endpoints in the segment struct. This avoids doing lookups for segment masses when merging segment chains in methods like `merge_two_ancestors`. This change takes the new methods introduced in #862 like `recomb_map_mass_between` off the critical path. The special case of updating the mass of a segment at the start of a segment chain in discrete coordinates still requires a lookup, but the impact is negligible.

- Some small refactoring of update methods for masses on the Fenwick tree.

Resolves #873.