### PR TITLE
Refactor migration matrix handling

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,8 @@ information on how to use the
 `tskit Python API <https://tskit.readthedocs.io/en/stable/python-api.html>`_
 to analyse simulation results.
 
+.. _sec_api_simulation_model:
+
 ****************
 Simulation model
 ****************
@@ -65,10 +67,26 @@ However, recombination (with or without recombination maps) and a constant gene 
 rate along the genome can be combined in ``msprime``.
 
 Population structure is modelled by specifying a fixed number of subpopulations
-:math:`d`, and a :math:`d \times d` matrix :math:`M` of per generation
-migration rates. Each element of the matrix :math:`M_{j,k}` defines
+:math:`d`, and a :math:`d \times d` matrix :math:`M` of per generation migration rates.
+Each element of the matrix :math:`M_{j,k}` defines
 the fraction of population :math:`j` that consists of migrants from
 population :math:`k` in each generation.
+Note that migration rates are specified in a way that makes sense for the
+coalescence process, so that the :math:`(j, k)^{th}` entry of the migration matrix,
+:math:`M_{j, k}`, gives the rate at which an ancestral lineage moves from
+population :math:`j` to population :math:`k` as one follows it back through time.
+In terms of the demographic process of the populations, if a total of
+:math:`n` migrants move from population :math:`k` to
+population :math:`j` per generation, and population :math:`j` has a total of
+:math:`N_{j}` individuals, then the migration matrix has :math:`M_{j,k} = n/N_j`.
+This differs from the migration matrix one usually uses in population
+demography: if :math:`m_{k,j}` is the proportion
+of individuals (in the usual sense; not lineages) in population :math:`k`
+that move to population :math:`j` per generation,
+then translating this proportion of population :math:`k`
+to a proportion of population :math:`j`, we have
+:math:`M_{j,k} = m_{k,j} \times N_k / N_j`.
+
 Each subpopulation has an initial absolute population size :math:`s`
 and a per generation exponential growth rate :math:`\alpha`. The size of a
 given population at time :math:`t` in the past (measured in generations) is
@@ -157,7 +175,7 @@ Species trees hold information about the sequence and the times at which species
 diverged from each other. Viewed backwards in time, divergence events are equivalent
 to mass migration events in which all lineages from one population move to another
 population. The history of a set of populations can thus be modelled according to
-a given species tree. To faciliate the specification of the model, 
+a given species tree. To faciliate the specification of the model,
 :func:`.parse_species_tree` parses a species tree and returns the mass migration
 events corresponding to all species divergence events in the tree, together with
 population configurations that specify population sizes and names.
@@ -483,7 +501,7 @@ Evaluating sampling probabilities
 that of a stored tree sequence for a given diploid effective population size
 :math:`N_e` and per-link, per-generation recombination probability :math:`r`
 under the standard ancestral recombination graph; and that of a pattern of
-mutations given a tree sequence and per-site, per-generation mutation 
+mutations given a tree sequence and per-site, per-generation mutation
 probability :math:`\mu` under the infinite sites model.
 
 Specifically, the methods assume that each pair of lineages merges at rate

--- a/lib/dev-tools/dev-cli.c
+++ b/lib/dev-tools/dev-cli.c
@@ -301,7 +301,7 @@ read_demographic_events(msp_t *msp, config_t *config)
     const char *type;
     double time, growth_rate, initial_size, migration_rate, proportion,
            intensity, strength;
-    int num_demographic_events, population_id, matrix_index, source, dest;
+    int num_demographic_events, population_id, source, dest;
     config_setting_t *s, *t;
     config_setting_t *setting = config_lookup(config, "demographic_events");
 
@@ -357,13 +357,18 @@ read_demographic_events(msp_t *msp, config_t *config)
                 fatal_error("migration_rate not specified");
             }
             migration_rate = config_setting_get_float(t);
-            t = config_setting_get_member(s, "matrix_index");
+            t = config_setting_get_member(s, "source");
             if (t == NULL) {
-                fatal_error("matrix_index not specified");
+                fatal_error("source not specified");
             }
