### PR TITLE
Complete provenance recording

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,14 @@
+***************************
+[UPCOMING.X.X] - XXXX-XX-XX
+***************************
+
+**New features**:
+
+- Complete provenance recording of all arguments to simulate and mutate.
+  Adds argument record_provenance to simulate, which allows recording of
+  provenances to be disabled, for example when they are large.
+  (:user:`benjeffery` :pr:`914`).
+
 ********************
 [0.7.4] - 2019-12-05
 ********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@
   provenances to be disabled, for example when they are large.
   (:user:`benjeffery` :pr:`914`).
 
+- Add replicate_index to simulate, allowing output of a single tree sequence
+  from a set of replicates. (:user:`benjeffery` :pr:`914`).
+
 ********************
 [0.7.4] - 2019-12-05
 ********************

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -20,6 +20,14 @@
 Common provenance methods used to determine the state and versions
 of various dependencies and the OS.
 """
+import base64
+import importlib
+import json
+import marshal
+import logging
+import types
+
+import numpy
 import tskit
 
 import _msprime
@@ -30,6 +38,7 @@ try:
     __version__ = _version.version
 except ImportError:
     pass
+logger = logging.getLogger(__name__)
 
 
 def get_provenance_dict(parameters=None):
@@ -68,3 +77,129 @@ def get_environment():
     if _environment is None:
         _environment = _get_environment()
     return _environment
+
+
+class ProvenanceEncoderDecoder(json.JSONEncoder):
+    """
+    Extension of the `json` encoder that serializes arbitrary python class objects
+    by calling an `asdict` method on the object that should provide the arguments
+    needed to exactly recreate it. Special cases numpy arrays, classes and functions
+    """
+
+    def default(self, obj):
+        if isinstance(obj, types.FunctionType):
+            # Some provenance-relevant classes such as SimulationModelChange take
+            # functional arguments. Note that we have a tight definition of
+            # what we allow as a function here. We don't include builtins or
+            # callable classes, we also block functions that refer to globals
+            # or the outer scope for both complexity and security reasons.
+            # We can deserialize these later with
+            # FunctionType(fcode, fglobals, fname, fdefaults, fclosure)
+            if len(obj.__code__.co_names) > 0:
+                error = (f'Configuration function {obj.__code__.co_name} refers to'
+                         f' global variables {obj.__code__.co_names} which are not'
+                         f' currently serialized')
+                logger.warning(error)
+                return {'__error__': error}
+            if obj.__closure__ is not None and len(obj.__closure__) > 0:
+                error = (f'Configuration function {obj.__code__.co_name} refers to outer'
+                         f' scope variables which are not currently serialized')
+                logger.warning(error)
+                return {'__error__': error}
+            return {
+                '__function__': base64.b64encode(
+                    marshal.dumps(obj.__code__)).decode("utf-8"),
+                'defaults': obj.__defaults__
+            }
+
+        if isinstance(obj, tskit.TreeSequence):
+            # Store the tree sequence as the tables deserialised with
+            # tskit.TableCollection.fromdict(tables).tree_sequence()
+            return {'__ts__': obj.tables.asdict()}
+
+        elif isinstance(obj, numpy.ndarray):
+            # The most failsafe way would be be to `base64.b64encode(obj.tostring())`
+            # but as we expect only simple arrays we make this trade-off so that
+            # the array is human readable
+            return {
+                '__ndarray__': obj.tolist(),
+                'dtype': obj.dtype.str
+            }
+
+        elif isinstance(obj, numpy.number):
+            # Some numbers come through as numpy types
+            return {
+                '__npgeneric__': str(obj),
+                'dtype': obj.dtype.str,
+            }
+
+        try:
+            ret = obj.asdict()
+            cls = obj.__class__
+            ret['__class__'] = f'{cls.__module__}.{cls.__name__}'
+            return ret
+        except AttributeError:
+            raise TypeError(f'Object of type {obj.__class__.__name__} '
+                            f'is not JSON serializable, provide an `asdict` method '
+                            f'that gives the objects args')
+
+    @staticmethod
+    def decode(s):
+        def hook(obj):
+            if '__function__' in obj:
+                return types.FunctionType(
+                    marshal.loads(base64.b64decode(obj['__function__'])),
+                    {}, 'func', obj['defaults'], ())
+            elif '__ts__' in obj:
+                return tskit.TableCollection.fromdict(obj['__ts__']).tree_sequence()
+            elif '__ndarray__' in obj:
+                return numpy.asarray(obj['__ndarray__'], dtype=obj['dtype'])
+            elif '__npgeneric__' in obj:
+                return numpy.array([obj['__npgeneric__']]).astype(obj['dtype'])[0]
+            elif '__class__' in obj:
+                module, cls = obj['__class__'].rsplit('.', 1)
+                module = importlib.import_module(module)
+                del obj['__class__']
+                return getattr(module, cls)(**obj)
+            return obj
+        return json.JSONDecoder(object_hook=hook).decode(s)
+
+
+def parse_provenance(ts, index=None):
+    """
+    Convert the specified provenance to tuple of the command used and dict suitable
+    for calling the command again e.g `msprime.simulate(**parse_provenance(ts)[1])`
+    """
+    if index is None:
+        index = ts.num_provenances - 1
+    prov = ts.provenance(index).record
+    ret = ProvenanceEncoderDecoder.decode(prov)
+    if ret['software']['name'] != 'msprime':
+        raise ValueError(f'Only msprime provanances can be parsed,'
+                         f' found {ret["software"]["name"]}')
+    command = ret['parameters']['command']
+    del ret['parameters']['command']
+    return command, ret['parameters']
+
+
+def _human_readable_size(size, decimal_places=2):
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+        if size < 1024.0:
+            break
+        size /= 1024.0
+    return f"{size:.{decimal_places}f}{unit}"
+
+
+def json_encode_provenance(provenance_dict, num_replicates=1):
+    """
+        Return a JSON representation of the provenance
+    """
+    prov = ProvenanceEncoderDecoder().encode(provenance_dict)
+    if len(prov) > 2_097_152:
+        logger.warning(f'The provenance information for the resulting tree sequence is'
+                       f' {_human_readable_size(len(prov))}.'
+                       f' This is nothing to worry about as provenance is a good thing'
+                       f' to have, but if you want to save this memory/storage space'
+                       f' you can disable provenance recording by setting'
+                       f' record_provenance=False')
+    return prov

--- a/tests/test_highlevel.py
+++ b/tests/test_highlevel.py
@@ -760,13 +760,11 @@ class TestSimulateInterface(unittest.TestCase):
         self.assertEqual(provenance.timestamp[k], "T")
         d = json.loads(provenance.record)
         self.assertGreater(len(d), 0)
-        # TODO check the format of the dictionary.
 
     def test_provenance(self):
         ts = msprime.simulate(10)
         self.assertEqual(ts.num_provenances, 1)
         self.verify_provenance(ts.provenance(0))
-        # TODO check the form of the dictionary
         for ts in msprime.simulate(10, num_replicates=10):
             self.assertEqual(ts.num_provenances, 1)
             self.verify_provenance(ts.provenance(0))
@@ -854,6 +852,29 @@ class TestSimulateInterface(unittest.TestCase):
             t.provenances.clear()
         for t in tables:
             self.assertEqual(t, tables[0])
+
+    def test_replicate_index(self):
+        tables_1 = list(msprime.simulate(10, num_replicates=5, random_seed=1))[4].tables
+        tables_2 = msprime.simulate(10, replicate_index=4, random_seed=1).tables
+        tables_1.provenances.clear()
+        tables_2.provenances.clear()
+        self.assertEqual(tables_1, tables_2)
+
+        with self.assertRaises(ValueError) as cm:
+            msprime.simulate(5, replicate_index=5)
+        self.assertEqual(
+            "Cannot specify replicate_index without random_seed as this "
+            "has the same effect as not specifying replicate_index i.e. a "
+            "random tree sequence",
+            str(cm.exception)
+        )
+        with self.assertRaises(ValueError) as cm:
+            msprime.simulate(5, random_seed=1, replicate_index=5, num_replicates=26)
+        self.assertEqual(
+            "Cannot specify replicate_index with num_replicates as only "
+            "the replicate_index specified will be returned.",
+            str(cm.exception)
+        )
 
 
 # Convenience method for getting seeds in a subprocess.

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -165,6 +165,11 @@ class TestBuildObjects(unittest.TestCase):
                 random_seed=1,
                 demographic_events=[msprime.SimulationModelChange(time=BadClass)])
 
+    def test_replicate_index(self):
+        for i, ts in enumerate(msprime.simulate(5, num_replicates=3)):
+            decoded = self.decode(ts.provenance(0).record)
+            self.assertEqual(decoded.parameters['replicate_index'], i)
+
     def test_large_provenance_warning(self):
         with self.assertLogs('msprime.provenance', level='WARNING') as cm:
             msprime.provenance.json_encode_provenance(

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -19,6 +19,8 @@
 """
 Tests for the provenance information attached to tree sequences.
 """
+import base64
+import marshal
 import unittest
 import json
 
@@ -28,6 +30,7 @@ import python_jsonschema_objects as pjs
 
 import _msprime
 import msprime
+from tests import tsutil
 
 
 class TestProvenance(unittest.TestCase):
@@ -85,14 +88,94 @@ class TestBuildObjects(unittest.TestCase):
         self.assertEqual(decoded.parameters.command, "simulate")
         self.assertEqual(decoded.parameters.random_seed, 1)
 
-    def test_simulation_numpy(self):
+    def test_no_provenance(self):
+        ts = msprime.simulate(5, record_provenance=False)
+        self.assertEqual(len(list(ts.provenances())), 0)
+
+    def test_encode_numpy_functions_and_classes(self):
         seeds = np.ones(1, dtype=int)
-        ts = msprime.simulate(5, random_seed=seeds[0])
+        pop_configs = [msprime.PopulationConfiguration(5) for _ in range(2)]
+
+        def time(t):
+            return t + 0.01
+
+        def bad_func(t):
+            if msprime:
+                pass
+            return t
+
+        with self.assertLogs('msprime.provenance', level='WARNING') as cm:
+            ts = msprime.simulate(
+                random_seed=seeds[0],
+                population_configurations=pop_configs,
+                migration_matrix=[[0, 1], [1, 0]],
+                demographic_events=[
+                    msprime.SimulationModelChange(time=time),
+                    msprime.SimulationModelChange(time=bad_func),
+                    msprime.SimulationModelChange(time=lambda t: t + seeds[0])
+                ])
+        self.assertIn(
+            "WARNING:msprime.provenance:Configuration function bad_func refers"
+            " to global variables ('msprime',) which are not currently"
+            " serialized", cm.output)
+        self.assertIn(
+            "WARNING:msprime.provenance:Configuration function <lambda> refers"
+            " to outer scope variables which are not currently serialized",
+            cm.output)
         prov = ts.provenance(0).record
         decoded = self.decode(prov)
         self.assertEqual(decoded.schema_version, "1.0.0")
         self.assertEqual(decoded.parameters.command, "simulate")
-        self.assertEqual(decoded.parameters.random_seed, 1)
+        parameters = decoded.parameters
+        self.assertEqual(parameters.random_seed, 1)
+        self.assertEqual(parameters.population_configurations, [
+            {'sample_size': 5, 'initial_size': 1, 'growth_rate': 0.0, 'metadata': None,
+                '__class__': 'msprime.simulations.PopulationConfiguration'},
+            {'sample_size': 5, 'initial_size': 1, 'growth_rate': 0.0, 'metadata': None,
+                '__class__': 'msprime.simulations.PopulationConfiguration'}])
+        self.assertEqual(parameters.migration_matrix, [[0, 1], [1, 0]])
+        self.assertDictEqual(
+            parameters.demographic_events[0],
+            {'time':
+                {'__function__': base64.b64encode(
+                    marshal.dumps(time.__code__)).decode("utf-8"), 'defaults': None},
+             'model': None, '__class__': 'msprime.simulations.SimulationModelChange'})
+        self.assertDictEqual(
+            parameters.demographic_events[1],
+            {'time': {
+                '__error__': "Configuration function bad_func refers to global variables"
+                             " ('msprime',) which are not currently serialized"},
+                'model': None, '__class__': 'msprime.simulations.SimulationModelChange'}
+        ),
+        self.assertDictEqual(
+            parameters.demographic_events[2],
+            {'time': {
+                '__error__': 'Configuration function <lambda> refers to outer scope'
+                             ' variables which are not currently serialized'},
+                'model': None, '__class__': 'msprime.simulations.SimulationModelChange'})
+
+    def test_unencodable_function(self):
+        class BadClass:
+            def __call__(self, t):
+                return t
+
+        with self.assertRaises(TypeError):
+            msprime.simulate(
+                5,
+                random_seed=1,
+                demographic_events=[msprime.SimulationModelChange(time=BadClass)])
+
+    def test_large_provenance_warning(self):
+        with self.assertLogs('msprime.provenance', level='WARNING') as cm:
+            msprime.provenance.json_encode_provenance(
+                {"test": np.zeros(shape=(500_000,))}, 5)
+        self.assertIn(
+            "WARNING:msprime.provenance:The provenance information for the resulting"
+            " tree sequence is 2.38MB. This is nothing to worry about as"
+            " provenance is a good thing to have, but if you want to save this"
+            " memory/storage space you can disable provenance recording by setting"
+            " record_provenance=False",
+            cm.output)
 
     def test_mutate(self):
         ts = msprime.simulate(5, random_seed=1)
@@ -106,6 +189,11 @@ class TestBuildObjects(unittest.TestCase):
         self.assertEqual(decoded.parameters.start_time, 0)
         self.assertEqual(decoded.parameters.end_time, 100)
         self.assertEqual(decoded.parameters.keep, False)
+        self.assertEqual(decoded.parameters.model['alphabet'], 0)
+        self.assertEqual(
+            decoded.parameters.model['__class__'],
+            'msprime.mutations.InfiniteSites'
+        )
 
     def test_mutate_numpy(self):
         ts = msprime.simulate(5, random_seed=1)
@@ -124,3 +212,111 @@ class TestBuildObjects(unittest.TestCase):
         self.assertEqual(decoded.parameters.start_time, 0)
         self.assertEqual(decoded.parameters.end_time, 100)
         self.assertEqual(decoded.parameters.keep, False)
+
+
+class TestParseProvenance(unittest.TestCase):
+    def test_parse_non_msprime(self):
+        # Most testing of parsing is in the round tripping below
+        with self.assertRaises(ValueError):
+            ts = msprime.simulate(5)
+            prov = json.loads(ts.provenance(0).record)
+            prov['software']['name'] = 'skynet'
+            tables = ts.tables
+            tables.provenances.clear()
+            tables.provenances.add_row(json.dumps(prov))
+            command, prov = msprime.provenance.parse_provenance(tables.tree_sequence())
+
+    def test_parse_index(self):
+        ts = msprime.simulate(5, random_seed=1)
+        ts = msprime.mutate(ts)
+        command, prov = msprime.provenance.parse_provenance(ts)
+        self.assertEquals(command, 'mutate')
+        command, prov = msprime.provenance.parse_provenance(ts, 0)
+        self.assertEquals(command, 'simulate')
+        command, prov = msprime.provenance.parse_provenance(ts, 1)
+        self.assertEquals(command, 'mutate')
+
+
+class TestRoundTrip(unittest.TestCase):
+    """
+    Check that we can recreate tree sequences from their provenances
+    """
+    def verify_equal(self, ts1, ts2):
+        ts1_tables = ts1.dump_tables()
+        ts2_tables = ts2.dump_tables()
+        # We clear the provenances as they are not equal due to timestamps
+        ts1_tables.provenances.clear()
+        ts2_tables.provenances.clear()
+        self.assertEqual(ts1_tables, ts2_tables)
+
+    def verify(self, ts, recurse=True):
+        recreated = None
+        for i, _ in enumerate(ts.provenances()):
+            command, parsed_prov = msprime.provenance.parse_provenance(ts, i)
+            if recreated:
+                parsed_prov["tree_sequence"] = recreated
+            recreated = getattr(msprime, command)(**parsed_prov)
+        self.verify_equal(ts, recreated)
+        # We verify again to check that the recreated provenace is also good.
+        if recurse:
+            self.verify(recreated, recurse=False)
+
+
+class TestSimulateRoundTrip(TestRoundTrip):
+    def test_sample_size(self):
+        ts = msprime.simulate(10)
+        self.verify(ts)
+
+    def test_random_seed(self):
+        ts = msprime.simulate(10, random_seed=1234)
+        self.verify(ts)
+
+    def test_population_configuration(self):
+        pop_configs = [msprime.PopulationConfiguration(5) for _ in range(2)]
+        ts = msprime.simulate(population_configurations=pop_configs,
+                              migration_matrix=[[0, 1], [1, 0]],
+                              demographic_events=[msprime.SimulationModelChange(
+                                  time=lambda t: t+0.1),
+                              ])
+        self.verify(ts)
+
+    def test_pedigree(self):
+        inds = np.array([1, 2, 3, 4, 5, 6])
+        parent_indices = np.array([
+            4, 5,
+            4, 5,
+            4, 5,
+            4, 5,
+            -1, -1,
+            -1, -1]).reshape(-1, 2)
+        times = np.array([0, 0, 0, 0, 1, 1])
+        is_sample = np.array([1, 1, 1, 1, 0, 0])
+        t = max(times)
+        model = msprime.WrightFisherPedigree()
+        ped = msprime.Pedigree(inds, parent_indices, times, is_sample,
+                               sex=None, ploidy=2)
+        ts = msprime.simulate(
+            sample_size=4,
+            pedigree=ped,
+            demographic_events=[
+                msprime.SimulationModelChange(
+                    t, msprime.DiscreteTimeWrightFisher(2))],
+            model=model)
+        self.verify(ts)
+
+    def test_from_ts(self):
+        from_ts = msprime.simulate(10, random_seed=5)
+        from_ts = tsutil.decapitate(from_ts, from_ts.num_edges // 2)
+        start_time = from_ts.tables.nodes.time.max()
+        ts = msprime.simulate(
+            from_ts=from_ts, start_time=start_time, random_seed=2)
+        print(list(ts.provenances()))
+        self.verify(ts)
+
+
+class TestMutateRoundTrip(TestRoundTrip):
+    def test_mutate_round_trip(self):
+        ts = msprime.simulate(5, random_seed=1)
+        ts = msprime.mutate(
+            ts, rate=2, random_seed=1, start_time=0, end_time=100, keep=False)
+        self.verify(ts)

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -160,11 +160,12 @@ class TestBasicFunctionality(unittest.TestCase):
         self.assertEqual(final_tables.mutations, from_tables.mutations)
 
         # Afterwards, the other tables should be equal up to the length of the
-        # input tables.
+        # input tables, apart from the provenance.
         final_tables.nodes.truncate(len(from_tables.nodes))
         final_tables.edges.truncate(len(from_tables.edges))
         final_tables.migrations.truncate(len(from_tables.migrations))
-        final_tables.provenances.truncate(len(from_tables.provenances))
+        final_tables.provenances.clear()
+        from_tables.provenances.clear()
         self.assertEqual(final_tables, from_tables)
 
         if final_ts.num_migrations == 0:
@@ -831,8 +832,6 @@ class TestSlimOutput(unittest.TestCase):
         # should always have the same set of mutations before and after.
         self.assertEqual(final_tables.sites, from_tables.sites)
         self.assertEqual(final_tables.mutations, from_tables.mutations)
-        final_tables.provenances.truncate(len(from_tables.provenances))
-        self.assertEqual(final_tables.provenances, from_tables.provenances)
         self.assertEqual(max(tree.num_roots for tree in final_ts.trees()), 1)
 
     def test_minimal_example_no_recombination(self):


### PR DESCRIPTION
Issue #912 

I've started looking into this, the following `simulate` arguments use non-basic types that would need serialising:
- [x] recombination_map (`RecombinationMap`)
- [x] population_configurations (list of `PopulationConfiguration` or None.)
- [x] migration_matrix (list or numpy array)
- [x] demographic_events (list of subclasses of `DemographicEvent`)
- [x] samples (list of `Sample`)
- [x] from_ts (`TreeSequence`) 
- [x] model (string or `SimulationModel`)

Also the following two undocumented arguments have non-basic types:
- [x] pedigree (`Pedigree`)
- [x] ~~mutation_generator (`_msprime.MutationGenerator`)~~ Deprecated since 0.6.1 so don't include

Some of these classes do not support serialising by inspecting by `cls.__dict__`, for example `RecombinationMap` doesn't store it's arguments but passes them to the low-level instance. ~~My plan is to add `to_json` methods to these classes.~~ `asdict` methods as this allows easier recursive serialisation.

- [x] consider security implications of functional serialisation
- [x]  log errors in final provenance
- [x] `record_provenance` option to disable writing
- [x] `parse_simulate_provenance` to give dict of args from a provenance
- [x] replication index issues
- [x] `mutate` provenance
- [x] `parse_mutate_provenance`

