### PR TITLE
Fix recombination site sampling in DTWF

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -1843,7 +1843,7 @@ msp_init_segments_and_compute_breakpoint(msp_t *self, label_id_t label, segment_
     t = fenwick_get_cumulative_sum(tree, y->id);
     x = y->prev;
 
-    k = recomb_map_shift_left_by_mass(self->recomb_map, y->right, t - h);
+    k = recomb_map_shift_by_mass(self->recomb_map, y->right, h - t);
 
     /* Reject if fallen directly on y left when not allowed to */
     if (k == y->left && y->prev == NULL) {
@@ -1978,7 +1978,7 @@ msp_gene_conversion_within_event(msp_t *self, label_id_t label)
     y = msp_get_segment(self, segment_id, label);
 
     t = fenwick_get_cumulative_sum(&self->links[label], segment_id);
-    k = recomb_map_shift_left_by_mass(self->recomb_map, y->right, t - h);
+    k = recomb_map_shift_by_mass(self->recomb_map, y->right, h - t);
     assert(k >= 0 && k < self->sequence_length);
     /* Check if the gene conversion falls between segments and hence has no effect */
     if (y->left >= k + tl){

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -467,7 +467,7 @@ double recomb_map_mass_between_left_exclusive(recomb_map_t *self, double left, d
 double recomb_map_mass_between(recomb_map_t *self, double left, double right);
 double recomb_map_mass_to_position(recomb_map_t *self, double mass);
 double recomb_map_position_to_mass(recomb_map_t *self, double position);
-double recomb_map_shift_left_by_mass(recomb_map_t *self, double right_pos, double recomb_mass);
+double recomb_map_shift_by_mass(recomb_map_t *self, double pos, double mass);
 double recomb_map_sample_poisson(recomb_map_t *self, gsl_rng *rng, double start);
 
 int mutgen_alloc(mutgen_t *self, double mutation_rate, gsl_rng *rng,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -307,6 +307,27 @@ class TestDtwf(unittest.TestCase):
             10, Ne=1e2, model="dtwf", recombination_rate=1e-300, random_seed=2)
         self.assertEqual(ts.num_trees, 1)
 
+    def test_single_recombination(self):
+        recombination_map = msprime.RecombinationMap(
+                                [0, 100, 101, 200], [0, 1, 0, 0], discrete=True)
+        ts = msprime.simulate(10, Ne=10, model="dtwf", random_seed=2,
+                              recombination_map=recombination_map)
+        self.assertEqual(ts.num_trees, 2)
+        trees = ts.trees()
+        self.assertEqual(next(trees).interval, (0, 100))
+        self.assertEqual(next(trees).interval, (100, 200))
+
+    def test_no_recombination_interval(self):
+        positions = [0, 50, 100, 150, 200]
+        rates = [0.01, 0.0, 0.1, 0.005, 0.0]
+        recombination_map = msprime.RecombinationMap(positions, rates)
+        ts = msprime.simulate(10, Ne=10, model="dtwf", random_seed=2,
+                              recombination_map=recombination_map)
+        for tree in ts.trees():
+            left, right = tree.interval
+            self.assertTrue(left < 50 or left > 100)
+            self.assertTrue(right < 50 or right > 100)
+
 
 class TestUnsupportedFullArg(unittest.TestCase):
     """


### PR DESCRIPTION
## Bug Fix
Recombination sites for DTWF were generated by sampling from a Poisson distribution in physical coordinates where lambda was the average recombination rate moving forward on the sequence. Doing this in physical space is very problematic when using non-uniform recombination rates. All spatial knowledge is lost and it allows recombination breakpoints to fall in areas of no recombination.

Instead, we now sample a point in recombination space at which the following breakpoint will occur. In this space, the lambda for the Poisson is just 1. We can then translate this to the corresponding physical coordinate after our starting point to find the next breakpoint.

## Testing
- Added plots of breakpoint distributions for all DTWF vs coalescent comparisons.
- Added tests for DTWF using non-uniform recombination maps, in discrete and continuous coordinates
- Added test from #876 to confirm that a single forced breakpoint in discrete space creates two and only two trees, ensuring those trees are consistent between Hudson and DTWF.

Resolves #876