-            matrix_index = config_setting_get_int(t);
+            source = config_setting_get_int(t);
+            t = config_setting_get_member(s, "dest");
+            if (t == NULL) {
+                fatal_error("dest not specified");
+            }
+            dest = config_setting_get_int(t);
             ret = msp_add_migration_rate_change(msp, time,
-                    matrix_index, migration_rate);
+                    source, dest, migration_rate);
         } else if (strcmp(type, "mass_migration") == 0) {
             t = config_setting_get_member(s, "proportion");
             if (t == NULL) {

--- a/lib/dev-tools/example.cfg
+++ b/lib/dev-tools/example.cfg
@@ -169,7 +169,8 @@ is_sample = [0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 #    {
 #        type = "migration_rate_change";
 #        time = 0.3;
-#        matrix_index = -1;
+#        source = -1;
+#        dest = -1;
 #        migration_rate = 0.0;
 #    }
 #

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -5127,22 +5127,28 @@ msp_print_migration_rate_change(
  * units of generations. */
 int MSP_WARN_UNUSED
 msp_add_migration_rate_change(
-    msp_t *self, double time, int matrix_index, double migration_rate)
+    msp_t *self, double time, int source, int dest, double migration_rate)
 {
     int ret = -1;
     demographic_event_t *de;
     int N = (int) self->num_populations;
+    int matrix_index;
 
-    if (matrix_index < -1 || matrix_index >= N * N) {
-        ret = MSP_ERR_BAD_MIGRATION_MATRIX_INDEX;
-        goto out;
+    if (source == -1 && dest == -1) {
+        matrix_index = -1;
+    } else {
+        if (source < 0 || source >= N || dest < 0 || dest >= N) {
+            ret = MSP_ERR_BAD_MIGRATION_MATRIX_INDEX;
+            goto out;
+        }
+        if (source == dest) {
+            ret = MSP_ERR_DIAGONAL_MIGRATION_MATRIX_INDEX;
+            goto out;
+        }
+        matrix_index = source * N + dest;
     }
     if (migration_rate < 0) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
-        goto out;
-    }
-    if (matrix_index % (N + 1) == 0) {
-        ret = MSP_ERR_DIAGONAL_MIGRATION_MATRIX_INDEX;
         goto out;
     }
     ret = msp_add_demographic_event(self, time, &de);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -374,7 +374,7 @@ int msp_set_population_configuration(
 int msp_add_population_parameters_change(
     msp_t *self, double time, int population_id, double size, double growth_rate);
 int msp_add_migration_rate_change(
-    msp_t *self, double time, int matrix_index, double migration_rate);
+    msp_t *self, double time, int source_pop, int dest_pop, double migration_rate);
 int msp_add_mass_migration(
     msp_t *self, double time, int source, int dest, double proportion);
 int msp_add_simple_bottleneck(

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -797,11 +797,21 @@ test_demographic_events(void)
         CU_ASSERT_EQUAL(
             msp_add_mass_migration(&msp, 10, 0, 1, -5), MSP_ERR_BAD_PROPORTION);
 
-        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, -2, 2.0),
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, -1, 0, 2.0),
             MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
-        CU_ASSERT_EQUAL(
-            msp_add_migration_rate_change(&msp, 10, -1, -2.0), MSP_ERR_BAD_PARAM_VALUE);
-        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 3, 2.0),
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 0, -1, 2.0),
+            MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 0, 2, 2.0),
+            MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 2, 0, 2.0),
+            MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, -1, 0, 2.0),
+            MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 0, -1, 2.0),
+            MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, -1, -1, -2.0),
+            MSP_ERR_BAD_PARAM_VALUE);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 0, 0, 2.0),
             MSP_ERR_DIAGONAL_MIGRATION_MATRIX_INDEX);
 
         CU_ASSERT_EQUAL(msp_add_population_parameters_change(&msp, 10, -2, 0, 0),
@@ -832,9 +842,9 @@ test_demographic_events(void)
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_add_migration_rate_change(&msp, 0.2, 1, 2.0);
+        ret = msp_add_migration_rate_change(&msp, 0.2, 0, 1, 2.0);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_add_migration_rate_change(&msp, 0.3, -1, 3.0);
+        ret = msp_add_migration_rate_change(&msp, 0.3, -1, -1, 3.0);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_add_population_parameters_change(&msp, 0.4, 1, 1, GSL_NAN);
         CU_ASSERT_EQUAL(ret, 0);
@@ -858,7 +868,7 @@ test_demographic_events(void)
             /* Need to lower final migration rate for DTWF or else lineages will
              * alternate pops every generation and miss each other - need to let
              * one lineage migrate while the others stay put */
-            ret = msp_add_migration_rate_change(&msp, 1.5, -1, 0.3);
+            ret = msp_add_migration_rate_change(&msp, 1.5, -1, -1, 0.3);
             CU_ASSERT_EQUAL(ret, 0);
             /* Bottleneck events only supported in Hudson model so we add
              * another mass migration to have the same number of events */
@@ -868,7 +878,7 @@ test_demographic_events(void)
 
         CU_ASSERT_EQUAL(msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5),
             MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
-        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 0.2, 1, 2.0),
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 0.2, 0, 1, 2.0),
             MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
         CU_ASSERT_EQUAL(msp_add_population_parameters_change(&msp, 0.4, 0, 0.5, 1.0),
             MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
@@ -1025,7 +1035,7 @@ test_dtwf_events_between_generations(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_add_population_parameters_change(&msp, 1.2, 1, 10, 0);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_add_migration_rate_change(&msp, 3, -1, 0.3);
+    ret = msp_add_migration_rate_change(&msp, 3, -1, -1, 0.3);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -312,7 +312,8 @@ class TestRateConversions(unittest.TestCase):
         ll_event = {
             "type": "migration_rate_change",
             "time": g,
-            "matrix_index": -1,
+            "source": -1,
+            "dest": -1,
             "migration_rate": migration_rate,
         }
         self.assertEqual(event.get_ll_representation(d), ll_event)
@@ -462,7 +463,7 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertTrue(math.isinf(e.end_time))
         self.assertEqual(len(e.demographic_events), 0)
         self.assertEqual(len(e.populations), 2)
-        self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+        np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
         for pop in e.populations:
             self.assertEqual(pop.growth_rate, 0)
             self.assertEqual(pop.start_size, pop.end_size)
@@ -493,7 +494,7 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertEqual(e.end_time, 10)
         self.assertEqual(len(e.demographic_events), 0)
         self.assertEqual(len(e.populations), 2)
-        self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+        np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
         self.assertEqual(e.populations[0].start_size, 10)
         self.assertEqual(e.populations[0].end_size, p0_end_size)
         self.assertEqual(e.populations[1].start_size, 20)
@@ -509,7 +510,7 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertEqual(d.initial_size, None)
         self.assertEqual(d.population, -1)
         self.assertEqual(len(e.populations), 2)
-        self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+        np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
         for pop in e.populations:
             self.assertEqual(pop.growth_rate, 0)
             self.assertEqual(pop.start_size, pop.end_size)
@@ -533,7 +534,7 @@ class TestDemographyDebugger(unittest.TestCase):
         e = dd.epochs[0]
         self.assertEqual(e.start_time, 0)
         self.assertEqual(e.end_time, 20)
-        self.assertEqual(e.migration_matrix, [[0, 0.25], [0, 0]])
+        np.testing.assert_array_equal(e.migration_matrix, [[0, 0.25], [0, 0]])
         for pop in e.populations:
             self.assertEqual(pop.growth_rate, 0)
             self.assertEqual(pop.start_size, pop.end_size)
@@ -544,11 +545,12 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertTrue(e.end_time, 22)
         self.assertEqual(len(e.demographic_events), 1)
         d = e.demographic_events[0]
-        self.assertEqual(d.matrix_index, None)
+        self.assertEqual(d.source, -1)
+        self.assertEqual(d.dest, -1)
         self.assertEqual(d.time, 20)
         self.assertEqual(d.rate, 1)
         self.assertEqual(len(e.populations), 2)
-        self.assertEqual(e.migration_matrix, [[0, 1], [1, 0]])
+        np.testing.assert_array_equal(e.migration_matrix, [[0, 1], [1, 0]])
         for pop in e.populations:
             self.assertEqual(pop.growth_rate, 0)
             self.assertEqual(pop.start_size, pop.end_size)
@@ -559,11 +561,12 @@ class TestDemographyDebugger(unittest.TestCase):
         self.assertTrue(math.isinf(e.end_time))
         self.assertEqual(len(e.demographic_events), 1)
         d = e.demographic_events[0]
-        self.assertEqual(d.matrix_index, (0, 1))
+        self.assertEqual(d.source, 0)
+        self.assertEqual(d.dest, 1)
         self.assertEqual(d.time, 22)
         self.assertEqual(d.rate, 1.7)
         self.assertEqual(len(e.populations), 2)
-        self.assertEqual(e.migration_matrix, [[0, 1.7], [1, 0]])
+        np.testing.assert_array_equal(e.migration_matrix, [[0, 1.7], [1, 0]])
         for pop in e.populations:
             self.assertEqual(pop.growth_rate, 0)
             self.assertEqual(pop.start_size, pop.end_size)
@@ -606,7 +609,7 @@ class TestDemographyDebugger(unittest.TestCase):
             self.assertEqual(dd.epoch_times[1], t1)
             self.assertEqual(len(e.demographic_events), 0)
             self.assertEqual(len(e.populations), 2)
-            self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+            np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             self.assertEqual(e.populations[0].start_size, N0)
             n0 = N0 * math.exp(-alpha * t1)
             self.assertEqual(e.populations[0].end_size, n0)
@@ -618,7 +621,7 @@ class TestDemographyDebugger(unittest.TestCase):
             self.assertEqual(e.end_time, t2)
             self.assertEqual(len(e.demographic_events), 1)
             self.assertEqual(len(e.populations), 2)
-            self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+            np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             self.assertEqual(e.populations[0].start_size, n0)
             n0 = N0 * math.exp(-alpha * t2)
             self.assertEqual(e.populations[0].end_size, n0)
@@ -631,7 +634,7 @@ class TestDemographyDebugger(unittest.TestCase):
             self.assertEqual(e.end_time, t3)
             self.assertEqual(len(e.demographic_events), 1)
             self.assertEqual(len(e.populations), 2)
-            self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+            np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             self.assertEqual(e.populations[0].start_size, n0)
             n0 = n0 * math.exp(alpha * (t3 - t2))
             self.assertEqual(e.populations[0].end_size, n0)
@@ -644,7 +647,7 @@ class TestDemographyDebugger(unittest.TestCase):
             self.assertTrue(math.isinf(e.end_time))
             self.assertEqual(len(e.demographic_events), 1)
             self.assertEqual(len(e.populations), 2)
-            self.assertEqual(e.migration_matrix, [[0, 0], [0, 0]])
+            np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             self.assertEqual(e.populations[0].start_size, n0)
             self.assertEqual(e.populations[0].end_size, n0)
             self.assertEqual(e.populations[1].start_size, n1)
@@ -1505,8 +1508,8 @@ class TestCoalescenceLocations(unittest.TestCase):
         ]
         t = 5
         demographic_events = [
-            msprime.MigrationRateChange(time=t, rate=1, matrix_index=(0, 2)),
-            msprime.MigrationRateChange(time=t, rate=1, matrix_index=(1, 2)),
+            msprime.MigrationRateChange(time=t, rate=1, source=0, dest=2),
+            msprime.MigrationRateChange(time=t, rate=1, source=1, dest=2),
         ]
         ts = msprime.simulate(
             population_configurations=population_configurations,
@@ -1750,6 +1753,10 @@ class MigrationRecordsMixin:
             self.assertEqual(mig.dest, 0)
             self.assertEqual(mig.left, 0)
             self.assertEqual(mig.right, 1)
+        # All lineages should end up in population 1
+        for tree in ts.trees():
+            node = ts.node(tree.root)
+            self.assertEqual(node.population, 0)
 
     def test_two_pops_asymmetric_migrations(self):
         population_configurations = [
@@ -2130,7 +2137,8 @@ class TestLowLevelConversions(unittest.TestCase):
                 "time": g,
                 "type": "migration_rate_change",
                 "migration_rate": 0,
-                "matrix_index": -1,
+                "source": -1,
+                "dest": -1,
             }
             self.assertEqual(d, dp)
 
@@ -2138,14 +2146,22 @@ class TestLowLevelConversions(unittest.TestCase):
         g = 51
         for N in range(1, 5):
             for index in itertools.permutations(range(N), 2):
-                event = msprime.MigrationRateChange(time=g, rate=0, matrix_index=index)
+                event = msprime.MigrationRateChange(
+                    time=g, rate=0, source=index[0], dest=index[1]
+                )
                 d = event.get_ll_representation(N)
                 dp = {
                     "time": g,
                     "type": "migration_rate_change",
                     "migration_rate": 0,
-                    "matrix_index": index[0] * N + index[1],
+                    "source": index[0],
+                    "dest": index[1],
                 }
+                self.assertEqual(d, dp)
+
+                # Check the deprecated form
+                event = msprime.MigrationRateChange(time=g, rate=0, matrix_index=index)
+                d = event.get_ll_representation(N)
                 self.assertEqual(d, dp)
 
     def test_migration_rate_change_rate(self):
@@ -2157,7 +2173,8 @@ class TestLowLevelConversions(unittest.TestCase):
                 "time": g,
                 "type": "migration_rate_change",
                 "migration_rate": rate,
-                "matrix_index": -1,
+                "source": -1,
+                "dest": -1,
             }
             self.assertEqual(d, dp)
 
@@ -2212,7 +2229,7 @@ class TestLowLevelConversions(unittest.TestCase):
             ],
             migration_matrix=m,
         )
