### PR TITLE
Finite sites branchwise

### DIFF
--- a/lib/dev-tools/dev-cli.c
+++ b/lib/dev-tools/dev-cli.c
@@ -762,6 +762,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     msp_t msp;
     recomb_map_t recomb_map;
     interval_map_t mut_map;
+    mutation_model_t mut_model;
     mutgen_t mutgen;
     tsk_table_collection_t tables;
     tsk_treeseq_t tree_seq;
@@ -780,7 +781,11 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     if (ret != 0) {
         fatal_msprime_error(ret, __LINE__);
     }
-    ret = mutgen_alloc(&mutgen, rng, &mut_map, mutation_params.alphabet, 0);
+    ret = mutation_model_factory(&mut_model, mutation_params.alphabet);
+    if (ret != 0) {
+        fatal_msprime_error(ret, __LINE__);
+    }
+    ret = mutgen_alloc(&mutgen, rng, &mut_map, &mut_model, 0);
     if (ret != 0) {
         fatal_msprime_error(ret, __LINE__);
     }
@@ -847,6 +852,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     msp_free(&msp);
     recomb_map_free(&recomb_map);
     interval_map_free(&mut_map);
+    mutation_model_free(&mut_model);
     mutgen_free(&mutgen);
     gsl_rng_free(rng);
     tsk_table_collection_free(&tables);

--- a/lib/dev-tools/example.cfg
+++ b/lib/dev-tools/example.cfg
@@ -69,7 +69,7 @@ gene_conversion_rate = 1.1;
 gene_conversion_track_length = 1.0;
 
 # The mutation rate per generation.
-mutation_rate = 0.002;
+mutation_rate = 0.02;
 # Alphabet used in infinite sites mutations. 0 for binary and 1 for ACGT
 mutation_alphabet = 1;
 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -87,12 +87,6 @@ ran_inc_beta(gsl_rng *r, double a, double b, double x)
     }
 }
 
-static bool
-doubles_almost_equal(double a, double b, double eps)
-{
-    return (fabs(a) < eps && fabs(b) < eps) || gsl_fcmp(a, b, eps) == 0;
-}
-
 static int
 cmp_individual(const void *a, const void *b) {
     const segment_t *ia = (const segment_t *) a;

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -26,82 +26,368 @@
 
 #include "msprime.h"
 
+typedef struct mutation_t {
+    tsk_id_t id;
+    tsk_id_t site;
+    tsk_id_t node;
+    char *derived_state;
+    tsk_size_t derived_state_length;
+    char *metadata;
+    tsk_size_t metadata_length;
+    // additions to tsk_mutation_t:
+    double time;
+    struct mutation_t *parent;
+    struct mutation_t *next;
+    bool new;
+    bool keep;
+} mutation_t;
+
 typedef struct {
-    const char *ancestral_state;
-    const char *derived_state;
-} mutation_type_t;
-
-static const mutation_type_t binary_mutation_types[] = {
-    {"0", "1"}
-};
-
-static const mutation_type_t acgt_mutation_types[] = {
-    {"A", "C"},
-    {"A", "G"},
-    {"A", "T"},
-    {"C", "A"},
-    {"C", "G"},
-    {"C", "T"},
-    {"G", "A"},
-    {"G", "C"},
-    {"G", "T"},
-    {"T", "A"},
-    {"T", "C"},
-    {"T", "G"},
-};
+    double position;
+    char *ancestral_state;
+    tsk_size_t ancestral_state_length;
+    char *metadata;
+    tsk_size_t metadata_length;
+    // modifications to tsk_site_t:
+    mutation_t *mutations;
+    size_t mutations_length;
+    bool new;
+} site_t;
 
 static int
