### PR TITLE
Reject zero mass_to_next_recomb in poisson sampling for dtwf

### DIFF
--- a/lib/recomb_map.c
+++ b/lib/recomb_map.c
@@ -210,7 +210,9 @@ recomb_map_sample_poisson(recomb_map_t *self, gsl_rng *rng, double start)
     double left_bound, mass_to_next_recomb;
 
     left_bound = self->discrete ? start + 1 : start;
-    mass_to_next_recomb = gsl_ran_exponential(rng, 1.0);
+    do {
+        mass_to_next_recomb = gsl_ran_exponential(rng, 1.0);
+    } while (mass_to_next_recomb == 0.0);
 
     return recomb_map_shift_by_mass(self, left_bound, mass_to_next_recomb);
 }


### PR DESCRIPTION
In sampling breakpoints for DTWF, we use `gsl_ran_exponential` to get the recombination mass from `start` to step forward, sampled from a Poisson distribution. `gsl_ran_exponential` returns values >= 0, though we cannot have two breakpoints in the same location so we want values strictly greater than 0. Sure enough, the day that it would return 0 came at last in #938. I verified that `mass_to_next_recomb == 0` on the iteration that the assert `k > start` failed.

To address this, just reject values that == 0 and resample. Manual test of the sim in #938 no longer fails the assert.

Resolves #938 