### PR TITLE
Initial proposal for 'rerun' function.

### DIFF
--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -113,9 +113,7 @@ class ProvenanceEncoderDecoder(json.JSONEncoder):
             }
 
         if isinstance(obj, tskit.TreeSequence):
-            # Store the tree sequence as the tables deserialised with
-            # tskit.TableCollection.fromdict(tables).tree_sequence()
-            return {'__ts__': obj.tables.asdict()}
+            return "__current_ts__"
 
         elif isinstance(obj, numpy.ndarray):
             # The most failsafe way would be be to `base64.b64encode(obj.tostring())`
@@ -150,8 +148,6 @@ class ProvenanceEncoderDecoder(json.JSONEncoder):
                 return types.FunctionType(
                     marshal.loads(base64.b64decode(obj['__function__'])),
                     {}, 'func', obj['defaults'], ())
-            elif '__ts__' in obj:
-                return tskit.TableCollection.fromdict(obj['__ts__']).tree_sequence()
             elif '__ndarray__' in obj:
                 return numpy.asarray(obj['__ndarray__'], dtype=obj['dtype'])
             elif '__npgeneric__' in obj:
@@ -165,21 +161,25 @@ class ProvenanceEncoderDecoder(json.JSONEncoder):
         return json.JSONDecoder(object_hook=hook).decode(s)
 
 
-def parse_provenance(ts, index=None):
+def parse_provenance(provenance, current_ts):
     """
     Convert the specified provenance to tuple of the command used and dict suitable
     for calling the command again e.g `msprime.simulate(**parse_provenance(ts)[1])`
     """
-    if index is None:
-        index = ts.num_provenances - 1
-    prov = ts.provenance(index).record
-    ret = ProvenanceEncoderDecoder.decode(prov)
+    ret = ProvenanceEncoderDecoder.decode(provenance.record)
     if ret['software']['name'] != 'msprime':
         raise ValueError(f'Only msprime provanances can be parsed,'
                          f' found {ret["software"]["name"]}')
-    command = ret['parameters']['command']
-    del ret['parameters']['command']
-    return command, ret['parameters']
+    parameters = ret['parameters']
+    command = parameters.pop('command')
+    updated_parameters = {}
+    for key, value in parameters.items():
+        # TODO This is potentially unsafe. What if we had another argument to
+        # the function that happened to be "__current_ts__"?
+        if value == "__current_ts__":
+            value = current_ts
+        updated_parameters[key] = value
+    return command, updated_parameters
 
 
 def _human_readable_size(size, decimal_places=2):

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -2477,3 +2477,20 @@ class DemographyDebugger(object):
         Returns the number of epochs defined by the demographic model.
         """
         return len(self.epochs)
+
+
+def rerun(ts):
+    """
+    Reruns the simulations encoded in the provenance of the specified tree
+    sequence.
+    """
+    # TODO We can imagine passing in extra software/cmd arguments which map to a
+    # callable.
+    # TODO figure out how to workaround the circular import problems. Possibly
+    # this should just be in it's own module or something.
+    cmd_map = {"simulate": simulate}  # , "mutate": mutations.mutate}
+    current_ts = None
+    for prov in ts.provenances():
+        cmd, args = provenance.parse_provenance(prov, current_ts)
+        current_ts = cmd_map[cmd](**args)
+    return current_ts


### PR DESCRIPTION
This is an alternative proposal for dealing with provenance. I think fundamentally this is the right way to do things, but there's details to be worked out.

The idea is that we should guarantee that we can reproduce a tree sequence **only** if the same sequence of operations is applied.  We use the ``__current_ts__`` as a marker to say, "apply the function to the current state of the tree sequence`` as you are running through the provenances, one-by-one.

The cool thing here is that we don't even need to do this within msprime! If there was a standard way of decoding provenance (i.e., we associated a schema with it) and we provided the map of command->callable as input, we could do this with tskit.

Anyway, we don't need to do this now, but we should decide on the protocol used to denote the current state of the tree sequence.