### PR TITLE
Safely account for double inequality when calculating breakpoints

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -2076,12 +2076,9 @@ msp_init_segments_and_compute_breakpoint(msp_t *self, label_id_t label, segment_
     t = fenwick_get_cumulative_sum(tree, y->id);
     x = y->prev;
 
-    k = recomb_map_mass_to_position(&self->recomb_map, y->right_mass - (t - h));
-
-    /* Reject if fallen directly on y left when not allowed to */
-    if (k == y->left && y->prev == NULL) {
-      return msp_init_segments_and_compute_breakpoint(self, label, x_ret, y_ret);
-    }
+    do {
+        k = recomb_map_mass_to_position(&self->recomb_map, y->right_mass - (t - h));
+    } while (y->left >= k && y->prev == NULL);
 
     *x_ret = x;
     *y_ret = y;


### PR DESCRIPTION
In the rejection sampling of breakpoints, this change:
- Uses a do-while instead of recursion
- Uses an inequality instead of `==` for the rejection case because `==` was sometimes failing due to floating point precision.

A more detailed description of the problem where this arose is discussed in #942. This PR only addresses the assertion error in the issue and not any additional problems concerning rates.