### PR TITLE
Store from_ts as offsets in provenance.

### DIFF
--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018-2019 University of Oxford
+# Copyright (C) 2018-2020 University of Oxford
 #
 # This file is part of msprime.
 #


### PR DESCRIPTION
Proposal for #928. All the tests pass, so we can round trip successfully. It's not 100% robust because you could have called ``mutate`` on the tree sequence output by ``simulate`` afterwards and the extra sites and mutations (which won't just be appended but will also be sorted) will be in there.

Anyway, though, I wonder if this is missing the point. The idea of provenances is that if we sequentially apply the provenance commands we should end up with the same tree sequence at the end. So, the first provenance will just have the simulate arguments encoded. The second provenance will have extra arguments encoded but will assume that the tree seq is present.

I'll open another PR with a different proposal.

