### PR TITLE
use numpy c api a bit more

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -218,31 +218,6 @@ out:
 }
 
 static PyObject *
-convert_float_list(double *list, size_t size)
-{
-    PyObject *ret = NULL;
-    PyObject *l = NULL;
-    PyObject *py_float = NULL;
-    size_t j;
-
-    l = PyList_New(size);
-    if (l == NULL) {
-        goto out;
-    }
-    for (j = 0; j < size; j++) {
-        py_float = Py_BuildValue("d", list[j]);
-        if (py_float == NULL) {
-            Py_DECREF(l);
-            goto out;
-        }
-        PyList_SET_ITEM(l, j, py_float);
-    }
-    ret = l;
-out:
-    return ret;
-}
-
-static PyObject *
 make_metadata(const char *metadata, Py_ssize_t length)
 {
     const char *m = metadata == NULL? "": metadata;
@@ -1970,47 +1945,46 @@ RecombinationMap_init(RecombinationMap *self, PyObject *args, PyObject *kwds)
     int ret = -1;
     int err;
     static char *kwlist[] = {"positions", "rates", "discrete", NULL};
-    Py_ssize_t size, j;
+    Py_ssize_t size;
     PyObject *py_positions = NULL;
     PyObject *py_rates = NULL;
     double *positions = NULL;
     double *rates = NULL;
+    PyArrayObject *pyarray_positions = NULL;
+    PyArrayObject *pyarray_rates = NULL;
     int discrete = false;
-    PyObject *item;
 
     self->recomb_map = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!p", kwlist,
-            &PyList_Type, &py_positions, &PyList_Type,
-            &py_rates, &discrete)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOp", kwlist,
+            &py_positions, &py_rates, &discrete)) {
         goto out;
     }
 