-cmp_site(const void *a, const void *b) {
-    const tsk_site_t *ia = (const tsk_site_t *) a;
-    const tsk_site_t *ib = (const tsk_site_t *) b;
+cmp_site(const void *a, const void *b)
+{
+    const site_t *ia = (const site_t *) a;
+    const site_t *ib = (const site_t *) b;
     return (ia->position > ib->position) - (ia->position < ib->position);
+}
+
+static int
+cmp_mutationp(const void *a, const void *b)
+{
+    int out;
+    /* the extra cast is to avoid a gcc bug in -Werror=cast-qual:
+     * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=81631 */
+    const mutation_t *ia = *(const mutation_t **) (uintptr_t) a;
+    const mutation_t *ib = *(const mutation_t **) (uintptr_t) b;
+    out = (ia->new || ib->new) ? 0 : (ia->id - ib->id) - (ib->id - ia->id);
+    if (out == 0) {
+        out = (ib->time > ia->time) - (ib->time < ia->time);
+    }
+    return out;
+}
+
+static void
+insert_mutation(site_t *site, mutation_t *new)
+{
+    mutation_t *u;
+    u = site->mutations;
+    new->next = u;
+    site->mutations = new;
+    site->mutations_length++;
+}
+
+static int MSP_WARN_UNUSED
+sort_mutations(site_t *site)
+{
+    int ret = 0;
+    size_t k;
+    mutation_t *m;
+    size_t num_mutations = site->mutations_length;
+    mutation_t **p = NULL;
+    if (num_mutations > 0) {
+        p = malloc(num_mutations * sizeof(*p));
+        if (p == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
+        k = 0;
+        for (m = site->mutations; m != NULL; m = m->next) {
+            p[k] = m;
+            k++;
+        }
+        assert(k == num_mutations);
+        qsort(p, (size_t) num_mutations, sizeof(mutation_t *), &cmp_mutationp);
+        site->mutations = p[0];
+        for (k = 0; k < num_mutations; k++) {
+            m = p[k];
+            if (k == num_mutations - 1) {
+                m->next = NULL;
+            } else {
+                m->next = p[k+1];
+            }
+        }
+    }
+out:
+    msp_safe_free(p);
+    return ret;
+}
+
+/*******************
+ * Mutation model */
+
+void
+mutation_model_print_state(mutation_model_t *self, FILE *out)
+{
+    size_t j, k;
+    double *mutation_row;
+
+    fprintf(out, "mutation_model (%p):: (%d)", (void *) self, (int) self->num_alleles);
+    fprintf(out, "\nroot_distribution =");
+    for (j = 0; j < self->num_alleles; j++) {
+        fprintf(out, " %s (%0.4f),", self->alleles[j], self->root_distribution[j]);
+    }
+    fprintf(out, "\n\t------------------------------\n");
+    for (j = 0; j < self->num_alleles; j++) {
+        mutation_row = self->transition_matrix + j * self->num_alleles;
+        fprintf(out, "\t");
+        for (k = 0; k < self->num_alleles; k++) {
+            fprintf(out, " %0.4f", mutation_row[k]);
+        }
+        fprintf(out, "\n");
+    }
+    fprintf(out, "\n");
+}
+
+static int MSP_WARN_UNUSED
+mutation_model_check_validity(mutation_model_t *self)
+{
+    int ret = 0;
+    size_t j, k;
+    double prob, min_prob;
+    double *mutation_row;
+
+    /* Check probabilities sum to one */
+    prob = 0;
+    min_prob = 0;
+    for (j = 0; j < self->num_alleles; j++) {
+        prob += self->root_distribution[j];
+        min_prob = GSL_MIN(min_prob, self->root_distribution[j]);
+    }
+    if (!doubles_almost_equal(prob, 1.0, 1e-12) || min_prob < 0.0) {
+        ret = MSP_ERR_BAD_ROOT_PROBABILITIES;
+        goto out;
+    }
+    for (j = 0; j < self->num_alleles; j++) {
+        prob = 0;
+        min_prob = 0;
+        mutation_row = self->transition_matrix + j * self->num_alleles;
+        for (k = 0; k < self->num_alleles; k++) {
+            prob += mutation_row[k];
+            min_prob = GSL_MIN(min_prob, mutation_row[k]);
+        }
+        if (!doubles_almost_equal(prob, 1.0, 1e-12) || min_prob < 0.0) {
+            ret = MSP_ERR_BAD_TRANSITION_MATRIX;
+            goto out;
+        }
+    }
+
+out:
+    return ret;
+}
+
+static int MSP_WARN_UNUSED
+mutation_model_copy_alleles(mutation_model_t *self, char **alleles)
+{
+    int ret = 0;
+    size_t j, len;
+
+    for (j = 0; j < self->num_alleles; j++) {
+        len = strlen(alleles[j]);
+        self->alleles[j] = malloc(len + 1);
+        if (self->alleles[j] == NULL) {
+            goto out;
+        }
+        strcpy(self->alleles[j], alleles[j]);
+    }
+out:
+    return ret;
+}
+
+int MSP_WARN_UNUSED
+mutation_model_alloc(mutation_model_t *self, size_t num_alleles,
+        char **alleles, double *root_distribution, double *transition_matrix)
+{
+    int ret = 0;
+
+    memset(self, 0, sizeof(mutation_model_t));
+    if (num_alleles < 2) {
+        ret = MSP_ERR_INSUFFICIENT_ALLELES;
+        goto out;
+    }
+    self->alleles = calloc(num_alleles, sizeof(*self->alleles));
+    self->root_distribution = malloc(num_alleles * sizeof(*self->root_distribution));
+    self->transition_matrix = malloc(num_alleles * num_alleles
+        * sizeof(*self->transition_matrix));
+    if (self->alleles == NULL || self->root_distribution == NULL
+            || self->transition_matrix == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    self->num_alleles = num_alleles;
+    memcpy(self->root_distribution, root_distribution,
+            num_alleles * sizeof(*root_distribution));
+    memcpy(self->transition_matrix, transition_matrix,
+            num_alleles * num_alleles * sizeof(*transition_matrix));
+    ret = mutation_model_copy_alleles(self, alleles);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = mutation_model_check_validity(self);
+out:
+    return ret;
+}
+
+int
+mutation_model_free(mutation_model_t *self)
+{
+    size_t j;
+
+    if (self->alleles != NULL) {
+        for (j = 0; j < self->num_alleles; j++) {
+            msp_safe_free(self->alleles[j]);
+        }
+    }
+    msp_safe_free(self->alleles);
+    msp_safe_free(self->root_distribution);
+    msp_safe_free(self->transition_matrix);
+    return 0;
+}
+
+size_t
+mutation_model_get_num_alleles(mutation_model_t *self)
+{
+    return self->num_alleles;
+}
+
+static tsk_id_t
+mutation_model_allele_index(mutation_model_t *self, const char *allele, size_t length)
+{
+    tsk_id_t ret = -1;
+    tsk_size_t j;
+
+    for (j = 0; j < self->num_alleles; j++) {
+        if (length == strlen(self->alleles[j])
+            && memcmp(allele, self->alleles[j], length) == 0) {
+            ret = (tsk_id_t) j;
+            break;
+        }
+    }
+    return ret;
+}
+
+static const char *binary_alleles[] = {"0", "1"};
+static double binary_model_root_distribution[] = {1.0, 0.0};
+static double binary_model_transition_matrix[] = {0.0, 1.0, 1.0, 0.0};
+
+#define ONE_THIRD (1.0 / 3.0)
+static const char *acgt_alleles[] = {"A", "C", "G", "T"};
+static double jukes_cantor_model_root_distribution[] = {0.25, 0.25, 0.25, 0.25};
+static double jukes_cantor_model_transition_matrix[] =
+        {0.0, ONE_THIRD, ONE_THIRD, ONE_THIRD,
+        ONE_THIRD, 0.0, ONE_THIRD, ONE_THIRD,
+        ONE_THIRD, ONE_THIRD, 0.0, ONE_THIRD,
+        ONE_THIRD, ONE_THIRD, ONE_THIRD, 0.0};
+
+
+/* Populates this mutation model instance with simple mutation model.
+ *
+ * 0 -> Symmetric 0/1 mutations
+ * 1 -> Jukes Cantor ACGT mutations.
+ *
+ * This is only provided for testing purposes to make it easy to
+ * obtain a populated model.
+ */
+int
+mutation_model_factory(mutation_model_t *self, int model)
+{
+    int ret = MSP_ERR_GENERIC;
+
+    /* We need to cast to uintptr_t * first to work around the annoying pedantry
+     * about discarding const qualifiers. */
+    if (model == 0) {
+        ret = mutation_model_alloc(self, 2, (char **) (uintptr_t *) binary_alleles,
+                binary_model_root_distribution, binary_model_transition_matrix);
+    } else if (model == 1) {
+        ret = mutation_model_alloc(self, 4, (char **) (uintptr_t *) acgt_alleles,
+                jukes_cantor_model_root_distribution, jukes_cantor_model_transition_matrix);
+    }
+    return ret;
+}
+
+/***********************
+ * Mutation generator */
+
+static void
+mutgen_check_state(mutgen_t *self)
+{
+    size_t j;
+    avl_node_t *a;
+    site_t *s;
+    mutation_t *m;
+
+    for (a = self->sites.head; a != NULL; a = a->next) {
+        s = (site_t *) a->item;
+        m = s->mutations;
+        for (j = 0; j < s->mutations_length; j++) {
+            assert(m != NULL);
+            assert(m->id >= -1);
+            assert(m->node >= 0);
+            if (j == s->mutations_length - 1) {
+                assert(m->next == NULL);
+            }
+            m = m->next;
+        }
+        assert(m == NULL);
+    }
 }
 
 void
 mutgen_print_state(mutgen_t *self, FILE *out)
 {
     avl_node_t *a;
-    tsk_site_t *site;
-    tsk_mutation_t *mutation;
-    tsk_size_t j;
+    site_t *s;
+    mutation_t *m;
+    tsk_id_t parent_id;
 
     fprintf(out, "Mutgen state\n");
     fprintf(out, "\trate_map:\n");
     interval_map_print_state(self->rate_map, out);
     fprintf(out, "\tstart_time = %f\n", self->start_time);
     fprintf(out, "\tend_time = %f\n", self->end_time);
+    fprintf(out, "\tmodel:\n");
+    mutation_model_print_state(self->model, out);
     tsk_blkalloc_print_state(&self->allocator, out);
 
     for (a = self->sites.head; a != NULL; a = a->next) {
-        site = (tsk_site_t *) a->item;
-        fprintf(out, "%f\t%.*s\t%.*s\n", site->position,
-                (int) site->ancestral_state_length, site->ancestral_state,
-                (int) site->metadata_length, site->metadata);
-        for (j = 0; j < site->mutations_length; j++) {
-            mutation = site->mutations + j;
-            fprintf(out, "\t%d\t%d\t%.*s\t%.*s\n", mutation->node, mutation->parent,
-                    (int) mutation->derived_state_length, mutation->derived_state,
-                    (int) mutation->metadata_length, mutation->metadata);
+        s = (site_t *) a->item;
+        fprintf(out, "%f\t%.*s\t%.*s\t(%d)\t%d\n", s->position,
+                (int) s->ancestral_state_length, s->ancestral_state,
+                (int) s->metadata_length, s->metadata,
+                s->new, (int) s->mutations_length);
+        for (m = s->mutations; m != NULL; m = m->next) {
+            parent_id = m->parent == NULL ? TSK_NULL : m->parent->id;
+            fprintf(out, "\t(%d)\t%f\t%d\t%d\t%.*s\t%.*s\t(%d)\t%d\n",
+                    m->id, m->time, m->node, parent_id,
+                    (int) m->derived_state_length, m->derived_state,
+                    (int) m->metadata_length, m->metadata, m->new, m->keep);
         }
     }
+    mutgen_check_state(self);
 }
 
 int MSP_WARN_UNUSED
 mutgen_alloc(mutgen_t *self, gsl_rng *rng, interval_map_t *rate_map,
-        int alphabet, size_t block_size)
+        mutation_model_t *model, size_t block_size)
 {
     int ret = 0;
     size_t j;
 
     assert(rng != NULL);
     memset(self, 0, sizeof(mutgen_t));
-    if (! (alphabet == MSP_ALPHABET_BINARY || alphabet == MSP_ALPHABET_NUCLEOTIDE)) {
-        ret = MSP_ERR_BAD_PARAM_VALUE;
-        goto out;
-    }
-    self->alphabet = alphabet;
     self->rng = rng;
     self->rate_map = rate_map;
+    self->model = model;
     self->start_time = -DBL_MAX;
     self->end_time = DBL_MAX;
     self->block_size = block_size;
@@ -134,7 +420,7 @@ mutgen_free(mutgen_t *self)
     return 0;
 }
 
-int
+int MSP_WARN_UNUSED
 mutgen_set_time_interval(mutgen_t *self, double start_time, double end_time)
 {
     int ret = 0;
@@ -183,184 +469,202 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_mutation(mutgen_t *self, node_id_t node, double position,
-        const char *ancestral_state, const char *derived_state)
+mutgen_add_site(mutgen_t *self, double position, bool new,
+        const char *ancestral_state, tsk_size_t ancestral_state_length,
+        const char *metadata, tsk_size_t metadata_length,
+        avl_node_t **avl_nodep)
 {
     int ret = 0;
-    tsk_site_t *site = tsk_blkalloc_get(&self->allocator, sizeof(*site));
-    tsk_mutation_t *mutation = tsk_blkalloc_get(&self->allocator, sizeof(*mutation));
-    avl_node_t* avl_node = tsk_blkalloc_get(&self->allocator, sizeof(*avl_node));
+    char *buff;
+    avl_node_t *avl_node;
+    site_t *site;
 
-    if (site == NULL || mutation == NULL || avl_node == NULL) {
+    avl_node = tsk_blkalloc_get(&self->allocator, sizeof(*avl_node));
+    site = tsk_blkalloc_get(&self->allocator, sizeof(*site));
+    if (site == NULL || avl_node == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
     memset(site, 0, sizeof(*site));
-    memset(mutation, 0, sizeof(*mutation));
     site->position = position;
-    site->ancestral_state = ancestral_state;
-    site->ancestral_state_length = 1;
-    mutation->derived_state = derived_state;
-    mutation->derived_state_length = 1;
-    mutation->node = node;
-    mutation->parent = TSK_NULL;
-    site->mutations = mutation;
-    site->mutations_length = 1;
+    site->new = new;
+
+    /* ancestral state */
+    buff = tsk_blkalloc_get(&self->allocator, ancestral_state_length);
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, ancestral_state, ancestral_state_length);
+    site->ancestral_state = buff;
+    site->ancestral_state_length = ancestral_state_length;
+
+    /* metadata */
+    buff = tsk_blkalloc_get(&self->allocator, metadata_length);
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, metadata, metadata_length);
+    site->metadata = buff;
+    site->metadata_length = metadata_length;
 
     avl_init_node(avl_node, site);
     avl_node = avl_insert_node(&self->sites, avl_node);
-    assert(avl_node != NULL);
+    if (avl_node == NULL) {
+        ret = MSP_ERR_DUPLICATE_SITE_POSITION;
+        goto out;
+    }
+    *avl_nodep = avl_node;
+
 out:
     return ret;
 }
 
 static int MSP_WARN_UNUSED
-mutget_initialise_sites(mutgen_t *self, tsk_table_collection_t *tables)
+mutgen_add_mutation(mutgen_t *self, site_t *site,
+        tsk_id_t id, node_id_t node, double time, bool new,
+        const char *derived_state, tsk_size_t derived_state_length,
+        const char *metadata, tsk_size_t metadata_length)
 {
     int ret = 0;
-    tsk_site_table_t *sites = &tables->sites;
-    tsk_mutation_table_t *mutations = &tables->mutations;
-    mutation_id_t mutation_id;
-    site_id_t site_id;
-    tsk_site_t *site;
-    avl_node_t *avl_node;
-    tsk_mutation_t *site_mutations;
-    tsk_size_t j, num_mutations, length;
     char *buff;
 
-    mutation_id = 0;
-    for (site_id = 0; site_id < (site_id_t) sites->num_rows; site_id++) {
-        j = (tsk_size_t) mutation_id;
-        while (j < mutations->num_rows && mutations->site[j] == site_id) {
-            j++;
-        }
-        num_mutations = j - (tsk_size_t) mutation_id;
-
-        site = tsk_blkalloc_get(&self->allocator, sizeof(*site));
-        avl_node = tsk_blkalloc_get(&self->allocator, sizeof(*avl_node));
-        site_mutations = tsk_blkalloc_get(&self->allocator,
-                num_mutations * sizeof(*site_mutations));
-        if (site == NULL || avl_node == NULL || site_mutations == NULL) {
-            ret = MSP_ERR_NO_MEMORY;
-            goto out;
-        }
-        site->position = sites->position[site_id];
-        site->mutations = site_mutations;
-        site->mutations_length = num_mutations;
-        /* ancestral state */
-        length = sites->ancestral_state_offset[site_id + 1]
-            - sites->ancestral_state_offset[site_id];
-        buff = tsk_blkalloc_get(&self->allocator, length);
-        if (buff == NULL) {
-            ret = MSP_ERR_NO_MEMORY;
-            goto out;
-        }
-        memcpy(buff, sites->ancestral_state +
-            sites->ancestral_state_offset[site_id], length);
-        site->ancestral_state = buff;
-        site->ancestral_state_length = length;
-
-        /* metadata */
-        length = sites->metadata_offset[site_id + 1]
-            - sites->metadata_offset[site_id];
-        buff = tsk_blkalloc_get(&self->allocator, length);
-        if (buff == NULL) {
-            ret = MSP_ERR_NO_MEMORY;
-            goto out;
-        }
-        memcpy(buff, sites->metadata +
-            sites->metadata_offset[site_id], length);
-        site->metadata = buff;
-        site->metadata_length = length;
-
-        for (j = 0; j < num_mutations; j++) {
-            /* We don't use the mutation ID directly here, so we can use it as a
-             * flag to indicate when a mutation was imported from outside or not.
-             * This is used when computing updated mutation parents when we
-             * re-export to the tables.. */
-            site_mutations[j].id = 1;
-            site_mutations[j].node = mutations->node[mutation_id];
-            site_mutations[j].parent = mutations->parent[mutation_id];
-
-            /* ancestral state */
-            length = mutations->derived_state_offset[mutation_id + 1]
-                - mutations->derived_state_offset[mutation_id];
-            buff = tsk_blkalloc_get(&self->allocator, length);
-            if (buff == NULL) {
-                ret = MSP_ERR_NO_MEMORY;
-                goto out;
-            }
-            memcpy(buff, mutations->derived_state +
-                mutations->derived_state_offset[mutation_id], length);
-            site_mutations[j].derived_state = buff;
-            site_mutations[j].derived_state_length = length;
-
-            /* metadata */
-            length = mutations->metadata_offset[mutation_id + 1]
-                - mutations->metadata_offset[mutation_id];
-            buff = tsk_blkalloc_get(&self->allocator, length);
-            if (buff == NULL) {
-                ret = MSP_ERR_NO_MEMORY;
-                goto out;
-            }
-            memcpy(buff, mutations->metadata +
-                mutations->metadata_offset[mutation_id], length);
-            site_mutations[j].metadata = buff;
-            site_mutations[j].metadata_length = length;
-
-            mutation_id++;
-        }
-        avl_init_node(avl_node, site);
-        avl_node = avl_insert_node(&self->sites, avl_node);
-        if (avl_node == NULL) {
-            ret = MSP_ERR_DUPLICATE_SITE_POSITION;
-            goto out;
-        }
+    mutation_t *mutation = tsk_blkalloc_get(&self->allocator, sizeof(*mutation));
+    if (mutation == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
     }
+    memset(mutation, 0, sizeof(*mutation));
+    mutation->id = id,
+    mutation->node = node;
+    mutation->parent = NULL;
+    mutation->time = time;
+    mutation->new = new;
+    mutation->keep = true;
+
+    /* derived state */
+    buff = tsk_blkalloc_get(&self->allocator, derived_state_length);
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, derived_state, derived_state_length);
+    mutation->derived_state = buff;
+    mutation->derived_state_length = derived_state_length;
+
+    /* metadata */
+    buff = tsk_blkalloc_get(&self->allocator, metadata_length);
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, metadata, metadata_length);
+    mutation->metadata = buff;
+    mutation->metadata_length = metadata_length;
+
+    insert_mutation(site, mutation);
 out:
     return ret;
 }
 
-static int
+static int MSP_WARN_UNUSED
+mutgen_initialise_sites(mutgen_t *self, tsk_table_collection_t *tables)
+{
+    int ret = 0;
+    tsk_site_table_t *sites = &tables->sites;
+    tsk_mutation_table_t *mutations = &tables->mutations;
+    tsk_node_table_t *nodes = &tables->nodes;
+    site_id_t site_id;
+    avl_node_t *avl_node;
+    const char *state, *metadata;
+    tsk_size_t j, length, metadata_length;
+
+    j = 0;
+    for (site_id = 0; site_id < (site_id_t) sites->num_rows; site_id++) {
+        avl_node = tsk_blkalloc_get(&self->allocator, sizeof(*avl_node));
+        if (avl_node == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
+        state = sites->ancestral_state + sites->ancestral_state_offset[site_id];
+        length = sites->ancestral_state_offset[site_id + 1]
+                    - sites->ancestral_state_offset[site_id];
+        metadata = sites->metadata + sites->metadata_offset[site_id];
+        metadata_length = sites->metadata_offset[site_id + 1]
+                    - sites->metadata_offset[site_id];
+        ret = mutgen_add_site(self, sites->position[site_id], false,
+                    state, length, metadata, metadata_length, &avl_node);
+        if (ret != 0) {
+            goto out;
+        }
+
+        while (j < mutations->num_rows && mutations->site[j] == site_id) {
+            assert(j < mutations->num_rows);
+            state = mutations->derived_state + mutations->derived_state_offset[j];
+            length = mutations->derived_state_offset[j + 1]
+                        - mutations->derived_state_offset[j];
+            metadata = mutations->metadata + mutations->metadata_offset[j];
+            metadata_length = mutations->metadata_offset[j + 1]
+                        - mutations->metadata_offset[j];
+            ret = mutgen_add_mutation(self,
+                    (site_t *) avl_node->item, (int) j,
+                    mutations->node[j], nodes->time[mutations->node[j]], false,
+                    state, length, metadata, metadata_length);
+            if (ret != 0) {
+                goto out;
+            }
+            j++;
+        }
+    }
+
+out:
+    return ret;
+}
+
+static int MSP_WARN_UNUSED
 mutgen_populate_tables(mutgen_t *self, tsk_site_table_t *sites, tsk_mutation_table_t *mutations)
 {
     int ret = 0;
-    size_t j;
-    site_id_t site_id;
+    tsk_id_t site_id, mutation_id, parent_id;
     avl_node_t *a;
-    tsk_site_t *site;
-    tsk_mutation_t *mutation;
-    mutation_id_t new_mutations = 0;
-    mutation_id_t parent;
+    site_t *site;
+    mutation_t *m;
+    size_t num_mutations;
 
+    site_id = 0;
     for (a = self->sites.head; a != NULL; a = a->next) {
-        site = (tsk_site_t *) a->item;
-        site_id = tsk_site_table_add_row(sites, site->position, site->ancestral_state,
-                site->ancestral_state_length, site->metadata, site->metadata_length);
-        if (site_id < 0) {
-            ret = msp_set_tsk_error(site_id);
-            goto out;
-        }
-        for (j = 0; j < site->mutations_length; j++) {
-            mutation = site->mutations + j;
-            parent = mutation->parent;
-            if (parent != TSK_NULL) {
-                parent += new_mutations;
+        site = (site_t *) a->item;
+        num_mutations = 0;
+        for (m = site->mutations; m != NULL; m = m->next) {
+            if (m->keep) {
+                if (m->parent == NULL) {
+                    parent_id = TSK_NULL;
+                } else {
+                    parent_id = m->parent->id;
+                    assert(parent_id != TSK_NULL);
+                }
+                mutation_id = tsk_mutation_table_add_row(mutations, site_id,
+                                m->node, parent_id,
+                                m->derived_state, m->derived_state_length,
+                                m->metadata, m->metadata_length);
+                if (mutation_id < 0) {
+                    ret = msp_set_tsk_error(mutation_id);
+                    goto out;
+                }
+                assert(mutation_id > parent_id);
+                m->id = mutation_id;
+                num_mutations++;
             }
-            ret = tsk_mutation_table_add_row(mutations, site_id,
-                    mutation->node, parent,
-                    mutation->derived_state, mutation->derived_state_length,
-                    mutation->metadata, mutation->metadata_length);
+        }
+        /* Omit any new sites that have no mutations */
+        if ((!site->new) || num_mutations > 0) {
+            ret = tsk_site_table_add_row(sites, site->position, site->ancestral_state,
+                    site->ancestral_state_length, site->metadata, site->metadata_length);
             if (ret < 0) {
-                ret = msp_set_tsk_error(ret);
                 goto out;
             }
-            if (mutation->id == 0) {
-                /* We use this flag to track the number of extra mutations we have
-                 * generated, which enables us to compute the new mutation parent
-                 * ID efficiently. See above for more notes on this */
-                new_mutations++;
-            }
+            site_id++;
         }
     }
     ret = 0;
@@ -368,25 +672,319 @@ out:
     return ret;
 }
 
+static int MSP_WARN_UNUSED
+mutgen_place_mutations(mutgen_t *self, tsk_table_collection_t *tables, bool discrete_sites)
+{
+    /* The mutation model for discrete sites is that there is
+     * a unit of "mutation mass" on each integer, so that
+     * in a segment [left, right) there can be mutations at the
+     * integers {ceil(left), ceil(left) + 1, ..., ceil(right) - 1},
+     * and the total mutation "length" is ceil(right) - ceil(left). */
+    int ret = 0;
+    const double *map_position = self->rate_map->position;
+    const double *map_rate = self->rate_map->value;
+    size_t branch_mutations, map_index;
+    size_t j, k;
+    tsk_node_table_t *nodes = &tables->nodes;
+    tsk_edge_table_t *edges = &tables->edges;
+    double left, right, site_left, site_right, edge_right;
+    double time, mu, position;
+    double branch_start, branch_end, branch_length;
+    node_id_t parent, child;
+    avl_node_t *avl_node;
+    double start_time = self->start_time;
+    double end_time = self->end_time;
+    site_t search;
+
+    for (j = 0; j < edges->num_rows; j++) {
+        left = edges->left[j];
+        edge_right = edges->right[j];
+        parent = edges->parent[j];
+        child = edges->child[j];
+        assert(child >= 0 && child < (node_id_t) nodes->num_rows);
+        branch_start = GSL_MAX(start_time, nodes->time[child]);
+        branch_end = GSL_MIN(end_time, nodes->time[parent]);
+        branch_length = branch_end - branch_start;
+
+        map_index = interval_map_get_index(self->rate_map, left);
+        right = 0;
+        while (right != edge_right) {
+            right = GSL_MIN(edge_right, map_position[map_index + 1]);
+            site_left = discrete_sites ? ceil(left) : left;
+            site_right = discrete_sites ? ceil(right) : right;
+            mu = branch_length * (site_right - site_left) * map_rate[map_index];
+            branch_mutations = gsl_ran_poisson(self->rng, mu);
+            for (k = 0; k < branch_mutations; k++) {
+                /* Rejection sample positions until we get one we haven't seen before,
+                 * unless we are doing discrete sites. Note that in principle this
+                 * could lead to an infinite loop here, but in practise we'd need to
+                 * use up all of the doubles before it could happen and so we'd
+                 * certainly run out of memory first. */
+                do {
+                    position = gsl_ran_flat(self->rng, site_left, site_right);
+                    if (discrete_sites) {
+                        position = floor(position);
+                    }
+                    search.position = position;
+                    avl_node = avl_search(&self->sites, &search);
+                } while (avl_node != NULL && !discrete_sites);
+
+                time = gsl_ran_flat(self->rng, branch_start, branch_end);
+                assert(site_left <= position && position < site_right);
+                assert(branch_start <= time && time < branch_end);
+                if (avl_node == NULL) {
+                    ret = mutgen_add_site(self, position, true,
+                            NULL, 0, NULL, 0, &avl_node);
+                    if (ret != 0) {
+                        goto out;
+                    }
+                }
+                ret = mutgen_add_mutation(self,
+                        (site_t *) avl_node->item,
+                        TSK_NULL, child, time, true,
+                        NULL, 0, NULL, 0);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+            map_index++;
+        }
+    }
+out:
+    return ret;
+}
+
+static int
+mutation_model_pick_allele(mutation_model_t *self, gsl_rng *rng)
+{
+    double u = gsl_ran_flat(rng, 0.0, 1.0);
+    int j = 0;
+    while (u > self->root_distribution[j]) {
+        u -= self->root_distribution[j];
+        j++;
+        assert(j < (int) self->num_alleles);
+    }
+    return j;
+}
+
+static int
+mutation_model_transition_allele(mutation_model_t *self, int parent_allele, gsl_rng *rng)
+{
+    double *probs = self->transition_matrix + parent_allele * (int) self->num_alleles;
+    double u = gsl_ran_flat(rng, 0.0, 1.0);
+    int j = 0;
+
+    while (u > probs[j]) {
+        u -= probs[j];
+        j++;
+        assert(j < (int) self->num_alleles);
+    }
+    return j;
+}
+
+static int
+mutgen_set_ancestral_state(mutgen_t *self, site_t *site, int allele)
+{
+    int ret = 0;
+    size_t len = strlen(self->model->alleles[allele]);
+    char *buff = tsk_blkalloc_get(&self->allocator, len);
+
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, self->model->alleles[allele], len);
+    site->ancestral_state = buff;
+    site->ancestral_state_length = (tsk_size_t) len;
+out:
+    return ret;
+}
+
+static int
+mutgen_set_derived_state(mutgen_t *self, mutation_t *mut, int allele)
+{
+    int ret = 0;
+    size_t len = strlen(self->model->alleles[allele]);
+    char *buff = tsk_blkalloc_get(&self->allocator, len);
+
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, self->model->alleles[allele], len);
+    mut->derived_state = buff;
+    mut->derived_state_length = (tsk_size_t) len;
+out:
+    return ret;
+}
+
+static int MSP_WARN_UNUSED
+mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_mutation,
+        tsk_size_t num_nodes, site_t *site)
+{
+    int ret = 0;
+    int ai, pa, da;
+    mutation_t *mut, *parent_mut;
+    tsk_id_t u;
+
+    ret = sort_mutations(site);
+    if (ret != 0) {
+        goto out;
+    }
+
+    if (site->new) {
+        ai = mutation_model_pick_allele(self->model, self->rng);
+        ret = mutgen_set_ancestral_state(self, site, ai);
+        if (ret != 0) {
+            goto out;
+        }
+    } else {
+        /* we don't error here if the allele is not found (and so ai < 0)
+         * because it's ok if we don't try to add a mutation to the site,
+         * e.g., if it is kept and we're doing infinite sites, or if we're
+         * mutating a different part of the genome  */
+        ai = mutation_model_allele_index(self->model,
+                site->ancestral_state, site->ancestral_state_length);
+    }
+
+    /* Create a mapping from mutations to nodes in bottom_mutation. If we see
+     * more than one mutation at a node, the previously seen one must be the
+     * parent of the current one since we assume they are in order. */
+    for (mut = site->mutations; mut != NULL; mut = mut->next) {
+        u = mut->node;
+        assert((tsk_size_t) u < num_nodes);
+        while (u != TSK_NULL && bottom_mutation[u] == NULL) {
+            u = parent[u];
+        }
+        if (u == TSK_NULL) {
+            pa = ai;
+            assert(mut->parent == NULL);
+        } else {
+            parent_mut = bottom_mutation[u];
+            mut->parent = parent_mut;
+            if (mut->time > parent_mut->time || (parent_mut->new && !mut->new)) {
+                ret = MSP_ERR_MUTATION_GENERATION_OUT_OF_ORDER;
+                goto out;
+            }
+            if (mut->new) {
+                pa = mutation_model_allele_index(self->model,
+                        parent_mut->derived_state, parent_mut->derived_state_length);
+            }
+        }
+        if (mut->new) {
+            if (pa < 0) {
+                /* only error if we are actually trying to mutate an unknown allele */
+                ret = MSP_ERR_UNKNOWN_ALLELE;
+                goto out;
+            }
+            da = mutation_model_transition_allele(self->model, pa, self->rng);
+            if (da == pa) {
+                // mark mut for removal
+                mut->keep = false;
+            } else {
+                ret = mutgen_set_derived_state(self, mut, da);
+                if (ret != 0) {
+                    goto out;
+                }
+            }
+        }
+        /* mut->keep defaults to true */
+        if (mut->keep) {
+            bottom_mutation[mut->node] = mut;
+        }
+    }
+    /* Reset the mapping for the next site */
+    for (mut = site->mutations; mut != NULL; mut = mut->next) {
+        bottom_mutation[mut->node] = NULL;
+    }
+
+out:
+    return ret;
+}
+
+static int MSP_WARN_UNUSED
+mutgen_apply_mutations(mutgen_t *self, tsk_table_collection_t *tables)
+{
+    int ret = 0;
+    const tsk_id_t *I, *O;
+    const tsk_edge_table_t edges = tables->edges;
+    const tsk_node_table_t nodes = tables->nodes;
+    const tsk_id_t M = (tsk_id_t) edges.num_rows;
+    tsk_id_t tj, tk;
+    tsk_id_t *parent = NULL;
+    mutation_t **bottom_mutation = NULL;
+    double left, right;
+    avl_node_t *avl_node;
+    site_t *site;
+
+    parent = malloc(nodes.num_rows * sizeof(*parent));
+    bottom_mutation = malloc(nodes.num_rows * sizeof(*bottom_mutation));
+    if (parent == NULL || bottom_mutation == NULL) {
+        ret = TSK_ERR_NO_MEMORY;
+        goto out;
+    }
+    memset(parent, 0xff, nodes.num_rows * sizeof(*parent));
+    memset(bottom_mutation, 0, nodes.num_rows * sizeof(*bottom_mutation));
+
+    if (!tsk_table_collection_has_index(tables, 0)) {
+        ret = tsk_table_collection_build_index(tables, 0);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    I = tables->indexes.edge_insertion_order;
+    O = tables->indexes.edge_removal_order;
+    tj = 0;
+    tk = 0;
+    left = 0;
+    avl_node = self->sites.head;
+    while (tj < M || left < tables->sequence_length) {
+        while (tk < M && edges.right[O[tk]] == left) {
+            parent[edges.child[O[tk]]] = TSK_NULL;
+            tk++;
+        }
+        while (tj < M && edges.left[I[tj]] == left) {
+            parent[edges.child[I[tj]]] = edges.parent[I[tj]];
+            tj++;
+        }
+        right = tables->sequence_length;
+        if (tj < M) {
+            right = TSK_MIN(right, edges.left[I[tj]]);
+        }
+        if (tk < M) {
+            right = TSK_MIN(right, edges.right[O[tk]]);
+        }
+
+        /* Tree is now ready. We look at each site on this tree in turn */
+        while (avl_node != NULL) {
+            site = (site_t *) avl_node->item;
+            if (site->position >= right) {
+                break;
+            }
+            ret = mutgen_choose_alleles(self, parent, bottom_mutation,
+                    nodes.num_rows, site);
+            if (ret != 0) {
+                goto out;
+            }
+            avl_node = avl_node->next;
+        }
+        /* Move on to the next tree */
+        left = right;
+    }
+
+out:
+    msp_safe_free(parent);
+    msp_safe_free(bottom_mutation);
+    return ret;
+}
+
+
 int MSP_WARN_UNUSED
 mutgen_generate(mutgen_t *self, tsk_table_collection_t *tables, int flags)
 {
     int ret = 0;
-    tsk_node_table_t *nodes = &tables->nodes;
-    tsk_edge_table_t *edges = &tables->edges;
-    const double *map_position = self->rate_map->position;
-    const double *map_rate = self->rate_map->value;
-    size_t j, l, branch_mutations, map_index;
-    double left, right, edge_right, branch_length, mu, position;
-    node_id_t parent, child;
-    const mutation_type_t *mutation_types;
-    unsigned long num_mutation_types;
-    unsigned long type;
-    double start_time = self->start_time;
-    double end_time = self->end_time;
-    double branch_start, branch_end;
-    avl_node_t *avl_node;
-    tsk_site_t search;
+    bool discrete_sites = flags & MSP_DISCRETE_SITES;
 
     avl_clear_tree(&self->sites);
 
@@ -404,57 +1002,27 @@ mutgen_generate(mutgen_t *self, tsk_table_collection_t *tables, int flags)
         goto out;
     }
     if (flags & MSP_KEEP_SITES) {
-        ret = mutget_initialise_sites(self, tables);
+        ret = mutgen_initialise_sites(self, tables);
         if (ret != 0) {
             goto out;
         }
     }
-    tsk_site_table_clear(&tables->sites);
-    tsk_mutation_table_clear(&tables->mutations);
 
-    if (self->alphabet == 0) {
-        mutation_types = binary_mutation_types;
-        num_mutation_types = 1;
-    } else {
-        mutation_types = acgt_mutation_types;
-        num_mutation_types = 12;
+    ret = tsk_site_table_clear(&tables->sites);
+    if (ret != 0) {
+        goto out;
     }
-
-    for (j = 0; j < edges->num_rows; j++) {
-        left = edges->left[j];
-        edge_right = edges->right[j];
-        parent = edges->parent[j];
-        child = edges->child[j];
-        assert(child >= 0 && child < (node_id_t) nodes->num_rows);
-        branch_start = GSL_MAX(start_time, nodes->time[child]);
-        branch_end = GSL_MIN(end_time, nodes->time[parent]);
-        branch_length = branch_end - branch_start;
-
-        map_index = interval_map_get_index(self->rate_map, left);
-        right = 0;
-        while (right != edge_right) {
-            right = GSL_MIN(edge_right, map_position[map_index + 1]);
-            mu = branch_length * (right - left) * map_rate[map_index];
-            branch_mutations = gsl_ran_poisson(self->rng, mu);
-            for (l = 0; l < branch_mutations; l++) {
-                /* Rejection sample positions until we get one we haven't seen before. */
-                /* TODO add a maximum number of rejections here */
-                do {
-                    position = gsl_ran_flat(self->rng, left, right);
-                    search.position = position;
-                    avl_node = avl_search(&self->sites, &search);
-                } while (avl_node != NULL);
-                assert(left <= position && position < right);
-                type = gsl_rng_uniform_int(self->rng, num_mutation_types);
-                ret = mutgen_add_mutation(self, child, position,
-                        mutation_types[type].ancestral_state,
-                        mutation_types[type].derived_state);
-                if (ret != 0) {
-                    goto out;
-                }
-            }
-            map_index++;
-        }
+    ret = tsk_mutation_table_clear(&tables->mutations);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = mutgen_place_mutations(self, tables, discrete_sites);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = mutgen_apply_mutations(self, tables);
+    if (ret != 0) {
+        goto out;
     }
     ret = mutgen_populate_tables(self, &tables->sites, &tables->mutations);
     if (ret != 0) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -25,6 +25,8 @@
 #include <errno.h>
 #include <assert.h>
 
+#include <gsl/gsl_math.h>
+
 #include <tskit/core.h>
 #include "util.h"
 
@@ -193,6 +195,23 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_PSI:
             ret = "Bad PSI. Must have 0 < PSI <= 1";
             break;
+        case MSP_ERR_UNKNOWN_ALLELE:
+            ret = "Existing allele(s) incompatible with mutation model alphabet.";
+            break;
+        case MSP_ERR_MUTATION_GENERATION_OUT_OF_ORDER:
+            ret = "Tree sequence contains mutations that would descend from "
+                "existing mutations: finite site mutations must be generated on "
+                "older time periods first.";
+            break;
+        case MSP_ERR_INSUFFICIENT_ALLELES:
+            ret = "Must have at least two alleles.";
+            break;
+        case MSP_ERR_BAD_ROOT_PROBABILITIES:
+            ret = "Root probabilities must be nonnegative and sum to one.";
+            break;
+        case MSP_ERR_BAD_TRANSITION_MATRIX:
+            ret = "Each row of the transition matrix must be nonnegative and sum to one.";
+            break;
         default:
             ret = "Error occurred generating error string. Please file a bug "
                 "report!";
@@ -212,7 +231,7 @@ msp_set_tsk_error(int err)
 bool
 msp_is_tsk_error(int err)
 {
-    return !(err & (1 << MSP_TSK_ERR_BIT));
+    return (err < 0) && !(err & (1 << MSP_TSK_ERR_BIT));
 }
 
 const char *
@@ -261,4 +280,10 @@ msp_binary_interval_search(double query, const double *values, size_t n_values)
         }
     }
     return l;
+}
+
+bool
+doubles_almost_equal(double a, double b, double eps)
+{
+    return (fabs(a) < eps && fabs(b) < eps) || gsl_fcmp(a, b, eps) == 0;
 }

--- a/lib/util.h
+++ b/lib/util.h
@@ -87,6 +87,11 @@
 #define MSP_ERR_INTERVAL_POSITIONS_UNSORTED                         -49
 #define MSP_ERR_BAD_C                                               -50
 #define MSP_ERR_BAD_PSI                                             -51
+#define MSP_ERR_UNKNOWN_ALLELE                                      -52
+#define MSP_ERR_MUTATION_GENERATION_OUT_OF_ORDER                    -53
+#define MSP_ERR_INSUFFICIENT_ALLELES                                -54
+#define MSP_ERR_BAD_ROOT_PROBABILITIES                              -55
+#define MSP_ERR_BAD_TRANSITION_MATRIX                               -56
 
 /* This bit is 0 for any errors originating from tskit */
 #define MSP_TSK_ERR_BIT 13
@@ -99,5 +104,6 @@ void __msp_safe_free(void **ptr);
 #define msp_safe_free(pointer) __msp_safe_free((void **) &(pointer))
 
 size_t msp_binary_interval_search(double query, const double *values, size_t n_values);
+bool doubles_almost_equal(double a, double b, double eps);
 
 #endif /*__UTIL_H__*/

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -27,8 +27,10 @@ import random
 import signal
 import sys
 
-import msprime
 import tskit
+
+import msprime
+from . import mutations
 
 
 def set_sigpipe_handler():
@@ -213,13 +215,10 @@ class SimulationRunner(object):
         self._random_generator = msprime.RandomGenerator(seed)
         self._ms_random_seeds = ms_seeds
         self._simulator.random_generator = self._random_generator
-        rate_map = msprime.IntervalMap(
-            position=[0, self._simulator.sequence_length],
-            value=[self._mutation_rate, 0]
-        )
-        self._mutation_generator = msprime.MutationGenerator(
-            self._random_generator, rate_map
-        )
+        self._mutation_generator = mutations._simple_mutation_generator(
+            self._mutation_rate,
+            self._simulator.sequence_length,
+            self._random_generator)
 
     def get_num_replicates(self):
         """

--- a/msprime/utils.py
+++ b/msprime/utils.py
@@ -1,0 +1,67 @@
+#
+# Copyright (C) 2015-2020 University of Oxford
+#
+# This file is part of msprime.
+#
+# msprime is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# msprime is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with msprime.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Various utilities shared across modules.
+"""
+import os
+import random
+
+
+# Some machinery here for generating default random seeds. We need a map
+# indexed by process ID here because we cannot use a global variable
+# to store the state across multiple processes. Copy-on-write semantics
+# for child processes means that they inherit the state of the parent
+# process, so if we just keep a global variable without indexing by
+# PID, child processes will share the same random generator as the
+# parent.
+
+_seed_rng_map = {}
+
+
+def get_seed_rng():
+    return _seed_rng_map.get(os.getpid(), None)
+
+
+def clear_seed_rng():
+    _seed_rng_map.pop(os.getpid(), None)
+
+
+def get_random_seed():
+    global _seed_rng_map
+    pid = os.getpid()
+    if pid not in _seed_rng_map:
+        # If we don't provide a seed to Random(), Python will seed either
+        # from a system source of randomness (i.e., /dev/urandom) or the
+        # current time if this is not available. Thus, our seed rng should
+        # be unique, even across different processes.
+        _seed_rng_map[pid] = random.Random()
+    return _seed_rng_map[pid].randint(1, 2**32 - 1)
+
+
+# Note, this is no longer needed as we have Python 3.6 minimum.
+# https://github.com/tskit-dev/msprime/issues/960
+def almost_equal(a, b, rel_tol=1e-9, abs_tol=0.0):
+    """
+    Returns true if the specified pair of numbers are equal to
+    within the specified tolerances.
+
+    The signature and implementation are taken from PEP 485,
+    https://www.python.org/dev/peps/pep-0485/
+    """
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -21,8 +21,13 @@ Test cases for the high level interface to msprime.
 """
 import unittest
 import json
+import itertools
+import functools
 
 import numpy as np
+import scipy.stats as stats
+import tskit
+import attr
 
 import msprime
 import _msprime
@@ -80,10 +85,109 @@ class TestMutateProvenance(unittest.TestCase):
             self.assertEqual(record["parameters"]["keep"], keep)
 
 
-class TestMutate(unittest.TestCase):
-    """
-    Tests the msprime.mutate function.
-    """
+class TestMutationModel(unittest.TestCase):
+
+    def validate_model(self, model):
+        num_alleles = len(model.alleles)
+        self.assertEqual(num_alleles, len(model.root_distribution))
+        self.assertEqual((num_alleles, num_alleles), model.transition_matrix.shape)
+        self.assertEqual(sum(model.root_distribution), 1.0)
+        for j in range(num_alleles):
+            self.assertEqual(sum(model.transition_matrix[j]), 1.0)
+        s = model.__str__()
+        self.assertIsInstance(s, str)
+        self.assertTrue(s.startswith("Mutation model with alleles"))
+
+    def validate_stationary(self, model):
+        # for most models, the root distribution should be the
+        # stationary distribution of the transition matrix
+        x = np.matmul(model.root_distribution,
+                      model.transition_matrix)
+        self.assertSequenceEqual(list(x), list(model.root_distribution))
+
+    def validate_asdict(self, model):
+        m = msprime.MutationModel(**model.asdict())
+        self.assertEqual(model, m)
+
+    def test_bad_alleles(self):
+        for alleles, err in [
+                (0, TypeError),
+                (b'xyz', TypeError),
+                (['0', '1'], TypeError),
+                ([b'0', '1'], TypeError),
+                ([1, 2, 3], TypeError),
+                ([b'a'], _msprime.LibraryError)
+                ]:
+            with self.assertRaises(err):
+                msprime.MutationModel(
+                        alleles=alleles,
+                        root_distribution=[1] + [0] * (len(alleles) - 1),
+                        transition_matrix=[[1 / len(alleles)]
+                                           * len(alleles)] * len(alleles))
+
+    def test_bad_root_distribution(self):
+        alleles = [b'a', b'b', b'c']
+        transition_matrix = [[1 / len(alleles)] * len(alleles)] * len(alleles)
+        for root_distribution, err in [
+                ([1, 0], ValueError),
+                ([1, 0, 0, 0], ValueError),
+                (1.0, ValueError),
+                ('xyz', ValueError),
+                (None, ValueError),
+                ([1.5, -.5, 0], _msprime.LibraryError),
+                ([0.5, 0, 0], _msprime.LibraryError),
+                ]:
+            with self.assertRaises(err):
+                msprime.MutationModel(
+                        alleles=alleles,
+                        root_distribution=root_distribution,
+                        transition_matrix=transition_matrix)
+
+    def test_bad_transition_matrix(self):
+        alleles = [b'a', b'b', b'c']
+        root_distribution = [0.5, 0.25, 0.25]
+        for transition_matrix, err in [
+                ([[1, 0]] * 3, ValueError),
+                ([[1, 0, 0]] * 2, ValueError),
+                (1.0, ValueError),
+                ('xyz', ValueError),
+                (None, ValueError),
+                ([[1.5, -.5, 0]] * 3, _msprime.LibraryError),
+                ([[0.5, 0, 0]] * 3, _msprime.LibraryError),
+                ]:
+            with self.assertRaises(err):
+                msprime.MutationModel(
+                        alleles=alleles,
+                        root_distribution=root_distribution,
+                        transition_matrix=transition_matrix)
+
+    def test_binary(self):
+        model = msprime.BinaryMutations()
+        self.validate_model(model)
+
+    def test_jukes_cantor(self):
+        model = msprime.JukesCantor()
+        self.validate_model(model)
+        self.validate_stationary(model)
+
+    def test_new_model(self):
+        alleles = [b'Alligator', b'Camel', b'Goat']
+        root_distribution = [0.5, 0.25, 0.25]
+        transition_matrix = [[0.0, 0.5, 0.5],
+                             [1.0, 0.0, 0.0],
+                             [1.0, 0.0, 0.0]]
+        model = msprime.MutationModel(alleles, root_distribution,
+                                      transition_matrix)
+        self.assertListEqual(model.alleles, alleles)
+        self.assertListEqual(list(model.root_distribution), root_distribution)
+        for a, b in zip(model.transition_matrix, transition_matrix):
+            self.assertListEqual(list(a), b)
+        self.validate_model(model)
+        self.validate_stationary(model)
+
+
+class MutateMixin(object):
+
     def verify_topology(self, source, dest):
         self.assertEqual(source.nodes, dest.nodes)
         self.assertEqual(source.edges, dest.edges)
@@ -95,6 +199,27 @@ class TestMutate(unittest.TestCase):
         after = list(dest.provenances)
         self.assertEqual(len(before) + 1, len(after))
         self.assertEqual(before, after[:-1])
+
+    def verify_binary_alphabet(self, ts):
+        self.assertGreater(ts.num_sites, 0)
+        self.assertTrue(all(site.ancestral_state == '0' for site in ts.sites()))
+        self.assertTrue(
+            all(mutation.derived_state == '1' for mutation in ts.mutations()))
+
+    def verify_nucleotides_alphabet(self, ts):
+        nucleotides = "ACGT"
+        self.assertGreater(ts.num_sites, 0)
+        self.assertTrue(all(site.ancestral_state in nucleotides for site in ts.sites()))
+        self.assertTrue(
+            all(mutation.derived_state in nucleotides for mutation in ts.mutations()))
+        for site in ts.sites():
+            self.assertNotEqual(site.ancestral_state, site.mutations[0].derived_state)
+
+
+class TestMutate(unittest.TestCase, MutateMixin):
+    """
+    Tests the msprime.mutate function.
+    """
 
     def test_zero_mutation_rate(self):
         ts = msprime.simulate(10, random_seed=1)
@@ -151,10 +276,6 @@ class TestMutate(unittest.TestCase):
         for bad_type in [{}, "234"]:
             self.assertRaises(TypeError, msprime.mutate, ts, rate=0, model=bad_type)
 
-    def test_bad_alphabet(self):
-        for bad_alphabet in [-1, 2, 10**6, "1"]:
-            self.assertRaises(ValueError, msprime.InfiniteSites, bad_alphabet)
-
     def test_bad_tree_sequence(self):
         for bad_type in [None, {}, "sdrf"]:
             self.assertRaises(ValueError, msprime.mutate, bad_type)
@@ -178,50 +299,276 @@ class TestMutate(unittest.TestCase):
         self.assertTrue(all(tables[0].sites == t.sites for t in tables[1:]))
         self.assertTrue(all(tables[0].mutations == t.mutations for t in tables[1:]))
 
-    def verify_binary_alphabet(self, ts):
-        self.assertGreater(ts.num_sites, 0)
-        self.assertTrue(all(site.ancestral_state == '0' for site in ts.sites()))
-        self.assertTrue(
-            all(mutation.derived_state == '1' for mutation in ts.mutations()))
-
-    def verify_nucleotides_alphabet(self, ts):
-        nucleotides = "ACGT"
-        self.assertGreater(ts.num_sites, 0)
-        self.assertTrue(all(site.ancestral_state in nucleotides for site in ts.sites()))
-        self.assertTrue(
-            all(mutation.derived_state in nucleotides for mutation in ts.mutations()))
-        for site in ts.sites():
-            self.assertNotEqual(site.ancestral_state, site.mutations[0].derived_state)
-
     def test_default_alphabet(self):
         ts = msprime.simulate(10, random_seed=2)
         mutated = msprime.mutate(ts, rate=1, random_seed=2)
         self.verify_binary_alphabet(mutated)
 
-    def test_alphabet_binary(self):
+    def test_deprecated_alphabet_binary(self):
         ts = msprime.simulate(10, random_seed=2)
         mutated = msprime.mutate(
             ts, rate=1, random_seed=2, model=msprime.InfiniteSites(msprime.BINARY))
         self.verify_binary_alphabet(mutated)
 
-    def test_alphabet_nucleotide(self):
+    def test_deprecated_alphabet_nucleotides(self):
         ts = msprime.simulate(10, random_seed=2)
         mutated = msprime.mutate(
             ts, rate=1, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES))
         self.verify_nucleotides_alphabet(mutated)
 
-    def test_identical_seed_alphabets(self):
+    def test_deprecated_bad_alphabet(self):
+        ts = msprime.simulate(10, random_seed=2)
+        with self.assertRaises(ValueError):
+            msprime.mutate(
+                ts, rate=1, random_seed=2, model=msprime.InfiniteSites(-1))
+        with self.assertRaises(ValueError):
+            msprime.mutate(
+                ts, rate=1, random_seed=2, model=msprime.InfiniteSites(2))
+
+    def test_deprecated_identical_seed_alphabets(self):
         ts = msprime.simulate(10, random_seed=2)
         binary = msprime.mutate(ts, rate=1, random_seed=2)
-        nucleotides = msprime.mutate(
+        nucs = msprime.mutate(
             ts, rate=1, random_seed=2, model=msprime.InfiniteSites(msprime.NUCLEOTIDES))
         self.assertGreater(binary.num_sites, 0)
         self.assertGreater(binary.num_mutations, 0)
-        self.assertEqual(binary.num_sites, nucleotides.num_sites)
-        self.assertEqual(binary.num_mutations, nucleotides.num_mutations)
-        for s1, s2 in zip(binary.sites(), nucleotides.sites()):
+        self.assertEqual(binary.num_sites, nucs.num_sites)
+        self.assertEqual(binary.num_mutations, nucs.num_mutations)
+        for s1, s2 in zip(binary.sites(), nucs.sites()):
             self.assertEqual(s1.position, s2.position)
             self.assertEqual(s1.mutations[0].node, s2.mutations[0].node)
+
+
+class TestFiniteSites(TestMutate):
+
+    def verify_binary_alphabet(self, ts):
+        binary = '01'
+        self.assertGreater(ts.num_sites, 0)
+        self.assertTrue(all(site.ancestral_state == '0' for site in ts.sites()))
+        self.assertTrue(
+            all(mutation.derived_state in binary for mutation in ts.mutations()))
+
+    def verify_mutations(self, ts, discrete, check_probs=False, model=None):
+        # Verify that mutation.parents are correct
+        # and that mutations actually involve a change of state
+        # that, if (not keep), has positive probability under the model
+        if check_probs:
+            assert model is not None
+            alleles = [x.decode() for x in model.alleles]
+        for site in ts.sites():
+            if not discrete:
+                self.assertEqual(len(site.mutations), 1)
+            t = ts.at(site.position)
+            parents = {}
+            for mut in site.mutations:
+                n = mut.node
+                # TODO: once mutations have times
+                # self.assertGreaterEqual(mut.time, ts.node(n).time)
+                # self.assertLess(mut.time, ts.node(t.parent(n)).time)
+                while n != tskit.NULL and n not in parents:
+                    n = t.parent(n)
+                if n == tskit.NULL:
+                    self.assertEqual(mut.parent, tskit.NULL)
+                    pa = site.ancestral_state
+                else:
+                    self.assertEqual(mut.parent, parents[n].id)
+                    # TODO: once mutations have times
+                    # self.assertLess(mut.time, parents[n].time)
+                    pa = parents[n].derived_state
+                self.assertNotEqual(mut.derived_state, pa)
+                if check_probs:
+                    self.assertTrue(pa in alleles)
+                    self.assertTrue(mut.derived_state in alleles)
+                    i = alleles.index(pa)
+                    j = alleles.index(mut.derived_state)
+                    self.assertGreater(model.transition_matrix[i][j], 0)
+                # do this last since parents should be listed before children
+                parents[mut.node] = mut
+
+    def mutate(self, ts, model, rate=1.0, keep=False, discrete=False, seed=42):
+        lib_ts = msprime.mutate(
+            ts, rate=rate, random_seed=seed, model=model, keep=keep, discrete=discrete)
+        self.verify_mutations(lib_ts, discrete, check_probs=not keep, model=model)
+        py_ts = py_mutate(
+            ts, rate=rate, random_seed=seed, model=model, keep=keep, discrete=discrete)
+        lib_tables = lib_ts.dump_tables()
+        lib_tables.provenances.clear()
+        py_tables = py_ts.dump_tables()
+        py_tables.provenances.clear()
+        self.assertEqual(lib_tables, py_tables)
+        return lib_ts
+
+    def mutate_binary(self, ts, rate=1.0, keep=False, discrete=False,
+                      transition_matrix=None,
+                      root_distribution=None):
+        alleles = [b'0', b'1']
+        if transition_matrix is None:
+            transition_matrix = [[0.0, 1.0], [1.0, 0.0]]
+        if root_distribution is None:
+            root_distribution = [1.0, 0.0]
+        model = msprime.MutationModel(alleles, root_distribution, transition_matrix)
+        return self.mutate(ts, model, rate=rate, keep=keep, discrete=discrete)
+
+    def mutate_nucleotides(self, ts, rate=1.0, keep=False, discrete=False,
+                           transition_matrix=None,
+                           root_distribution=None):
+        alleles = [b'A', b'C', b'G', b'T']
+        if transition_matrix is None:
+            transition_matrix = [[0.25] * 4] * 4
+        if root_distribution is None:
+            root_distribution = [0.25] * 4
+        model = msprime.MutationModel(alleles, root_distribution, transition_matrix)
+        model = msprime.MutationModel(alleles, root_distribution, transition_matrix)
+        return self.mutate(ts, model, rate=rate, keep=keep, discrete=discrete)
+
+    def test_alleles_binary(self):
+        ts = msprime.simulate(10, random_seed=1)
+        mutated = self.mutate_binary(ts)
+        self.verify_binary_alphabet(mutated)
+
+    def test_alleles_nucleotides(self):
+        ts = msprime.simulate(10, random_seed=1)
+        mutated = self.mutate_nucleotides(ts)
+        self.verify_nucleotides_alphabet(mutated)
+
+    def test_zero_mutation_rate(self):
+        for keep in (True, False):
+            ts = msprime.simulate(10, random_seed=1, mutation_rate=2.0)
+            mutated = self.mutate_binary(ts, 0, keep=keep)
+            t1 = ts.dump_tables()
+            t2 = mutated.dump_tables()
+            self.verify_topology(t1, t2)
+            self.verify_provenance(t1, t2)
+            if keep:
+                self.assertEqual(t1.sites, t2.sites)
+                self.assertEqual(t1.mutations, t2.mutations)
+            else:
+                self.assertEqual(t2.sites.num_rows, 0)
+
+    def test_bad_mutate_order(self):
+        ts = msprime.simulate(10, random_seed=1, recombination_rate=1, length=10)
+        mutated = msprime.mutate(ts, 3, random_seed=5, start_time=0.0, end_time=0.5,
+                                 discrete=True)
+        with self.assertRaises(_msprime.LibraryError):
+            msprime.mutate(mutated, 3, random_seed=6, start_time=0.5,
+                           end_time=1.0, discrete=True, keep=True)
+
+    def test_one_way_mutation(self):
+        for discrete in (True, False):
+            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            mut_matrix = [[0.0, 1.0], [0.0, 1.0]]
+            mutated = self.mutate_binary(ts, rate=1.0, transition_matrix=mut_matrix,
+                                         root_distribution=[1.0, 0.0],
+                                         discrete=discrete)
+            self.assertGreater(mutated.num_sites, 0)
+            if discrete:
+                self.assertGreater(max([len(s.mutations) for s in mutated.sites()]), 1)
+            for site in mutated.sites():
+                self.assertEqual(site.ancestral_state, '0')
+                self.assertGreaterEqual(len(site.mutations), 1)
+                for mut in site.mutations:
+                    self.assertEqual(mut.derived_state, '1')
+
+    def test_flip_flop_mutation(self):
+        nucleotides = 'ACGT'
+        for discrete in (True, False):
+            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            mut_matrix = [[0.0, 0.0, 0.5, 0.5],
+                          [0.0, 0.0, 0.5, 0.5],
+                          [0.5, 0.5, 0.0, 0.0],
+                          [0.5, 0.5, 0.0, 0.0]]
+            mutated = self.mutate_nucleotides(ts, rate=5.0, transition_matrix=mut_matrix,
+                                              discrete=discrete)
+            self.assertGreater(mutated.num_sites, 0)
+            if discrete:
+                self.assertGreater(max([len(s.mutations) for s in mutated.sites()]), 1)
+            for mut in ts.mutations():
+                self.assertTrue(mut.derived_state in nucleotides)
+                if mut.parent == -1:
+                    pa = ts.site(mut.site).ancestral_state
+                else:
+                    pa = ts.mutation(mut.parent).derived_state
+                if pa in 'AC':
+                    self.assertTrue(mut.derived_state in 'GT')
+                else:
+                    self.assertTrue(mut.derived_state in 'AC')
+
+    def test_do_nothing_mutations(self):
+        for discrete in (True, False):
+            ts = msprime.simulate(10, random_seed=1, length=10)
+            mut_matrix = [[1.0, 0.0, 0.0, 0.0],
+                          [0.0, 1.0, 0.0, 0.0],
+                          [0.0, 0.0, 1.0, 0.0],
+                          [0.0, 0.0, 0.0, 1.0]]
+            mutated = self.mutate_nucleotides(ts, rate=5.0,
+                                              transition_matrix=mut_matrix,
+                                              discrete=discrete)
+            self.assertEqual(mutated.num_sites, 0)
+            t1 = ts.dump_tables()
+            t2 = mutated.dump_tables()
+            self.verify_topology(t1, t2)
+            self.verify_provenance(t1, t2)
+            self.assertEqual(t1.sites, t2.sites)
+            self.assertEqual(t1.mutations, t2.mutations)
+
+    def test_uniform_mutations(self):
+        nucleotides = "ACGT"
+        for discrete in (True, False):
+            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            mut_matrix = [[0.1, 0.3, 0.3, 0.3],
+                          [0.0, 0.0, 0.5, 0.5],
+                          [0.0, 0.5, 0.0, 0.5],
+                          [0.0, 0.5, 0.5, 0.0]]
+            mutated = self.mutate_nucleotides(ts, rate=20.0,
+                                              transition_matrix=mut_matrix,
+                                              root_distribution=[1.0, 0.0, 0.0, 0.0],
+                                              discrete=discrete)
+            self.assertGreater(mutated.num_sites, 0)
+            if discrete:
+                self.assertGreater(max([len(s.mutations) for s in mutated.sites()]), 1)
+            num_nucs = {a: 0 for a in nucleotides}
+            for site in mutated.sites():
+                self.assertTrue(site.ancestral_state == 'A')
+            for mut in mutated.mutations():
+                num_nucs[mut.derived_state] += 1
+            self.assertEqual(num_nucs['A'], 0)
+            self.assertGreater(num_nucs['C'], 0)
+            self.assertGreater(num_nucs['G'], 0)
+            self.assertGreater(num_nucs['T'], 0)
+
+    def test_circular_mutations(self):
+        nucleotides = "ACGT"
+        for discrete in (True, False):
+            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            mut_matrix = [[0.0, 1.0, 0.0, 0.0],
+                          [0.0, 0.0, 1.0, 0.0],
+                          [0.0, 0.0, 0.0, 1.0],
+                          [1.0, 0.0, 0.0, 0.0]]
+            mutated = self.mutate_nucleotides(ts, rate=2.0, transition_matrix=mut_matrix,
+                                              root_distribution=[1.0, 0.0, 0.0, 0.0],
+                                              discrete=discrete)
+            self.assertGreater(mutated.num_sites, 0)
+            if discrete:
+                self.assertGreater(max([len(s.mutations) for s in mutated.sites()]), 1)
+            for site in mutated.sites():
+                self.assertTrue(site.ancestral_state == 'A')
+                self.assertGreater(len(site.mutations), 0)
+            for mut in mutated.mutations():
+                if mut.parent == tskit.NULL:
+                    self.assertEqual(mut.derived_state, "C")
+                else:
+                    pmut = mutated.mutation(mut.parent)
+                    self.assertEqual(
+                            (nucleotides.index(pmut.derived_state) + 1) % 4,
+                            nucleotides.index(mut.derived_state))
+
+    def test_integer_sites(self):
+        ts = msprime.simulate(10, random_seed=5, length=10, recombination_rate=10.0)
+        mutated = self.mutate_binary(ts, rate=5.0, discrete=True)
+        self.assertEqual(mutated.site(0).position, 0.0)
+        for site in mutated.sites():
+            self.assertEqual(site.position, np.floor(site.position))
+            self.assertLess(site.position, mutated.sequence_length)
 
 
 class TestInterval(unittest.TestCase):
@@ -380,7 +727,7 @@ class TestKeep(unittest.TestCase):
         self.assertGreater(ts.num_sites, 0)
         self.verify(ts, 1, random_seed=2)
 
-    def test_simple_nucleotide(self):
+    def test_deprecated_simple_nucleotide(self):
         ts = msprime.mutate(
             msprime.simulate(10, random_seed=2),
             rate=1,
@@ -410,6 +757,12 @@ class TestKeep(unittest.TestCase):
     def test_no_sites(self):
         ts = msprime.simulate(12, random_seed=3)
         self.assertEqual(ts.num_sites, 0)
+        self.verify(ts, 3, random_seed=7)
+
+    def test_site_with_no_mutation(self):
+        ts = tsutil.insert_site(
+                msprime.simulate(12, random_seed=3))
+        self.assertEqual(ts.num_sites, 1)
         self.verify(ts, 3, random_seed=7)
 
     def test_same_seeds(self):
@@ -472,57 +825,464 @@ class TestKeep(unittest.TestCase):
         self.assertEqual(t1, t2)
 
 
-def mutate_map(tables, mutation_map, seed):
+class StatisticalTestMixin(object):
+
+    p_threshold = 0.01
+
+    def chisquare(self, observed, expected):
+        obs = observed.reshape((np.product(observed.shape)),)
+        exp = expected.reshape((np.product(observed.shape)),)
+        not_zeros = (exp > 0)
+        self.assertSequenceEqual(list(obs[np.logical_not(not_zeros)]),
+                                 list(np.zeros((len(obs)-sum(not_zeros),))))
+        if sum(not_zeros) > 1:
+            chisq = stats.chisquare(obs[not_zeros], exp[not_zeros])
+            self.assertGreater(chisq.pvalue, self.p_threshold)
+
+    def bonferroni(self, pvals):
+        self.assertGreater(min(pvals), self.p_threshold / len(pvals))
+
+    def sign_tst(self, diffs):
+        np = sum(diffs > 0)
+        nm = sum(diffs < 0)
+        pp = stats.binom.cdf(np, n=np + nm, p=0.5)
+        pm = stats.binom.cdf(nm, n=np + nm, p=0.5)
+        self.assertGreater(min(pp, pm), self.p_threshold)
+
+
+class TestMutationStatistics(unittest.TestCase, StatisticalTestMixin):
+
+    def verify_model(self, model, verify_roots=True):
+        ots = msprime.simulate(10, random_seed=5, recombination_rate=0.05, length=20)
+        for discrete in (True, False):
+            for rate in (1, 10):
+                ts = msprime.mutate(ots, random_seed=6, rate=rate, model=model,
+                                    discrete=discrete)
+                self.verify_model_ts(ts, model, discrete, verify_roots)
+
+    def verify_model_ts(self, ts, model, discrete, verify_roots):
+        alleles = [a.decode() for a in model.alleles]
+        num_alleles = len(alleles)
+        roots = np.zeros((num_alleles,))
+        transitions = np.zeros((num_alleles, num_alleles))
+        for site in ts.sites():
+            aa = site.ancestral_state
+            roots[alleles.index(aa)] += 1
+        for mut in ts.mutations():
+            if mut.parent == tskit.NULL:
+                pa = ts.site(mut.site).ancestral_state
+            else:
+                pa = ts.mutation(mut.parent).derived_state
+            da = mut.derived_state
+            transitions[alleles.index(pa), alleles.index(da)] += 1
+        num_muts = np.sum(roots)
+        if verify_roots:
+            exp_roots = num_muts * model.root_distribution
+            self.chisquare(roots, exp_roots)
+        for j, (row, p) in enumerate(zip(transitions, model.transition_matrix)):
+            p[j] = 0
+            p /= sum(p)
+            self.chisquare(row, sum(row) * p)
+
+    def verify_mutation_rates(self, model):
+        # this test only works if the probability of dropping a mutation
+        # doesn't depend on the previous state
+        assert(len(set(np.diag(model.transition_matrix))) == 1)
+        np.random.seed(23)
+        ots = msprime.simulate(10, random_seed=5, recombination_rate=0.05, length=20)
+        for discrete in (False, True):
+            for rate in (1, 10):
+                ts = msprime.mutate(ots, random_seed=6, rate=rate, model=model,
+                                    discrete=discrete)
+                self.verify_mutation_rates_ts(ts, model, rate, discrete)
+
+    def verify_mutation_rates_ts(self, ts, model, rate, discrete):
+        mut_rate = rate * (1 - model.transition_matrix[0, 0])
+        lower_pvals = np.zeros(ts.num_trees)
+        upper_pvals = np.zeros(ts.num_trees)
+        diffs = np.zeros(ts.num_trees)
+        for j, t in enumerate(ts.trees()):
+            if discrete:
+                span = np.ceil(t.interval[1]) - np.ceil(t.interval[0])
+            else:
+                span = t.span
+            mean = mut_rate * span * t.total_branch_length
+            N = t.num_mutations
+            lower_pvals[j] = stats.poisson.cdf(mean, N)
+            upper_pvals[j] = 1.0 - stats.poisson.cdf(mean, N + 1)
+            # if we draw an indepenent Poisson with the same mean
+            # it should be greater than observed half the time it is different
+            # NOTE: more powerful might be a Wilcoxon test?
+            rand = stats.poisson.rvs(mean, 1)
+            diffs[j] = rand - N
+        self.sign_tst(diffs)
+        self.bonferroni(lower_pvals)
+        self.bonferroni(upper_pvals)
+
+    def test_binary_model(self):
+        model = msprime.BinaryMutations()
+        self.verify_model(model)
+        self.verify_mutation_rates(model)
+
+    def test_jukes_cantor(self):
+        model = msprime.JukesCantor()
+        self.verify_model(model)
+        self.verify_mutation_rates(model)
+
+    def test_arbitrary_model(self):
+        model = msprime.MutationModel(
+                alleles=[b"abc", b"", b"x"],
+                root_distribution=[0.8, 0.0, 0.2],
+                transition_matrix=[[0.2, 0.4, 0.4],
+                                   [0.1, 0.2, 0.7],
+                                   [0.5, 0.3, 0.2]])
+        self.verify_model(model)
+        self.verify_mutation_rates(model)
+
+
+class TestPythonMutationGenerator(unittest.TestCase):
     """
-    Parallel implementation of the C code which should produce precisely the same
+    Tests for the python implementation of the mutation generator
+    (but, note it is compared to the C version extensively above).
+    """
+    def verify(self, ts, **kwargs):
+        rates = [0, 0.01, 0.2]
+        discretes = [True, False]
+        keeps = [True, False]
+        for rate, keep, discrete in itertools.product(rates, keeps, discretes):
+            ts1 = msprime.mutate(ts, rate=rate, keep=keep, discrete=discrete, **kwargs)
+            ts2 = py_mutate(ts, rate=rate, keep=keep, discrete=discrete, **kwargs)
+            tables1 = ts1.dump_tables()
+            tables2 = ts2.dump_tables()
+            tables1.provenances.clear()
+            tables2.provenances.clear()
+            self.assertEqual(tables1, tables2)
+
+    def test_single_tree_no_mutations(self):
+        ts = msprime.simulate(10, length=100, random_seed=1234)
+        self.verify(ts, random_seed=234)
+
+    def test_single_tree_mutations(self):
+        ts = msprime.simulate(10, length=100, mutation_rate=0.1, random_seed=1234)
+        self.assertGreater(ts.num_sites, 0)
+        self.verify(ts, random_seed=34)
+
+    def test_many_trees_no_mutations(self):
+        ts = msprime.simulate(10, length=100, recombination_rate=0.1, random_seed=123)
+        self.assertGreater(ts.num_trees, 1)
+        self.verify(ts, random_seed=789)
+
+    def test_many_trees_mutations(self):
+        ts = msprime.simulate(
+            10, length=100, mutation_rate=0.1, recombination_rate=2, random_seed=123)
+        self.assertGreater(ts.num_trees, 1)
+        self.assertGreater(ts.num_sites, 1)
+        self.verify(ts, random_seed=789)
+
+
+####################################################
+# Python implementation of lib/mutgen.c algorithms #
+####################################################
+
+def py_mutate(
+        ts, rate=None, random_seed=None, model=None, keep=False, discrete=False):
+    """
+    Same interface as mutations.mutate() and should provide identical results.
+    """
+    if rate is None:
+        rate = 0
+    if model is None:
+        model = msprime.BinaryMutations()
+    tables = ts.dump_tables()
+    mutmap = msprime.MutationMap([0, ts.sequence_length], [rate, 0])
+    mutgen = PythonMutationGenerator(mutmap, model)
+    return mutgen.generate(tables, random_seed, keep=keep, discrete=discrete)
+
+
+@attr.s
+class Site(object):
+    position = attr.ib()
+    ancestral_state = attr.ib()
+    metadata = attr.ib()
+    mutations = attr.ib()
+    new = attr.ib()
+
+    def __str__(self):
+        s = f"Position: {self.position}\t{self.ancestral_state}"
+        s += f"\t{self.metadata}\t{self.new}\n"
+        for mut in self.mutations:
+            s += mut.__str__()
+        return s
+
+    def add_mutation(self, node, time, new, derived_state=None,
+                     metadata=b'', id=tskit.NULL):
+        mutation = Mutation(
+                node=node,
+                derived_state=derived_state,
+                parent=None,
+                metadata=metadata,
+                time=time,
+                new=new,
+                keep=True,
+                id=id)
+        self.mutations.append(mutation)
+
+
+@attr.s
+class Mutation(object):
+    node = attr.ib()
+    derived_state = attr.ib()
+    parent = attr.ib()
+    metadata = attr.ib()
+    time = attr.ib()
+    new = attr.ib()
+    keep = attr.ib()
+    id = attr.ib()
+
+    def __str__(self):
+        if self.parent is None:
+            parent_id = None
+        else:
+            parent_id = self.parent.id
+        s = f"\t{self.id}\t\tnode: {self.node}\tparent: {parent_id}"
+        s += f"\ttime: {self.time}\t{self.derived_state}\t{self.metadata}"
+        s += f"\t(new: {self.new})\tkeep: {self.keep}"
+        return s
+
+
+def cmp_mutation(a, b):
+    # Sort mutations by decreasing time and increasing parent,
+    # but preserving order of any kept mutations (assumed to be
+    # in order already). Kept mutations are given an id that is
+    # their order in the initial tables, and new mutations have id -1.
+    out = a.id * (not a.new) - b.id * (not b.new)
+    if out == 0:
+        out = (b.time > a.time) - (a.time > b.time)
+    return out
+
+
+class PythonMutationGenerator(object):
+    """
+    Python implementation of the C code which should produce precisely the same
     results.
     """
-    # Insert a sentinel into the map for convenience.
-    map_position = np.hstack([mutation_map.position, [tables.sequence_length]])
-    rng = msprime.RandomGenerator(seed)
-    time = tables.nodes.time
-    for edge in tables.edges:
-        branch_length = time[edge.parent] - time[edge.child]
-        index = np.searchsorted(map_position, edge.left)
-        if map_position[index] > edge.left:
-            index -= 1
-        left = edge.left
-        right = 0
-        while right != edge.right:
-            right = min(edge.right, map_position[index + 1])
-            assert left < right
-            assert mutation_map.position[index] <= left
-            assert right <= map_position[index + 1]
-            assert right <= edge.right
-            # Generate the mutations.
-            mu = mutation_map.rate[index] * (right - left) * branch_length
-            for _ in range(rng.poisson(mu)):
-                position = rng.flat(left, right)
-                site_id = tables.sites.add_row(position, ancestral_state="0")
-                tables.mutations.add_row(site_id, node=edge.child, derived_state="1")
-                # Sample from this to duplicate the behaviour in the C implementation.
-                rng.uniform_int(1)
-            index += 1
-            left = right
-    tables.sort()
-    return tables.tree_sequence()
 
+    def __init__(self, rate_map, model):
+        """
+        Defaults to all 0->1 mutations.
+        """
+        self.rate_map = rate_map
+        # for compatability with the C code we provide alleles as bytes,
+        # but we want them as strings here for simplicity.
+        self.alleles = [allele.decode() for allele in model.alleles]
+        self.transition_matrix = model.transition_matrix
+        self.root_distribution = model.root_distribution
+        self.sites = {}
 
-class TestMap(unittest.TestCase):
-    """
-    Tests for the mutation map.
-    """
+    def print_state(self):
+        print("alleles", self.alleles)
+        positions = sorted(self.sites.keys())
+        for pos in positions:
+            print(self.sites[pos])
 
-    def test_single_rate(self):
-        random_seed = 2
-        rate = 0.5
-        for random_seed in range(1, 5):
-            for rate in [0, 0.1, 0.5, 1.0]:
-                ts = msprime.simulate(10, recombination_rate=2, random_seed=random_seed)
-                mutmap = msprime.MutationMap([0], [rate])
-                tables1 = ts.dump_tables()
-                mutate_map(tables1, mutmap, random_seed)
-                ts = msprime.mutate(ts, rate=rate, random_seed=random_seed)
-                tables2 = ts.dump_tables()
-                self.assertEqual(tables1.sites, tables2.sites)
-                self.assertEqual(tables1.mutations, tables2.mutations)
+    def add_site(self, position, new, ancestral_state=None, metadata=b""):
+        assert position not in self.sites
+        site = Site(
+                position=position,
+                ancestral_state=ancestral_state,
+                metadata=metadata,
+                mutations=[],
+                new=new)
+        self.sites[position] = site
+        return site
+
+    def initialise_sites(self, tables):
+        nodes = tables.nodes
+        mutation_rows = iter(tables.mutations)
+        mutation_row = next(mutation_rows, None)
+        j = 0
+        for site_id, site_row in enumerate(tables.sites):
+            site = self.add_site(
+                          position=site_row.position,
+                          new=False,
+                          ancestral_state=site_row.ancestral_state,
+                          metadata=site_row.metadata)
+            while mutation_row is not None and mutation_row.site == site_id:
+                site.add_mutation(
+                        node=mutation_row.node,
+                        time=nodes.time[mutation_row.node],
+                        new=False,
+                        derived_state=mutation_row.derived_state,
+                        metadata=mutation_row.metadata,
+                        id=j)
+                j += 1
+                mutation_row = next(mutation_rows, None)
+
+    def populate_tables(self, tables):
+        positions = sorted(self.sites.keys())
+        site_id = 0
+        for pos in positions:
+            site = self.sites[pos]
+            num_mutations = 0
+            for mutation in site.mutations:
+                if mutation.keep:
+                    if mutation.parent is None:
+                        parent_id = tskit.NULL
+                    else:
+                        parent_id = mutation.parent.id
+                        assert parent_id >= 0
+                    mutation_id = tables.mutations.add_row(
+                                    site_id, mutation.node, mutation.derived_state,
+                                    parent=parent_id, metadata=mutation.metadata)
+                    assert mutation_id > parent_id
+                    mutation.id = mutation_id
+                    num_mutations += 1
+
+            if (not site.new) or num_mutations > 0:
+                sid = tables.sites.add_row(
+                        site.position,
+                        site.ancestral_state,
+                        site.metadata)
+                assert sid == site_id
+                site_id += 1
+
+    def place_mutations(self, tables, discrete=False):
+        # Insert a sentinel into the map for convenience.
+        map_position = np.hstack([self.rate_map.position, [tables.sequence_length]])
+        node_times = tables.nodes.time
+        for edge in tables.edges:
+            branch_start = node_times[edge.child]
+            branch_end = node_times[edge.parent]
+            branch_length = branch_end - branch_start
+            index = np.searchsorted(map_position, edge.left)
+            if map_position[index] > edge.left:
+                index -= 1
+            left = edge.left
+            right = 0
+            while right != edge.right:
+                right = min(edge.right, map_position[index + 1])
+                site_left = np.ceil(left) if discrete else left
+                site_right = np.ceil(right) if discrete else right
+                assert site_left <= site_right
+                assert map_position[index] <= left
+                assert right <= map_position[index + 1]
+                assert right <= edge.right
+                # Generate the mutations.
+                rate = self.rate_map.rate[index]
+                mu = rate * (site_right - site_left) * branch_length
+                for _ in range(self.rng.poisson(mu)):
+                    position = self.rng.flat(site_left, site_right)
+                    if discrete:
+                        position = np.floor(position)
+                    assert edge.left <= position
+                    assert position < edge.right
+                    if position not in self.sites:
+                        self.add_site(position=position, new=True)
+                    site = self.sites[position]
+                    time = self.rng.flat(branch_start, branch_end)
+                    site.add_mutation(node=edge.child, time=time, new=True)
+                index += 1
+                left = right
+
+    def choose_index(self, distribution):
+        u = self.rng.flat(0, 1)
+        j = 0
+        while u > distribution[j]:
+            u -= distribution[j]
+            j += 1
+        return j
+
+    def pick_allele(self):
+        return self.choose_index(self.root_distribution)
+
+    def transition_allele(self, current_allele):
+        return self.choose_index(self.transition_matrix[current_allele])
+
+    def choose_alleles(self, tree_parent, site, mutation_id_offset):
+        if site.new:
+            ai = self.pick_allele()
+            site.ancestral_state = self.alleles[ai]
+        else:
+            ai = self.alleles.index(site.ancestral_state)
+        # sort mutations by (increasing id if both are not null,
+        #  decreasing time, increasing insertion order)
+        site.mutations.sort(key=functools.cmp_to_key(cmp_mutation))
+        bottom_mutation = {}
+        for mut in site.mutations:
+            # Traverse up the tree to find the parent mutation
+            # bottom_mutation[u] is the index in mutations of the most recent
+            #    mutation seen on the edge above u so far, if any
+            u = mut.node
+            while u != tskit.NULL and u not in bottom_mutation:
+                u = tree_parent[u]
+            if u == tskit.NULL:
+                # parent is the ancestral state
+                pa = ai
+                assert mut.parent is None
+            else:
+                assert u in bottom_mutation
+                parent_mut = bottom_mutation[u]
+                mut.parent = parent_mut
+                assert mut.time <= parent_mut.time, "Parent after child mutation."
+                if mut.time > parent_mut.time or (parent_mut.new and not mut.new):
+                    raise ValueError("Generated mutation appears above "
+                                     "an existing mutation: cannot apply"
+                                     "finite sites mutations to a earlier"
+                                     "time period than where they already exist.")
+                if mut.new:
+                    pa = self.alleles.index(parent_mut.derived_state)
+
+            if mut.new:
+                da = self.transition_allele(pa)
+                if da == pa:
+                    mut.keep = False
+                else:
+                    mut.derived_state = self.alleles[da]
+            if mut.keep:
+                bottom_mutation[mut.node] = mut
+
+    def apply_mutations(self, tables):
+        ts = tables.tree_sequence()
+        positions = sorted(self.sites.keys())
+        j = 0
+        mutation_id_offset = 0
+        tree_parent = np.repeat(tskit.NULL, tables.nodes.num_rows)
+        for (tree_left, tree_right), edges_out, edges_in in ts.edge_diffs():
+            for edge in edges_out:
+                tree_parent[edge.child] = tskit.NULL
+            for edge in edges_in:
+                tree_parent[edge.child] = edge.parent
+            while (j < len(positions)
+                   and positions[j] < tree_right):
+                site = self.sites[positions[j]]
+                self.choose_alleles(tree_parent, site, mutation_id_offset)
+                num_mutations = len(site.mutations)
+                mutation_id_offset += num_mutations
+                j += 1
+
+    def generate(self, tables, seed, keep=False, discrete=False):
+        self.rng = msprime.RandomGenerator(seed)
+        if keep:
+            self.initialise_sites(tables)
+        tables.sites.clear()
+        tables.mutations.clear()
+        self.place_mutations(tables, discrete=discrete)
+        self.apply_mutations(tables)
+        self.populate_tables(tables)
+        self.record_provenance(tables, seed, keep, discrete)
+        return tables.tree_sequence()
+
+    def record_provenance(self, tables, seed, keep, discrete):
+        parameters = {
+            "command": "mutate",
+            "random_seed": seed,
+            "keep": keep,
+            "discrete": discrete,
+            "rate_map": None,  # not working??
+            "alleles": self.alleles,
+            "transition_matrix": self.transition_matrix,
+            "root_distribution": self.root_distribution
+        }
+        provenance_dict = msprime.provenance.get_provenance_dict(parameters)
+        encoded_provenance = msprime.provenance.json_encode_provenance(provenance_dict)
+        tables.provenances.add_row(encoded_provenance)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -193,11 +193,35 @@ class TestBuildObjects(unittest.TestCase):
         self.assertEqual(decoded.parameters.start_time, 0)
         self.assertEqual(decoded.parameters.end_time, 100)
         self.assertEqual(decoded.parameters.keep, False)
-        self.assertEqual(decoded.parameters.model['alphabet'], 0)
         self.assertEqual(
             decoded.parameters.model['__class__'],
-            'msprime.mutations.InfiniteSites'
+            'msprime.mutations.BinaryMutations'
         )
+
+    def test_mutate_model(self):
+        ts = msprime.simulate(5, random_seed=1)
+        ts = msprime.mutate(ts, model=msprime.JukesCantor())
+        decoded = self.decode(ts.provenance(1).record)
+        self.assertEqual(decoded.schema_version, "1.0.0")
+        self.assertEqual(decoded.parameters.command, "mutate")
+        self.assertEqual(
+            decoded.parameters.model['__class__'],
+            'msprime.mutations.JukesCantor'
+        )
+
+    def test_mutate_map(self):
+        ts = msprime.simulate(5, random_seed=1)
+        rate_map = msprime.MutationMap(position=[0, 0.5, 1], rate=[0, 1, 0])
+        ts = msprime.mutate(ts, rate=rate_map)
+        decoded = self.decode(ts.provenance(1).record)
+        self.assertEqual(decoded.schema_version, "1.0.0")
+        self.assertEqual(decoded.parameters.command, "mutate")
+        self.assertEqual(
+            decoded.parameters.rate['__class__'],
+            'msprime.mutations.MutationMap'
+        )
+        self.assertEqual(decoded.parameters.rate["position"], rate_map.position)
+        self.assertEqual(decoded.parameters.rate["rate"], rate_map.rate)
 
     def test_mutate_numpy(self):
         ts = msprime.simulate(5, random_seed=1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,101 @@
+#
+# Copyright (C) 2015-2020 University of Oxford
+#
+# This file is part of utils.
+#
+# utils.is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# utils.is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with utils.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test cases for the high level interface to utils.
+"""
+import unittest
+import multiprocessing
+import sys
+
+import msprime.utils as utils
+
+
+# Convenience method for getting seeds in a subprocess.
+def get_seed(x):
+    return utils.get_random_seed()
+
+
+class TestDefaultRandomSeeds(unittest.TestCase):
+    """
+    Tests for the default random seed generator.
+    """
+
+    def test_seed_generator_init(self):
+        utils.clear_seed_rng()
+        seed = utils.get_random_seed()
+        self.assertGreater(seed, 0)
+        self.assertIsNotNone(utils.get_seed_rng())
+
+    def test_unique(self):
+        n = 100
+        utils.clear_seed_rng()
+        seeds1 = [utils.get_random_seed() for _ in range(n)]
+        self.assertEqual(len(set(seeds1)), n)
+        seeds2 = [utils.get_random_seed() for _ in range(n)]
+        self.assertEqual(len(set(seeds2)), n)
+        self.assertEqual(len(set(seeds2)) + len(set(seeds2)), 2 * n)
+
+    def test_unique_multiple_processes_no_init(self):
+        n = 100
+        utils.clear_seed_rng()
+        # Would use with block here, but not supported in Py < 3.3.
+        pool = multiprocessing.Pool(5)
+        seeds = pool.map(get_seed, range(n))
+        self.assertEqual(len(set(seeds)), n)
+        pool.terminate()
+        pool.join()
+
+    def test_unique_multiple_processes_init(self):
+        n = 100
+        utils.get_random_seed()
+        self.assertIsNotNone(utils.get_seed_rng())
+        # Would use with block here, but not supported in Py < 3.3.
+        pool = multiprocessing.Pool(5)
+        seeds = pool.map(get_seed, range(n))
+        self.assertEqual(len(set(seeds)), n)
+        pool.terminate()
+        pool.join()
+
+
+class TestAlmostEqual(unittest.TestCase):
+    """
+    Simple tests to ensure that the almost_equal() method is sensible.
+    """
+
+    def test_defaults(self):
+        eps = sys.float_info.epsilon
+        equal = [
+            (1, 1), (0, 0), (1 + eps, 1), (1, 1 - eps),
+            (10.000000000001, 10.0)]
+        for a, b in equal:
+            self.assertAlmostEqual(a, b)
+            self.assertTrue(utils.almost_equal(a, b))
+
+    def test_near_zero(self):
+        eps = sys.float_info.epsilon
+        equal = [(0, 0), (eps, 0), (0, -eps), (-eps, eps)]
+        for a, b in equal:
+            self.assertAlmostEqual(a, b)
+            self.assertTrue(
+                utils.almost_equal(a, b, abs_tol=1e-9))
+        not_equal = [(0, 0.0000001), (-0.0000001, 0)]
+        for a, b in not_equal:
+            self.assertNotAlmostEqual(a, b)
+            self.assertFalse(
+                utils.almost_equal(a, b, abs_tol=1e-9))

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -120,6 +120,19 @@ def insert_branch_sites(ts):
     return tables.tree_sequence()
 
 
+def insert_site(ts):
+    """
+    Returns a copy of the specified tree sequence with a new site
+    and no mutation.
+    """
+    tables = ts.dump_tables()
+    tables.sites.add_row(
+            position=ts.sequence_length/2,
+            ancestral_state="XX")
+    add_provenance(tables.provenances, "insert_site")
+    return tables.tree_sequence()
+
+
 def insert_multichar_mutations(ts, seed=1, max_len=10):
     """
     Returns a copy of the specified tree sequence with multiple chararacter


### PR DESCRIPTION
I'm having a go at #553. The two methods sketched out there for doing this are roughly:

- build the trees and step along site-by-site
- throw down mutations and go back and deal with state later (including rejection sampling)

This PR is the latter. It doesn't work yet. Without fully explaining (yet), the idea is that:

- the previous mutgen code can *almost* lay down multiple mutations at the same site...
- however, it had no facilities for actually keeping track of those mutation; so I had to add that.
- edges come in order by time-ago
- compute_mutation_parents wants mutations to come in order by time (ie, reverse of the order that they are produced by mutgen)

So, once I've done this right, I should be able to 

- generate mutations
- compute mutation parents
- figure out state (and, there's python code in this PR to do this bit)

This is not yet right, and I've probably done something terribly wrong C-wise, but maybe you'll get the idea. Feel free to ignore for the moment (but suggestions appreciated).