### PR TITLE
test of changing models from sweep to hudson using time set to INF

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -141,14 +141,14 @@ that are currently supported. Note that all times are measured in
 generations, all sizes are absolute (i.e., *not* relative to :math:`N_e`),
 and all rates are per-generation.
 
+Model change events are also considered to be demographic events;
+see the :ref:`sec_api_simulation_models_change_events` section for details.
+
 .. autoclass:: msprime.PopulationParametersChange
 .. autoclass:: msprime.MigrationRateChange
 .. autoclass:: msprime.MassMigration
-.. autoclass:: msprime.SimulationModelChange
-
-.. _sec_api_demographic_events_census:
-
 .. autoclass:: msprime.CensusEvent
+
 
 ++++++++++++++++++++++++++++
 Debugging demographic models
@@ -198,6 +198,11 @@ and
     msprime.simulate(10, model=msprime.DiscreteTimeWrightFisher(1000))
 
 define the same simulation.
+
+.. note:: When ``Ne`` and an instance of :class:`.SimulationModel` with
+    ``reference_size`` set are both provided as arguments to :func:`.simulate`,
+    the ``Ne`` parameter is ignored.
+
 
 .. todo:: Add a discussion of population sizes here, describing
     what Ne/model.reference_size really means, and how it interacts
@@ -272,6 +277,27 @@ To use this option, set the flag ``model="dtwf"`` as in the following example::
 All other parameters can be set as usual.
 
 .. autoclass:: msprime.DiscreteTimeWrightFisher
+
+
+.. _sec_api_simulation_models_selective_sweeps:
+
+++++++++++++++++
+Selective sweeps
+++++++++++++++++
+
+.. todo:: Document the selective sweep models.
+
+
+.. _sec_api_simulation_models_change_events:
+
+++++++++++++++++++++++++
+Simulation model changes
+++++++++++++++++++++++++
+
+.. todo:: Describe the subtleties of how simulation model changes work
+    along with how times are computed.
+
+.. autoclass:: msprime.SimulationModelChange
 
 
 .. _sec_api_simulate_from:

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -1597,6 +1597,9 @@ class SimulationModelChange(DemographicEvent):
     :param float time: The time at which the simulation model changes
         to the new model, in generations. After this time, all internal
         tree nodes, edges and migrations are the result of the new model.