-        self.assertEqual(sim.migration_matrix, m)
+        np.testing.assert_array_equal(sim.migration_matrix, m)
 
     def test_instantaneous_bottleneck(self):
         g = 51
@@ -2602,8 +2619,8 @@ class TestEventsBetweenGenerationsWrightFisher(unittest.TestCase):
             msprime.PopulationParametersChange(population=0, time=0.2, initial_size=5),
             msprime.MassMigration(time=1.1, source=0, dest=2),
             msprime.MassMigration(time=1.2, source=1, dest=3),
-            msprime.MigrationRateChange(time=2.1, rate=0.3, matrix_index=(2, 3)),
-            msprime.MigrationRateChange(time=2.2, rate=0.3, matrix_index=(3, 2)),
+            msprime.MigrationRateChange(time=2.1, rate=0.3, source=2, dest=3),
+            msprime.MigrationRateChange(time=2.2, rate=0.3, source=3, dest=2),
         ]
         ts = msprime.simulate(
             migration_matrix=migration_matrix,

--- a/verification.py
+++ b/verification.py
@@ -1962,7 +1962,7 @@ class SimulationVerifier:
                 positions=[0, 100, 101, 201], rates=[0, 1, 0, 0], discrete=True
             )
 
-            self.run_dtwf_coalescent_single_replicate(
+            self.run_dtwf_coalescent_comparison(
                 test_name,
                 sample_size=10,
                 Ne=10,


### PR DESCRIPTION
This refactors the handling of migration matrices to natively use numpy and to avoid linearising coordinates within it. This is a nice update, and will clear the way for some planned simplifications and refactoring of the demography definition code.

**HOWEVER**, as I was going through the process of changing the old ``matrix_index`` used to describe the bit of the migration matrix we change on a MigrationRateChangeEvent to (source, dest), I hit a worrying inconsistency. In the mspms code, it turns out that we use (dest, source) instead and I'm worried that there's a long-standing bug in the Python API where I've flipped the direction of migration. It would be surprising if such a fundamental issue had slipped through all this time, but migration has been a persistent source of confusion.

@petrelharp, any chance you can take a look through here and see what you think?

I'm sure that mspms is correct, because there's loads of statistical tests checking all sorts of migration patterns (probably because I was worried about just this sort of thing).

Closes #666 