-    if (PyList_Size(py_positions) != PyList_Size(py_rates)) {
+    size = PyObject_Size(py_positions);
+    if (size != PyObject_Size(py_rates)) {
         PyErr_SetString(PyExc_ValueError,
             "positions and rates list must be the same length");
         goto out;
     }
-    size = PyList_Size(py_positions);
-    positions = PyMem_Malloc(size * sizeof(double));
-    rates = PyMem_Malloc(size * sizeof(double));
-    if (positions == NULL || rates == NULL) {
-        PyErr_NoMemory();
+
+    pyarray_positions = (PyArrayObject *)PyArray_FromAny(
+            py_positions, PyArray_DescrFromType(NPY_DOUBLE),
+            1, 1, NPY_ARRAY_IN_ARRAY, NULL);
+    if (pyarray_positions == NULL) {
+        PyErr_SetString(PyExc_TypeError, "positions must be a sequence of numbers");
         goto out;
     }
-    for (j = 0; j < size; j++) {
-        item = PyList_GetItem(py_positions, j);
-        if (!PyNumber_Check(item)) {
-            PyErr_SetString(PyExc_TypeError, "position must be a number");
-            goto out;
-        }
-        positions[j] = PyFloat_AsDouble(item);
-        item = PyList_GetItem(py_rates, j);
-        if (!PyNumber_Check(item)) {
-            PyErr_SetString(PyExc_TypeError, "rates must be a number");
-            goto out;
-        }
-        rates[j] = PyFloat_AsDouble(item);
+    pyarray_rates = (PyArrayObject *)PyArray_FromAny(
+            py_rates, PyArray_DescrFromType(NPY_DOUBLE),
+            1, 1, NPY_ARRAY_IN_ARRAY, NULL);
+    if (pyarray_rates == NULL) {
+        PyErr_SetString(PyExc_TypeError, "rates must be a sequence of numbers");
+        goto out;
     }
+
+    positions = PyArray_DATA(pyarray_positions);
+    rates = PyArray_DATA(pyarray_rates);
+
     self->recomb_map = PyMem_Malloc(sizeof(recomb_map_t));
     if (self->recomb_map == NULL) {
         PyErr_NoMemory();
@@ -2024,12 +1998,8 @@ RecombinationMap_init(RecombinationMap *self, PyObject *args, PyObject *kwds)
     }
     ret = 0;
 out:
-    if (positions != NULL) {
-        PyMem_Free(positions);
-    }
-    if (rates != NULL) {
-        PyMem_Free(rates);
-    }
+    Py_XDECREF(pyarray_positions);
+    Py_XDECREF(pyarray_rates);
     return ret;
 }
 
@@ -2091,28 +2061,28 @@ static PyObject *
 RecombinationMap_get_positions(RecombinationMap *self)
 {
     PyObject *ret = NULL;
-    double *positions = NULL;
-    size_t size;
+    PyObject *arr = NULL;
+    npy_intp size;
     int err;
 
     if (RecombinationMap_check_recomb_map(self) != 0) {
         goto out;
     }
     size = recomb_map_get_size(self->recomb_map);
-    positions = PyMem_Malloc(size * sizeof(double));
-    if (positions == NULL) {
-        PyErr_NoMemory();
+    arr = PyArray_SimpleNew(1, &size, NPY_FLOAT64);
+    if (arr == NULL) {
         goto out;
     }
-    err = recomb_map_get_positions(self->recomb_map, positions);
+    err = recomb_map_get_positions(self->recomb_map,
+            PyArray_DATA((PyArrayObject *)arr));
     if (err != 0) {
         handle_library_error(err);
         goto out;
     }
-    ret = convert_float_list(positions, size);
+    ret = arr;
 out:
-    if (positions != NULL) {
-        PyMem_Free(positions);
+    if (ret == NULL) {
+        Py_XDECREF(arr);
     }
     return ret;
 }
@@ -2121,28 +2091,28 @@ static PyObject *
 RecombinationMap_get_rates(RecombinationMap *self)
 {
     PyObject *ret = NULL;
-    double *rates = NULL;
-    size_t size;
+    PyObject *arr = NULL;
+    npy_intp size;
     int err;
 
     if (RecombinationMap_check_recomb_map(self) != 0) {
         goto out;
     }
     size = recomb_map_get_size(self->recomb_map);
-    rates = PyMem_Malloc(size * sizeof(double));
-    if (rates == NULL) {
-        PyErr_NoMemory();
+    arr = PyArray_SimpleNew(1, &size, NPY_FLOAT64);
+    if (arr == NULL) {
         goto out;
     }
-    err = recomb_map_get_rates(self->recomb_map, rates);
+    err = recomb_map_get_rates(self->recomb_map,
+            PyArray_DATA((PyArrayObject *)arr));
     if (err != 0) {
         handle_library_error(err);
         goto out;
     }
-    ret = convert_float_list(rates, size);
+    ret = arr;
 out:
-    if (rates != NULL) {
-        PyMem_Free(rates);
+    if (ret == NULL) {
+        Py_XDECREF(arr);
     }
     return ret;
 }
@@ -3601,28 +3571,30 @@ static PyObject *
 Simulator_get_migration_matrix(Simulator *self)
 {
     PyObject *ret = NULL;
-    double *migration_matrix = NULL;
-    size_t N;
+    PyObject *arr = NULL;
+    npy_intp N2;
     int err;
 
     if (Simulator_check_sim(self) != 0) {
         goto out;
     }
-    N = msp_get_num_populations(self->sim);
-    migration_matrix = PyMem_Malloc(N * N * sizeof(double));
-    if (migration_matrix == NULL) {
-        PyErr_NoMemory();
+    N2 = msp_get_num_populations(self->sim);
+    N2 *= N2;
+    // TODO return 2d numpy array and fix the breakage
+    arr = PyArray_SimpleNew(1, &N2, NPY_FLOAT64);
+    if (arr == NULL) {
         goto out;
     }
-    err = msp_get_migration_matrix(self->sim, migration_matrix);
+    err = msp_get_migration_matrix(self->sim,
+            PyArray_DATA((PyArrayObject *)arr));
     if (err != 0) {
         handle_library_error(err);
         goto out;
     }
-    ret = convert_float_list(migration_matrix, N * N);
+    ret = arr;
 out:
-    if (migration_matrix != NULL) {
-        PyMem_Free(migration_matrix);
+    if (ret == NULL) {
+        Py_XDECREF(arr);
     }
     return ret;
 }

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -248,7 +248,7 @@ class SimulationRunner(object):
         same tree. Therefore, we must keep track of all breakpoints from the
         simulation and write out a tree for each one.
         """
-        breakpoints = self._simulator.breakpoints + [self._num_loci]
+        breakpoints = list(self._simulator.breakpoints) + [self._num_loci]
         if self._num_loci == 1:
             tree = next(tree_sequence.trees())
             newick = tree.newick(precision=self._precision)

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -1087,7 +1087,12 @@ class RecombinationMap(object):
         raise ValueError("num_loci is no longer supported")
 
     def get_positions(self):
-        return self._ll_recombination_map.get_positions()
+        # For compatability with existing code we convert to a list
+        return list(self._ll_recombination_map.get_positions())
+
+    def get_rates(self):
+        # For compatability with existing code we convert to a list
+        return list(self._ll_recombination_map.get_rates())
 
     def get_sequence_length(self):
         return self._ll_recombination_map.get_sequence_length()
@@ -1095,9 +1100,6 @@ class RecombinationMap(object):
     def get_length(self):
         # Deprecated: use sequence_length instead
         return self.get_sequence_length()
-
-    def get_rates(self):
-        return self._ll_recombination_map.get_rates()
 
     @property
     def discrete(self):

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -984,10 +984,9 @@ class RecombinationMap(object):
         """
         chrom_length = self._ll_recombination_map.get_sequence_length()
 
-        positions = np.array(self._ll_recombination_map.get_positions())
+        positions = self._ll_recombination_map.get_positions()
         positions_diff = self._ll_recombination_map.get_positions()[1:]
-        positions_diff.append(chrom_length)
-        positions_diff = np.array(positions_diff)
+        positions_diff = np.append(positions_diff, chrom_length)
         window_sizes = positions_diff - positions
 
         weights = window_sizes / chrom_length
@@ -1026,8 +1025,8 @@ class RecombinationMap(object):
         if end != positions[-1]:
             j = bisect.bisect_right(positions, end, lo=i)
 
-        new_positions = positions[i:j]
-        new_rates = rates[i:j]
+        new_positions = list(positions[i:j])
+        new_rates = list(rates[i:j])
         new_positions[0] = start
         if end > new_positions[-1]:
             new_positions.append(end)

--- a/stress_lowlevel.py
+++ b/stress_lowlevel.py
@@ -15,6 +15,7 @@ import tests.test_demography as test_demography
 import tests.test_highlevel as test_highlevel
 import tests.test_lowlevel as test_lowlevel
 import tests.test_dict_encoding as test_dict_encoding
+import tests.test_recombination_map as test_recombination_map
 
 
 def main():
@@ -23,6 +24,7 @@ def main():
         "highlevel": test_highlevel,
         "lowlevel": test_lowlevel,
         "dict_encoding": test_dict_encoding,
+        "recombination_map": test_recombination_map,
     }
     parser = argparse.ArgumentParser(
         description="Run tests in a loop to stress low-level interface")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,6 +22,7 @@ Common code for the msprime test cases.
 import random
 import unittest
 
+import numpy as np
 import msprime
 
 NULL_NODE = -1
@@ -36,6 +37,21 @@ class MsprimeTestCase(unittest.TestCase):
     """
     Superclass of all tests msprime simulator test cases.
     """
+
+
+class SequenceEqualityMixin(object):
+    """
+    Overwrites unittest.TestCase.assertEqual to work with numpy arrays.
+
+    Note: unittest.TestCase.assertSequenceEqual also fails to work with
+    numpy arrays, and assertEqual works with ordinary lists/tuples anyway.
+    """
+    def assertEqual(self, it1, it2, msg=None):
+        if isinstance(it1, np.ndarray):
+            it1 = list(it1)
+        if isinstance(it2, np.ndarray):
+            it2 = list(it2)
+        unittest.TestCase.assertEqual(self, it1, it2, msg=msg)
 
 
 class PythonSparseTree(object):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ import tskit
 
 import msprime
 import msprime.cli as cli
+import tests
 
 _h5py_available = True
 try:
@@ -313,7 +314,7 @@ class CustomExceptionForTesting(Exception):
     """
 
 
-class TestHotspotsToRecombMap(TestCli):
+class TestHotspotsToRecombMap(tests.SequenceEqualityMixin, TestCli):
 
     def verify_map(self, recomb_map, expected_positions, expected_rates):
         self.assertEqual(recomb_map.get_positions(), expected_positions)
@@ -593,7 +594,7 @@ class TestMspmsCreateSimulationRunnerErrors(TestCli):
         self.assert_parser_error("10 1 -t 2.0 -eN 0.001 5.0 -es 0.01 1 0.0")
 
 
-class TestMspmsCreateSimulationRunner(unittest.TestCase):
+class TestMspmsCreateSimulationRunner(tests.SequenceEqualityMixin, unittest.TestCase):
     """
     Test that we correctly create a simulator instance based on the
     command line arguments.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,6 @@ import tskit
 
 import msprime
 import msprime.cli as cli
-import tests
 
 _h5py_available = True
 try:
@@ -314,7 +313,7 @@ class CustomExceptionForTesting(Exception):
     """
 
 
-class TestHotspotsToRecombMap(tests.SequenceEqualityMixin, TestCli):
+class TestHotspotsToRecombMap(TestCli):
 
     def verify_map(self, recomb_map, expected_positions, expected_rates):
         self.assertEqual(recomb_map.get_positions(), expected_positions)
@@ -594,7 +593,7 @@ class TestMspmsCreateSimulationRunnerErrors(TestCli):
         self.assert_parser_error("10 1 -t 2.0 -eN 0.001 5.0 -es 0.01 1 0.0")
 
 
-class TestMspmsCreateSimulationRunner(tests.SequenceEqualityMixin, unittest.TestCase):
+class TestMspmsCreateSimulationRunner(unittest.TestCase):
     """
     Test that we correctly create a simulator instance based on the
     command line arguments.

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -412,7 +412,7 @@ class TestSimulator(HighLevelTestCase):
         self.assertRaises(ValueError, msprime.Simulator, [(0, 0)], recomb_map)
 
 
-class TestSimulatorFactory(tests.SequenceEqualityMixin, unittest.TestCase):
+class TestSimulatorFactory(unittest.TestCase):
     """
     Tests that the simulator factory high-level function correctly
     creates simulators with the required parameter values.
@@ -518,7 +518,7 @@ class TestSimulatorFactory(tests.SequenceEqualityMixin, unittest.TestCase):
             ll_sim = sim.create_ll_instance()
             # If we don't specify a matrix, it's 0 everywhere.
             matrix = [0 for j in range(N * N)]
-            self.assertEqual(ll_sim.get_migration_matrix(), matrix)
+            np.testing.assert_array_equal(ll_sim.get_migration_matrix(), matrix)
 
             def f(hl_matrix):
                 return msprime.simulator_factory(
@@ -533,7 +533,7 @@ class TestSimulatorFactory(tests.SequenceEqualityMixin, unittest.TestCase):
             self.assertEqual(sim.migration_matrix, hl_matrix)
             ll_sim = sim.create_ll_instance()
             ll_matrix = [v for row in hl_matrix for v in row]
-            self.assertEqual(ll_sim.get_migration_matrix(), ll_matrix)
+            np.testing.assert_array_equal(ll_sim.get_migration_matrix(), ll_matrix)
             for bad_type in [234, 1.2]:
                 self.assertRaises(TypeError, f, bad_type)
             # Iterables should raise a value error.
@@ -551,7 +551,7 @@ class TestSimulatorFactory(tests.SequenceEqualityMixin, unittest.TestCase):
             hl_matrix = np.ones((N, N))
             np.fill_diagonal(hl_matrix, 0)
             sim = f(hl_matrix)
-            self.assertTrue(np.array_equal(np.array(sim.migration_matrix), hl_matrix))
+            np.testing.assert_array_equal(np.array(sim.migration_matrix), hl_matrix)
             sim.run()
             events = np.array(sim.num_migration_events)
             self.assertEqual(events.shape, (N, N))

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -412,7 +412,7 @@ class TestSimulator(HighLevelTestCase):
         self.assertRaises(ValueError, msprime.Simulator, [(0, 0)], recomb_map)
 
 
-class TestSimulatorFactory(unittest.TestCase):
+class TestSimulatorFactory(tests.SequenceEqualityMixin, unittest.TestCase):
     """
     Tests that the simulator factory high-level function correctly
     creates simulators with the required parameter values.

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1841,9 +1841,9 @@ class TestRecombinationMap(LowLevelTestCase):
     """
     def test_constructor(self):
         self.assertRaises(TypeError, _msprime.RecombinationMap)
-        self.assertRaises(TypeError, _msprime.RecombinationMap, None)
-        self.assertRaises(TypeError, _msprime.RecombinationMap, None, None)
-        self.assertRaises(TypeError, _msprime.RecombinationMap, {}, {}, False)
+        self.assertRaises(ValueError, _msprime.RecombinationMap, None)
+        self.assertRaises(ValueError, _msprime.RecombinationMap, None, None)
+        self.assertRaises(ValueError, _msprime.RecombinationMap, {}, {}, False)
         self.assertRaises(
                 ValueError, _msprime.RecombinationMap, [0, 0.1], [1, 2, 3], False)
         self.assertRaises(

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -297,7 +297,7 @@ def get_random_population_models(n):
     return models
 
 
-class LowLevelTestCase(tests.MsprimeTestCase):
+class LowLevelTestCase(tests.SequenceEqualityMixin, tests.MsprimeTestCase):
     """
     Superclass of tests for the low-level interface.
     """

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1195,18 +1195,19 @@ class TestSimulator(LowLevelTestCase):
                 samples, uniform_recombination_map(), rng,
                 _msprime.LightweightTableCollection())
 
+        err = (TypeError, ValueError)
         for bad_type in [None, {}, _msprime.Simulator]:
-            self.assertRaises(TypeError, f, bad_type)
-            self.assertRaises(TypeError, f, [(0, 0), bad_type])
-            self.assertRaises(TypeError, f, [(0, 0), (bad_type, 0)])
-            self.assertRaises(TypeError, f, [(0, 0), (0, bad_type)])
+            self.assertRaises(err, f, bad_type)
+            self.assertRaises(err, f, [(0, 0), bad_type])
+            self.assertRaises(err, f, [(0, 0), (bad_type, 0)])
+            self.assertRaises(err, f, [(0, 0), (0, bad_type)])
         self.assertRaises(_msprime.InputError, f, [])
         self.assertRaises(_msprime.InputError, f, [(0, 0)])
-        self.assertRaises(ValueError, f, [(0, 0), (0, 0, 0)])
-        self.assertRaises(ValueError, f, [(0, 0), (-1, 0)])
-        self.assertRaises(ValueError, f, [(0, 0), (0, -1)])
+        self.assertRaises(err, f, [(0, 0), (0, 0, 0)])
+        self.assertRaises(err, f, [(0, 0), (-1, 0)])
+        self.assertRaises(err, f, [(0, 0), (0, -1)])
         # Only tuples are supported.
-        self.assertRaises(TypeError, f, [(0, 0), [0, 0]])
+        self.assertRaises(err, f, [(0, 0), [0, 0]])
 
     def test_get_samples(self):
         N = 4

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -368,7 +368,7 @@ class TestSimulationState(LowLevelTestCase):
                 self.assertGreaterEqual(node, 0)
                 self.assertTrue(0 <= pop_id < N)
                 self.assertEqual(the_pop_id, pop_id)
-        breakpoints = [0] + sim.get_breakpoints() + [L]
+        breakpoints = [0] + list(sim.get_breakpoints()) + [L]
         self.assertEqual(len(breakpoints), sim.get_num_breakpoints() + 2)
         self.assertEqual(breakpoints, sorted(breakpoints))
         nodes = sim.get_nodes()

--- a/tests/test_recombination_map.py
+++ b/tests/test_recombination_map.py
@@ -26,8 +26,9 @@ import os
 import gzip
 import warnings
 
-import msprime
 import numpy as np
+import msprime
+import tests
 
 
 class TestConstructorAndGetters(unittest.TestCase):
@@ -57,7 +58,7 @@ class TestConstructorAndGetters(unittest.TestCase):
         self.assertEqual(recomb_map.get_total_recombination_rate(), 1)
 
 
-class TestReadHapmap(unittest.TestCase):
+class TestReadHapmap(tests.SequenceEqualityMixin, unittest.TestCase):
     """
     Tests file reading code.
     """
@@ -113,7 +114,7 @@ class TestReadHapmap(unittest.TestCase):
             os.unlink(filename)
 
 
-class TestSlice(unittest.TestCase):
+class TestSlice(tests.SequenceEqualityMixin, unittest.TestCase):
     def test_slice(self):
         """
         test RecombinationMap.slice(..., trim=False)

--- a/tests/test_recombination_map.py
+++ b/tests/test_recombination_map.py
@@ -27,8 +27,8 @@ import gzip
 import warnings
 
 import numpy as np
+
 import msprime
-import tests
 
 
 class TestConstructorAndGetters(unittest.TestCase):
@@ -58,7 +58,7 @@ class TestConstructorAndGetters(unittest.TestCase):
         self.assertEqual(recomb_map.get_total_recombination_rate(), 1)
 
 
-class TestReadHapmap(tests.SequenceEqualityMixin, unittest.TestCase):
+class TestReadHapmap(unittest.TestCase):
     """
     Tests file reading code.
     """
@@ -114,11 +114,9 @@ class TestReadHapmap(tests.SequenceEqualityMixin, unittest.TestCase):
             os.unlink(filename)
 
 
-class TestSlice(tests.SequenceEqualityMixin, unittest.TestCase):
+class TestSlice(unittest.TestCase):
     def test_slice(self):
-        """
-        test RecombinationMap.slice(..., trim=False)
-        """
+        # test RecombinationMap.slice(..., trim=False)
         a = msprime.RecombinationMap([0, 100, 200, 300, 400], [0, 1, 2, 3, 0])
         b = a.slice()
         self.assertEqual(a.get_sequence_length(), b.get_sequence_length())
@@ -171,9 +169,7 @@ class TestSlice(tests.SequenceEqualityMixin, unittest.TestCase):
         self.assertTrue(np.array_equal([0, 1, 0, 0], b.get_rates()))
 
     def test_slice_with_floats(self):
-        """
-        test RecombinationMap.slice(..., trim=False) with floats
-        """
+        #  test RecombinationMap.slice(..., trim=False) with floats
         a = msprime.RecombinationMap(
                 [np.pi*x for x in [0, 100, 200, 300, 400]], [0, 1, 2, 3, 0])
         b = a.slice(start=50*np.pi)
@@ -225,9 +221,7 @@ class TestSlice(tests.SequenceEqualityMixin, unittest.TestCase):
             recomb_map.slice(start=20, end=10)
 
     def test_getitem_slice(self):
-        """
-        test RecombinationMap slice syntax
-        """
+        # test RecombinationMap slice syntax
         a = msprime.RecombinationMap([0, 100, 200, 300, 400], [0, 1, 2, 3, 0])
         b = a[:]
         self.assertEqual(a.get_sequence_length(), b.get_sequence_length())
@@ -280,9 +274,7 @@ class TestSlice(tests.SequenceEqualityMixin, unittest.TestCase):
         self.assertTrue(np.array_equal([1, 0], b.get_rates()))
 
     def test_getitem_slice_with_negative_indexes_and_floats(self):
-        """
-        test RecombinationMap slice syntax with negative indexes and floats
-        """
+        # test RecombinationMap slice syntax with negative indexes and floats
         a = msprime.RecombinationMap([0, 100, 200, 300, 400], [0, 1, 2, 3, 0])
 
         b = a[150:250]


### PR DESCRIPTION
A few changes here related to #902 and #666.

The most common breakage will be in user code that assumes a list is returned by, e.g. RecombinationMap.get_positions() and then tries to append to the list.

It's not easy to hit all the error paths, so there might be ref leaks lurking here. And the numpy docs aren't always clear. I ran `stress_lowlevel.py` for a while and it reported thusly:
```
iter    tests   err     fail    skip    RSS     min     max     max@iter
46      290     0       0       1       96616   95316   96616   32
```