+        If time is set to infinity using ``np.Inf`` this has the effect
+        of the model change occuring after all other model change events
+        have completed.
     :param model: The new simulation model to use.
         This can either be a string (e.g., ``"smc_prime"``) or an instance of
         a simulation model class (e.g, ``msprime.DiscreteTimeWrightFisher(100)``.

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -598,18 +598,6 @@ class TestSimulatorFactory(unittest.TestCase):
             self.assertEqual(
                 ll_sim.get_sequence_length(), recomb_map.get_sequence_length())
 
-    def test_zero_recombination_map(self):
-        # test that beginning and trailing zero recombination regions in the
-        # recomb map are included in the sequence
-        for n in range(3, 10):
-            positions = list(range(n))
-            rates = [0.0, 0.2] + [0.0] * (n - 2)
-            recomb_map = msprime.RecombinationMap(positions, rates)
-            ts = msprime.simulate(10, recombination_map=recomb_map)
-            self.assertEqual(ts.sequence_length, n - 1)
-            self.assertEqual(min(ts.tables.edges.left), 0.0)
-            self.assertEqual(max(ts.tables.edges.right), n - 1.0)
-
     def test_combining_recomb_map_and_rate_length(self):
         recomb_map = msprime.RecombinationMap([0, 1], [1, 0])
         self.assertRaises(
@@ -622,52 +610,6 @@ class TestSimulatorFactory(unittest.TestCase):
             ValueError, msprime.simulator_factory, 10,
             recombination_map=recomb_map, length=1,
             recombination_rate=1)
-
-    def test_mean_recombination_rate(self):
-        # Some quick sanity checks.
-        recomb_map = msprime.RecombinationMap([0, 1], [1, 0])
-        mean_rr = recomb_map.mean_recombination_rate
-        self.assertEqual(mean_rr, 1.0)
-
-        recomb_map = msprime.RecombinationMap([0, 1, 2], [1, 0, 0])
-        mean_rr = recomb_map.mean_recombination_rate
-        self.assertEqual(mean_rr, 0.5)
-
-        recomb_map = msprime.RecombinationMap([0, 1, 2], [0, 0, 0])
-        mean_rr = recomb_map.mean_recombination_rate
-        self.assertEqual(mean_rr, 0.0)
-
-        # Test mean_recombination_rate is correct after reading from
-        # a hapmap file. RecombinationMap.read_hapmap() ignores the cM
-        # field, so here we test against using the cM field directly.
-        def hapmap_rr(hapmap_file):
-            first_pos = 0
-            with open(hapmap_file) as f:
-                next(f)  # skip header
-                for line in f:
-                    pos, rate, cM = map(float, line.split()[1:4])
-                    if cM == 0:
-                        first_pos = pos
-            return cM / 100 / (pos - first_pos)
-
-        hapmap = """chr pos        rate                    cM
-                    1   4283592    3.79115663174456        0
-                    1   4361401    0.0664276817058413      0.294986106359414
-                    1   7979763   10.9082897515584         0.535345505591925
-                    1   8007051    0.0976780648822495      0.833010916332456
-                    1   8762788    0.0899929572085616      0.906829844052373
-                    1   9477943    0.0864382908650907      0.971188757364862
-                    1   9696341    4.76495005895746        0.990066707213216
-                    1   9752154    0.0864316558730679      1.25601286485381
-                    1   9881751    0.0                     1.26721414815999"""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            hapfile = os.path.join(temp_dir, "hapmap.txt")
-            with open(hapfile, "w") as f:
-                f.write(hapmap)
-            recomb_map = msprime.RecombinationMap.read_hapmap(f.name)
-            mean_rr = recomb_map.mean_recombination_rate
-            mean_rr2 = hapmap_rr(hapfile)
-        self.assertAlmostEqual(mean_rr, mean_rr2, places=15)
 
     def test_sample_combination_errors(self):
         # Make sure that the various ways we can specify the samples
@@ -713,6 +655,20 @@ class TestSimulatorFactory(unittest.TestCase):
         self.assertEqual(sim.samples, samples)
         ll_sim = sim.create_ll_instance()
         self.assertEqual(ll_sim.get_samples(), samples)
+
+    def test_model_change_event_sizes(self):
+        models = [msprime.SweepGenicSelection(
+            position=j, start_frequency=j, end_frequency=j, alpha=j, dt=j,
+            reference_size=j) for j in range(1, 10)]
+        sim = msprime.simulator_factory(
+                sample_size=2, Ne=10,
+                demographic_events=[
+                    msprime.SimulationModelChange(None, model) for model in models])
+        self.assertEqual(sim.model.reference_size, 10)
+        self.assertEqual(len(sim.model_change_events), len(models))
+        for event, model in zip(sim.model_change_events, models):
+            self.assertEqual(
+                event.model.get_ll_representation(), model.get_ll_representation())
 
 
 class TestSimulateInterface(unittest.TestCase):
@@ -901,3 +857,61 @@ class TestRecombinationMap(unittest.TestCase):
         for truthy in [True, False, {}, None, "ser"]:
             rm = msprime.RecombinationMap.uniform_map(1, 0, discrete=truthy)
             self.assertEqual(rm.discrete, bool(truthy))
+
+    def test_zero_recombination_map(self):
+        # test that beginning and trailing zero recombination regions in the
+        # recomb map are included in the sequence
+        for n in range(3, 10):
+            positions = list(range(n))
+            rates = [0.0, 0.2] + [0.0] * (n - 2)
+            recomb_map = msprime.RecombinationMap(positions, rates)
+            ts = msprime.simulate(10, recombination_map=recomb_map)
+            self.assertEqual(ts.sequence_length, n - 1)
+            self.assertEqual(min(ts.tables.edges.left), 0.0)
+            self.assertEqual(max(ts.tables.edges.right), n - 1.0)
+
+    def test_mean_recombination_rate(self):
+        # Some quick sanity checks.
+        recomb_map = msprime.RecombinationMap([0, 1], [1, 0])
+        mean_rr = recomb_map.mean_recombination_rate
+        self.assertEqual(mean_rr, 1.0)
+
+        recomb_map = msprime.RecombinationMap([0, 1, 2], [1, 0, 0])
+        mean_rr = recomb_map.mean_recombination_rate
+        self.assertEqual(mean_rr, 0.5)
+
+        recomb_map = msprime.RecombinationMap([0, 1, 2], [0, 0, 0])
+        mean_rr = recomb_map.mean_recombination_rate
+        self.assertEqual(mean_rr, 0.0)
+
+        # Test mean_recombination_rate is correct after reading from
+        # a hapmap file. RecombinationMap.read_hapmap() ignores the cM
+        # field, so here we test against using the cM field directly.
+        def hapmap_rr(hapmap_file):
+            first_pos = 0
+            with open(hapmap_file) as f:
+                next(f)  # skip header
+                for line in f:
+                    pos, rate, cM = map(float, line.split()[1:4])
+                    if cM == 0:
+                        first_pos = pos
+            return cM / 100 / (pos - first_pos)
+
+        hapmap = """chr pos        rate                    cM
+                    1   4283592    3.79115663174456        0
+                    1   4361401    0.0664276817058413      0.294986106359414
+                    1   7979763   10.9082897515584         0.535345505591925
+                    1   8007051    0.0976780648822495      0.833010916332456
+                    1   8762788    0.0899929572085616      0.906829844052373
+                    1   9477943    0.0864382908650907      0.971188757364862
+                    1   9696341    4.76495005895746        0.990066707213216
+                    1   9752154    0.0864316558730679      1.25601286485381
+                    1   9881751    0.0                     1.26721414815999"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            hapfile = os.path.join(temp_dir, "hapmap.txt")
+            with open(hapfile, "w") as f:
+                f.write(hapmap)
+            recomb_map = msprime.RecombinationMap.read_hapmap(f.name)
+            mean_rr = recomb_map.mean_recombination_rate
+            mean_rr2 = hapmap_rr(hapfile)
+        self.assertAlmostEqual(mean_rr, mean_rr2, places=15)

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1136,6 +1136,22 @@ class TestSimulator(LowLevelTestCase):
             # Because we have a flat map we should convert exactly.
             self.assertEqual(j, model["locus"])
 
+    def test_sweep_after_coalescence(self):
+        sim = _msprime.Simulator(
+            get_samples(10),
+            uniform_recombination_map(L=10, rate=1),
+            _msprime.RandomGenerator(1),
+            _msprime.LightweightTableCollection(),
+            num_labels=2)
+        done = sim.run()
+        self.assertTrue(done)
+        t_before = sim.get_time()
+        for _ in range(100):
+            model = get_sweep_genic_selection_model(position=5)
+            sim.set_model(model)
+            self.assertTrue(sim.run())
+            self.assertEqual(t_before, sim.get_time())
+
     def test_store_migrations(self):
         def f(num_samples=10, random_seed=1, **kwargs):
             samples = [(j % 2, 0) for j in range(num_samples)]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -630,7 +630,8 @@ class TestSweepGenicSelection(unittest.TestCase):
             num_labels=2, random_seed=2)
         self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
 
-    @unittest.skip("Can't get sweep to be incomplete")
+    # commenting out skip as test works
+    # @unittest.skip("Can't get sweep to be incomplete")
     def test_sweep_start_time_incomplete(self):
         # Short sweep that doesn't make complete coalescence.
         sweep_model = msprime.SweepGenicSelection(
@@ -644,3 +645,20 @@ class TestSweepGenicSelection(unittest.TestCase):
                 msprime.SimulationModelChange(t_start, sweep_model)],
             num_labels=2, random_seed=2)
         self.assertTrue(any(tree.num_roots > 1 for tree in ts.trees()))
+
+    def test_sweep_model_change_time_complete(self):
+        # Short sweep that doesn't coalesce folled
+        # by Hudson phase to finish up coalescent
+        sweep_model = msprime.SweepGenicSelection(
+            reference_size=0.25, position=0.5, start_frequency=0.69,
+            end_frequency=0.7, alpha=1e-5, dt=1)
+        t_start = 0.0
+        ts = msprime.simulate(
+            10, Ne=0.25,
+            recombination_rate=2,
+            demographic_events=[
+                msprime.SimulationModelChange(t_start, sweep_model),
+                msprime.SimulationModelChange(np.Inf, "hudson")],
+            num_labels=2,
+            random_seed=2)
+        self.assertFalse(any(tree.num_roots > 1 for tree in ts.trees()))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 University of Oxford
+# Copyright (C) 2016-2020 University of Oxford
 
 #
 # This file is part of msprime.
@@ -569,6 +569,17 @@ class TestMixedModels(unittest.TestCase):
         for tree in ts.trees():
             self.assertEqual(tree.num_roots, 1)
 
+    def test_too_many_models(self):
+        # What happens when we have loads of models
+        demographic_events = []
+        models = ["hudson", "smc"]
+        for j in range(1000):
+            demographic_events.append(
+                msprime.SimulationModelChange(time=j, model=models[j % 2]))
+        ts = msprime.simulate(
+            10, demographic_events=demographic_events, random_seed=2)
+        self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
+
     def test_models_demographic_events(self):
         Ne = 10000
         ts = msprime.simulate(
@@ -582,6 +593,35 @@ class TestMixedModels(unittest.TestCase):
         for tree in ts.trees():
             self.assertEqual(tree.num_roots, 1)
             self.assertEqual(ts.node(tree.root).time, 11)
+
+    def test_models_out_of_order(self):
+        with self.assertRaises(ValueError):
+            msprime.simulate(
+                Ne=10,
+                sample_size=10,
+                demographic_events=[
+                    msprime.SimulationModelChange(10, "hudson"),
+                    msprime.SimulationModelChange(8, "hudson")])
+
+    def test_model_change_negative_time(self):
+        with self.assertRaises(ValueError):
+            msprime.simulate(
+                Ne=10,
+                sample_size=10,
+                demographic_events=[
+                    msprime.SimulationModelChange(-10, "hudson")])
+
+    def test_model_change_time_bad_func(self):
+        def bad_func(t):
+            return t - 1
+
+        with self.assertRaises(ValueError):
+            msprime.simulate(
+                Ne=10,
+                sample_size=10,
+                demographic_events=[
+                    msprime.SimulationModelChange(1, "hudson"),
+                    msprime.SimulationModelChange(bad_func, "hudson")])
 
 
 class TestSweepGenicSelection(unittest.TestCase):
@@ -669,6 +709,21 @@ class TestSweepGenicSelection(unittest.TestCase):
                 msprime.SimulationModelChange(None, "hudson")],
             random_seed=2)
         self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
+
+        # Returning None from a function should be identical
+        ts2 = msprime.simulate(
+            10, Ne=0.25,
+            recombination_rate=2,
+            demographic_events=[
+                msprime.SimulationModelChange(0, sweep_model),
+                msprime.SimulationModelChange(lambda t: None, "hudson")],
+            random_seed=2)
+        t1 = ts.dump_tables()
+        t2 = ts2.dump_tables()
+        t1.provenances.clear()
+        t2.provenances.clear()
+        self.assertEqual(t1, t2)
+
         # Make sure that the Hudson phase did something.
         ts = msprime.simulate(
             10, Ne=0.25,
@@ -691,6 +746,42 @@ class TestSweepGenicSelection(unittest.TestCase):
                 msprime.SimulationModelChange(0.01, sweep_models[0])] + [
                     msprime.SimulationModelChange(None, model)
                     for model in sweep_models] + [
-                msprime.SimulationModelChange(None, "hudson")],
+                msprime.SimulationModelChange()],
+            random_seed=2)
+        self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
+
+    def test_many_sweeps_regular_times_model_change(self):
+        demographic_events = []
+        for j in range(10):
+            sweep_model = msprime.SweepGenicSelection(
+                position=j, start_frequency=0.69, end_frequency=0.7,
+                alpha=1000, dt=0.0125)
+            # Start the sweep after 0.01 generations of Hudson
+            demographic_events.append(msprime.SimulationModelChange(
+                time=lambda t: t + 0.01, model=sweep_model))
+            # Revert back to Hudson until the next sweep
+            demographic_events.append(msprime.SimulationModelChange())
+        ts = msprime.simulate(
+            10, Ne=0.25, length=10, recombination_rate=0.2,
+            demographic_events=demographic_events,
+            random_seed=2)
+        self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
+
+    def test_too_many_sweeps(self):
+        # What happens when we have loads of sweeps
+        demographic_events = []
+        for j in range(1000):
+            sweep_model = msprime.SweepGenicSelection(
+                position=0.5, start_frequency=0.69, end_frequency=0.7,
+                alpha=1000, dt=0.0125)
+            # Start the sweep after 0.1 generations of Hudson
+            demographic_events.append(msprime.SimulationModelChange(
+                time=lambda t: t + 0.1,
+                model=sweep_model))
+            # Revert back to Hudson until the next sweep
+            demographic_events.append(msprime.SimulationModelChange())
+        ts = msprime.simulate(
+            10, Ne=0.25, length=10, recombination_rate=0.2,
+            demographic_events=demographic_events,
             random_seed=2)
         self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))


### PR DESCRIPTION
added a simple test of model change events. this PR will close https://github.com/tskit-dev/msprime/issues/884

also added a bit of documentation about using `np.Inf` as a time for model change events. 
