### PR TITLE
repair gene conversion for physical coordinates

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -2075,6 +2075,19 @@ out:
 }
 
 static PyObject *
+RecombinationMap_get_discrete(RecombinationMap *self)
+{
+    PyObject *ret = NULL;
+
+    if (RecombinationMap_check_recomb_map(self) != 0) {
+        goto out;
+    }
+    ret = Py_BuildValue("i", recomb_map_get_discrete(self->recomb_map));
+out:
+    return ret;
+}
+
+static PyObject *
 RecombinationMap_get_positions(RecombinationMap *self)
 {
     PyObject *ret = NULL;
@@ -2152,6 +2165,9 @@ static PyMethodDef RecombinationMap_methods[] = {
     {"get_rates",
         (PyCFunction) RecombinationMap_get_rates, METH_NOARGS,
         "Returns the rates in this recombination map."},
+    {"get_discrete",
+        (PyCFunction) RecombinationMap_get_discrete, METH_NOARGS,
+        "Returns the value of discrete in this recombination map."},
     {NULL}  /* Sentinel */
 };
 

--- a/algorithms.py
+++ b/algorithms.py
@@ -935,7 +935,7 @@ class Simulator(object):
             if rate != 0:
                 t_re = random.expovariate(rate)
             # Gene conversion can occur within segments ..
-            rate = self.recomb_map.mass_to_position(self.g * recomb_mass)
+            rate = self.g * self.recomb_map.mass_to_position(recomb_mass)
             t_gcin = infinity
             if rate != 0:
                 t_gcin = random.expovariate(rate)

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -3504,8 +3504,17 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
          * simulations */
         if (self->gene_conversion_rate > 0) {
             /* Gene conversion within segments */
-            lambda = recomb_map_mass_to_position(
-                self->recomb_map, recomb_mass) * self->gene_conversion_rate;
+            if (recomb_mass > 0.0) {
+                lambda = recomb_map_mass_to_position(
+                    self->recomb_map, recomb_mass) * self->gene_conversion_rate;
+            } else {
+                if (self->recomb_map->total_recombination_rate == 0.0) {
+                    printf("recombination rate zero and gene conversion rate > 0 currently not supported\n");
+                    assert(self->recomb_map->total_recombination_rate > 0.0);
+                } else {
+                    lambda = 0.0;
+                }
+            }
             gc_in_t_wait = DBL_MAX;
             if (lambda != 0.0) {
                 gc_in_t_wait = gsl_ran_exponential(self->rng, 1.0 / lambda);

--- a/lib/recomb_map.c
+++ b/lib/recomb_map.c
@@ -139,7 +139,10 @@ recomb_map_get_sequence_length(recomb_map_t *self)
     return self->sequence_length;
 }
 
-bool recomb_map_get_discrete(recomb_map_t *self)
+/* Returns a boolean indicating whether the recombination map is discrete.
+ */
+bool
+recomb_map_get_discrete(recomb_map_t *self)
 {
     return self->discrete;
 }

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -287,7 +287,7 @@ def simulator_factory(
     if gene_conversion_rate is None:
         gene_conversion_rate = 0
     else:
-        if not recomb_map.get_discrete():
+        if not recomb_map.discrete:
             raise ValueError(
                 "Cannot specify gene_conversion_rate along with "
                 "a nondiscrete recombination map")
@@ -989,15 +989,16 @@ class RecombinationMap(object):
     def get_sequence_length(self):
         return self._ll_recombination_map.get_sequence_length()
 
-    def get_discrete(self):
-        return self._ll_recombination_map.get_discrete()
-
     def get_length(self):
         # Deprecated: use sequence_length instead
         return self.get_sequence_length()
 
     def get_rates(self):
         return self._ll_recombination_map.get_rates()
+
+    @property
+    def discrete(self):
+        return self._ll_recombination_map.get_discrete()
 
 
 class PopulationConfiguration(object):

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -286,6 +286,11 @@ def simulator_factory(
     # have a non-trivial genetic map?
     if gene_conversion_rate is None:
         gene_conversion_rate = 0
+    else:
+        if not recomb_map.get_discrete():
+            raise ValueError(
+                "Cannot specify gene_conversion_rate along with "
+                "a nondiscrete recombination map")
     if gene_conversion_track_length is None:
         gene_conversion_track_length = 1
 
@@ -983,6 +988,9 @@ class RecombinationMap(object):
 
     def get_sequence_length(self):
         return self._ll_recombination_map.get_sequence_length()
+
+    def get_discrete(self):
+        return self._ll_recombination_map.get_discrete()
 
     def get_length(self):
         # Deprecated: use sequence_length instead

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -782,6 +782,13 @@ class TestSimulateInterface(unittest.TestCase):
         self.assertEqual(ts.num_samples, n)
         self.assertGreater(ts.num_trees, 1)
 
+    def test_gene_conversion_continuous(self):
+        rm = msprime.RecombinationMap.uniform_map(10, 1, discrete=False)
+        with self.assertRaises(ValueError):
+            msprime.simulate(
+                10, gene_conversion_rate=1, gene_conversion_track_length=1,
+                recombination_map=rm)
+
     @unittest.skip("Cannot use GC with default recomb map")
     def test_gene_conversion_default_map(self):
         n = 10
@@ -851,3 +858,14 @@ class TestDefaultRandomSeeds(unittest.TestCase):
         self.assertEqual(len(set(seeds)), n)
         pool.terminate()
         pool.join()
+
+
+class TestRecombinationMap(unittest.TestCase):
+    """
+    Tests for the RecombinationMap class.
+    """
+    # TODO these are incomplete.
+    def test_discrete(self):
+        for truthy in [True, False, {}, None, "ser"]:
+            rm = msprime.RecombinationMap.uniform_map(1, 0, discrete=truthy)
+            self.assertEqual(rm.discrete, bool(truthy))

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1849,6 +1849,15 @@ class TestRecombinationMap(LowLevelTestCase):
         rm = _msprime.RecombinationMap([0, 10, 20], [0.25, 0.5, 0], True)
         self.assertEqual(rm.get_total_recombination_rate(), 7.5)
 
+    def test_get_discrete(self):
+        for truthy in [[], "sd", None, ValueError]:
+            rm = _msprime.RecombinationMap([0, 10], [0.25, 0], discrete=truthy)
+            self.assertEqual(bool(truthy), rm.get_discrete())
+
+        for discrete in [True, False]:
+            rm = _msprime.RecombinationMap([0, 10], [0.25, 0], discrete)
+            self.assertEqual(rm.get_discrete(), discrete)
+
 
 class TestRandomGenerator(unittest.TestCase):
     """

--- a/verification.py
+++ b/verification.py
@@ -700,7 +700,7 @@ class SimulationVerifier(object):
             same_root_count_last = np.zeros(seq_length)
             low_recombination_rate = 0.000001
             recomb_map = msprime.RecombinationMap.uniform_map(
-                seq_length, low_recombination_rate)
+                seq_length, low_recombination_rate, discrete=True)
             replicates = msprime.simulate(
                 sample_size=sample_size,
                 recombination_map=recomb_map,
@@ -2659,6 +2659,9 @@ def run_tests(args):
         "admixture-2-pop4",
         "1000 1000 -t 2.0 -I 2 500 500 2 -es 0.01 1 0.75 -eg 0.02 1 5.0 "
         "-em 0.02 3 1 1")
+    verifier.add_ms_instance(
+        "gene-conversion-1-r0",
+        "100 10000 -t 5.0 -r 0 2501 -c 10 1")
     verifier.add_ms_instance(
         "gene-conversion-1",
         "100 10000 -t 5.0 -r 0.01 2501 -c 1000 1")


### PR DESCRIPTION
This fixes #879 
There have been different errors that resulted from the physical coordinates update in the python and the C version of gene conversion.
This should correct them.

If a constant recombination rate of zero is used the gene conversion rates are incorrect. I added a control for this scenario, but the plan is to fix this in #851 .