### PR TITLE
Store a placeholder for tree sequences in provenance

### DIFF
--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -162,8 +162,7 @@ def mutate(
     argspec = inspect.getargvalues(inspect.currentframe())
     parameters = {
         "command": "mutate",
-        **{arg: argspec.locals[arg] for arg in argspec.args
-           if arg not in ["tree_sequence"]}
+        **{arg: argspec.locals[arg] for arg in argspec.args}
     }
     parameters['random_seed'] = seed
     encoded_provenance = provenance.json_encode_provenance(


### PR DESCRIPTION
Fixes #928 

This is based on #934 in that it puts an object into provenance to represent the "current" tree sequence, which `parse_provenance` then replaces. This will work with any future tskit provenance work as discussed in #934.