### PR TITLE
Bring back genetic and physical space conversion in Recombination Map

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -2194,6 +2194,50 @@ out:
 }
 
 static PyObject *
+RecombinationMap_position_to_mass(RecombinationMap *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    double position;
+
+    if (RecombinationMap_check_recomb_map(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "d", &position)) {
+        goto out;
+    }
+    if (position < 0) {
+        PyErr_SetString(PyExc_ValueError, "Position must be >= 0");
+        goto out;
+    }
+
+    ret = Py_BuildValue("d", recomb_map_position_to_mass(self->recomb_map, position));
+out:
+    return ret;
+}
+
+static PyObject *
+RecombinationMap_mass_to_position(RecombinationMap *self, PyObject *args)
+{
+    PyObject *ret = NULL;
+    double mass;
+
+    if (RecombinationMap_check_recomb_map(self) != 0) {
+        goto out;
+    }
+    if (!PyArg_ParseTuple(args, "d", &mass)) {
+        goto out;
+    }
+    if (mass < 0) {
+        PyErr_SetString(PyExc_ValueError, "Recombination mass must be >= 0");
+        goto out;
+    }
+
+    ret = Py_BuildValue("d", recomb_map_mass_to_position(self->recomb_map, mass));
+out:
+    return ret;
+}
+
+static PyObject *
 RecombinationMap_get_total_recombination_rate(RecombinationMap *self)
 {
     PyObject *ret = NULL;
@@ -2312,6 +2356,12 @@ static PyMethodDef RecombinationMap_methods[] = {
     {"get_total_recombination_rate",
         (PyCFunction) RecombinationMap_get_total_recombination_rate, METH_NOARGS,
         "Returns the total product of physical distance times recombination rate"},
+    {"position_to_mass",
+        (PyCFunction) RecombinationMap_position_to_mass, METH_VARARGS,
+        "Returns the cumulative recombination mass corresponding to the given position"},
+    {"mass_to_position",
+        (PyCFunction) RecombinationMap_mass_to_position, METH_VARARGS,
+        "Returns the position corresponding to the given cumulative recombination mass"},
     {"get_size", (PyCFunction) RecombinationMap_get_size, METH_NOARGS,
         "Returns the number of physical  positions in this map."},
     {"get_sequence_length", (PyCFunction) RecombinationMap_get_sequence_length, METH_NOARGS,

--- a/msprime/simulations.py
+++ b/msprime/simulations.py
@@ -1117,19 +1117,19 @@ class RecombinationMap(object):
         return self._ll_recombination_map
 
     def physical_to_genetic(self, physical_x):
-        raise ValueError("Genetic space is no longer supported")
+        return self._ll_recombination_map.position_to_mass(physical_x)
 
     def physical_to_discrete_genetic(self, physical_x):
-        raise ValueError("Genetic space is no longer supported")
+        raise ValueError("Discrete genetic space is no longer supported")
 
     def genetic_to_physical(self, genetic_x):
-        raise ValueError("Genetic space is no longer supported")
+        return self._ll_recombination_map.mass_to_position(genetic_x)
 
     def get_total_recombination_rate(self):
         return self._ll_recombination_map.get_total_recombination_rate()
 
     def get_per_locus_recombination_rate(self):
-        raise ValueError("Genetic space is no longer supported")
+        raise ValueError("Genetic loci are no longer supported")
 
     def get_size(self):
         return self._ll_recombination_map.get_size()

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1963,6 +1963,18 @@ class TestRecombinationMap(LowLevelTestCase):
             rm = _msprime.RecombinationMap([0, 10], [0.25, 0], discrete)
             self.assertEqual(rm.get_discrete(), discrete)
 
+    def test_convert_mass_and_position(self):
+        rm = _msprime.RecombinationMap([0, 10, 20], [0, 1, 0], discrete=True)
+        self.assertRaises(TypeError, rm.position_to_mass)
+        self.assertRaises(TypeError, rm.mass_to_position)
+        for bad_value in [[1, 2, 3], "123", dict(), None]:
+            self.assertRaises(TypeError, rm.position_to_mass, bad_value)
+            self.assertRaises(TypeError, rm.mass_to_position, bad_value)
+        self.assertRaises(ValueError, rm.position_to_mass, -1)
+        self.assertRaises(ValueError, rm.mass_to_position, -1)
+        self.assertEqual(rm.position_to_mass(15), 5)
+        self.assertEqual(rm.mass_to_position(5), 15)
+
 
 class TestRandomGenerator(unittest.TestCase):
     """


### PR DESCRIPTION
These changes reinstate the conversion methods between genetic and physical coordinates on the Python `RecombinationMap`. Genetic coordinate is synonymous with the cumulative rate of recombination from the start of the sequence to the corresponding physical location. Methods to do this conversion already existed in C.

This definition differs _slightly_ from the previous semantics because there is no longer the separate notion of genetic loci as a parameter to the map. Given the above definition, and the fact that genetic loci no longer exist, the method for computing the discrete genetic coordinate doesn't seem to make much sense and remains deprecated.

 The tests are those that existed before [this PR](https://github.com/tskit-dev/msprime/commit/6c08fcf2dd01c04f85391323a89fe9dd1bca303c), save for some clean up to remove varying number of loci and the complications that result. They are also tested against the proposed implementation of `physical_to_genetic` in #919 

Resolves #919 

cc @jeromekelleher @hyanwong