### PR TITLE
Format C code with clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,20 @@ on:
     branches: [master]
 
 jobs:
+  lint-c:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - name: install clang-format
+        run: |
+          sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
+          sudo apt-get autoremove
+          sudo apt-get install clang-format clang-format-6.0
+      - name: install run-clang-format
+        run: wget https://raw.githubusercontent.com/Sarcasm/run-clang-format/de6e8ca07d171a7f378d379ff252a00f2905e81d/run-clang-format.py
+      - name: clang-format
+        run: python run-clang-format.py --clang-format-executable=clang-format --exclude lib/avl.c --exclude lib/avl.h --exclude lib/dev-tools --exclude lib/subprojects -r lib
   pre-commit:
     runs-on: ubuntu-18.04
     steps:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -40,6 +40,9 @@ Quickstart
   code. To run the checks without committing use ``pre-commit run``. To bypass
   the checks (to save or get feedback on work-in-progress) use ``git commit
   --no-verify``
+- If you have modifed the C code then
+  ``clang-format -i lib/tests/* lib/!(avl).{c,h}`` will format the code to
+  satisfy CI checks.
 - When ready open a pull request on GitHub. Please make sure that the tests pass before
   you open the PR, unless you want to ask the community for help with a failing test.
 - See the `tskit documentation <https://tskit.readthedocs.io/en/latest/development.html#github-workflow>`_

--- a/lib/.clang-format
+++ b/lib/.clang-format
@@ -1,0 +1,21 @@
+Language: Cpp
+BasedOnStyle: GNU
+SortIncludes:    false
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Linux
+TabWidth:        4
+IndentWidth:     4
+ColumnLimit:     89
+SpaceBeforeParens:
+    ControlStatements
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: true
+IndentCaseLabels: true
+AlignAfterOpenBracket: DontAlign
+BinPackArguments: true
+BinPackParameters: true
+AlwaysBreakAfterReturnType: AllDefinitions
+
+# These are disabled for version 6 compatibility
+# StatementMacros: ["PyObject_HEAD"]
+# AlignConsecutiveMacros: true

--- a/lib/fenwick.c
+++ b/lib/fenwick.c
@@ -179,7 +179,6 @@ fenwick_get_value(fenwick_t *self, size_t index)
     return self->values[index];
 }
 
-
 size_t
 fenwick_find(fenwick_t *self, double sum)
 {

--- a/lib/fenwick.h
+++ b/lib/fenwick.h
@@ -30,7 +30,6 @@ typedef struct {
     double *values;
 } fenwick_t;
 
-
 int fenwick_alloc(fenwick_t *, size_t);
 int fenwick_expand(fenwick_t *, size_t);
 int fenwick_free(fenwick_t *);

--- a/lib/interval_map.c
+++ b/lib/interval_map.c
@@ -80,7 +80,7 @@ out:
 int MSP_WARN_UNUSED
 interval_map_alloc_single(interval_map_t *self, double sequence_length, double value)
 {
-    double position[2] = {0, sequence_length};
+    double position[2] = { 0, sequence_length };
     return interval_map_alloc(self, 2, position, &value);
 }
 

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -28,7 +28,8 @@
 #include "msprime.h"
 
 static double
-get_total_material(tsk_treeseq_t *ts) {
+get_total_material(tsk_treeseq_t *ts)
+{
     double ret = 0;
     tsk_size_t j;
     const tsk_edge_table_t *edges = &ts->tables->edges;
@@ -40,14 +41,14 @@ get_total_material(tsk_treeseq_t *ts) {
         parent = edges->parent[j];
         child = edges->child[j];
         ret += (edges->right[j] - edges->left[j])
-            * (nodes->time[parent] - nodes->time[child]);
+               * (nodes->time[parent] - nodes->time[child]);
     }
     return ret;
 }
 
 int
-msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
-                                    double *r_lik) {
+msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu, double *r_lik)
+{
     int ret = 0;
     tsk_size_t j;
     tsk_mutation_t mut;
@@ -76,15 +77,15 @@ msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
                 branch_length = node_time[parent] - node_time[child];
                 child = parent;
                 parent = tree.parent[parent];
-                while (parent != TSK_NULL && tree.left_child[child]
-                        == tree.right_child[child]) {
+                while (parent != TSK_NULL
+                       && tree.left_child[child] == tree.right_child[child]) {
                     branch_length += node_time[parent] - node_time[child];
                     child = parent;
                     parent = tree.parent[parent];
                 }
                 child = mut.node;
-                while (tree.left_child[child] != TSK_NULL &&
-                        tree.left_child[child] == tree.right_child[child]) {
+                while (tree.left_child[child] != TSK_NULL
+                       && tree.left_child[child] == tree.right_child[child]) {
                     // unary nodes have left_child[node] == right_child[node]
                     // so this measures the valid leafwards branch length on
                     // which mutation mut could have taken place
@@ -140,7 +141,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
     }
     memset(first_parent_edge, TSK_NULL, sizeof(tsk_id_t) * nodes->num_rows);
     memset(last_parent_edge, TSK_NULL, sizeof(tsk_id_t) * nodes->num_rows);
-    for (i = 0; i < (tsk_id_t)edges->num_rows; i++) {
+    for (i = 0; i < (tsk_id_t) edges->num_rows; i++) {
         if (first_parent_edge[edges->child[i]] == TSK_NULL) {
             first_parent_edge[edges->child[i]] = i;
         }
@@ -157,8 +158,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
                 ret = 0;
                 goto out;
             }
-            while (edge < (tsk_id_t)edges->num_rows
-                    && edges->parent[edge] == parent) {
+            while (edge < (tsk_id_t) edges->num_rows && edges->parent[edge] == parent) {
                 edge++;
             }
             gap = edges->left[edge] - edges->right[edge - 1];
@@ -183,7 +183,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
                 material -= material_in_children;
             } else {
                 material_in_parent = edges->right[last_parent_edge[parent]]
-                    - edges->left[first_parent_edge[parent]];
+                                     - edges->left[first_parent_edge[parent]];
                 lineages--;
                 material -= material_in_children - material_in_parent;
             }

--- a/lib/likelihood.h
+++ b/lib/likelihood.h
@@ -23,9 +23,7 @@
 #include <stdio.h>
 #include <tskit.h>
 
-int msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu,
-                                        double *lik);
-int msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne,
-                           double *lik);
+int msp_unnormalised_log_likelihood_mut(tsk_treeseq_t *ts, double mu, double *lik);
+int msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *lik);
 
 #endif /*__LIKELIHOOD_H__*/

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -50,7 +50,7 @@ ran_inc_beta_rej(gsl_rng *r, double a, double b, double x)
     double ret;
     do {
         ret = gsl_ran_beta(r, a, b);
-    } while(ret > x);
+    } while (ret > x);
     return ret;
 }
 
@@ -88,7 +88,8 @@ ran_inc_beta(gsl_rng *r, double a, double b, double x)
 }
 
 static int
-cmp_individual(const void *a, const void *b) {
+cmp_individual(const void *a, const void *b)
+{
     const segment_t *ia = (const segment_t *) a;
     const segment_t *ib = (const segment_t *) b;
     return (ia->id > ib->id) - (ia->id < ib->id);
@@ -97,11 +98,12 @@ cmp_individual(const void *a, const void *b) {
 /* For pedigree individuals we sort on time and to break ties
  * we arbitrarily use the ID */
 static int
-cmp_pedigree_individual(const void *a, const void *b) {
+cmp_pedigree_individual(const void *a, const void *b)
+{
     const individual_t *ia = (const individual_t *) a;
     const individual_t *ib = (const individual_t *) b;
-    int ret =  (ia->time > ib->time) - (ia->time < ib->time);
-    if (ret == 0)  {
+    int ret = (ia->time > ib->time) - (ia->time < ib->time);
+    if (ret == 0) {
         ret = (ia->id > ib->id) - (ia->id < ib->id);
     }
     return ret;
@@ -110,25 +112,28 @@ cmp_pedigree_individual(const void *a, const void *b) {
 /* For the segment priority queue we want to sort on the left
  * coordinate and to break ties we arbitrarily use the ID */
 static int
-cmp_segment_queue(const void *a, const void *b) {
+cmp_segment_queue(const void *a, const void *b)
+{
     const segment_t *ia = (const segment_t *) a;
     const segment_t *ib = (const segment_t *) b;
     int ret = (ia->left > ib->left) - (ia->left < ib->left);
-    if (ret == 0)  {
+    if (ret == 0) {
         ret = (ia->id > ib->id) - (ia->id < ib->id);
     }
     return ret;
 }
 
 static int
-cmp_node_mapping(const void *a, const void *b) {
+cmp_node_mapping(const void *a, const void *b)
+{
     const node_mapping_t *ia = (const node_mapping_t *) a;
     const node_mapping_t *ib = (const node_mapping_t *) b;
     return (ia->left > ib->left) - (ia->left < ib->left);
 }
 
 static int
-cmp_sampling_event(const void *a, const void *b) {
+cmp_sampling_event(const void *a, const void *b)
+{
     const sampling_event_t *ia = (const sampling_event_t *) a;
     const sampling_event_t *ib = (const sampling_event_t *) b;
     return (ia->time > ib->time) - (ia->time < ib->time);
@@ -245,23 +250,19 @@ msp_set_dimensions(msp_t *self, size_t num_populations, size_t num_labels)
 
     self->num_populations = (uint32_t) num_populations;
     self->num_labels = (uint32_t) num_labels;
-    self->initial_migration_matrix = calloc(num_populations * num_populations,
-            sizeof(double));
-    self->migration_matrix = calloc(num_populations * num_populations,
-            sizeof(double));
-    self->num_migration_events = calloc(num_populations * num_populations,
-            sizeof(size_t));
+    self->initial_migration_matrix
+        = calloc(num_populations * num_populations, sizeof(double));
+    self->migration_matrix = calloc(num_populations * num_populations, sizeof(double));
+    self->num_migration_events
+        = calloc(num_populations * num_populations, sizeof(size_t));
     self->initial_populations = calloc(num_populations, sizeof(population_t));
     self->populations = calloc(num_populations, sizeof(population_t));
     self->links = calloc(self->num_labels, sizeof(fenwick_t));
     self->segment_heap = calloc(self->num_labels, sizeof(object_heap_t));
-    if (self->migration_matrix == NULL
-            || self->initial_migration_matrix == NULL
-            || self->num_migration_events == NULL
-            || self->initial_populations == NULL
-            || self->populations == NULL
-            || self->links == NULL
-            || self->segment_heap == NULL) {
+    if (self->migration_matrix == NULL || self->initial_migration_matrix == NULL
+        || self->num_migration_events == NULL || self->initial_populations == NULL
+        || self->populations == NULL || self->links == NULL
+        || self->segment_heap == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
@@ -315,8 +316,8 @@ msp_set_num_populations(msp_t *self, size_t num_populations)
 }
 
 int
-msp_set_population_configuration(msp_t *self, int population_id, double initial_size,
-        double growth_rate)
+msp_set_population_configuration(
+    msp_t *self, int population_id, double initial_size, double growth_rate)
 {
     int ret = MSP_ERR_BAD_POPULATION_CONFIGURATION;
     simulation_model_t *model = &self->model;
@@ -329,10 +330,10 @@ msp_set_population_configuration(msp_t *self, int population_id, double initial_
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    self->initial_populations[population_id].initial_size =
-        initial_size / model->reference_size;
-    self->initial_populations[population_id].growth_rate =
-        model->generation_rate_to_model_rate(model, growth_rate);
+    self->initial_populations[population_id].initial_size
+        = initial_size / model->reference_size;
+    self->initial_populations[population_id].growth_rate
+        = model->generation_rate_to_model_rate(model, growth_rate);
     ret = 0;
 out:
     return ret;
@@ -364,8 +365,8 @@ msp_set_migration_matrix(msp_t *self, size_t size, double *migration_matrix)
         }
     }
     for (j = 0; j < N * N; j++) {
-        self->initial_migration_matrix[j] = model->generation_rate_to_model_rate(
-                model, migration_matrix[j]);
+        self->initial_migration_matrix[j]
+            = model->generation_rate_to_model_rate(model, migration_matrix[j]);
     }
     ret = 0;
 out:
@@ -414,11 +415,10 @@ out:
     return ret;
 }
 
-static segment_t * MSP_WARN_UNUSED
-msp_alloc_segment(msp_t *self, double left, double right,
-        double left_mass, double right_mass, node_id_t value,
-        population_id_t population, label_id_t label,
-        segment_t *prev, segment_t *next)
+static segment_t *MSP_WARN_UNUSED
+msp_alloc_segment(msp_t *self, double left, double right, double left_mass,
+    double right_mass, node_id_t value, population_id_t population, label_id_t label,
+    segment_t *prev, segment_t *next)
 {
     segment_t *seg = NULL;
 
@@ -450,9 +450,9 @@ out:
 /* Top level allocators and initialisation */
 
 int
-msp_alloc(msp_t *self,
-        size_t num_samples, sample_t *samples,
-        recomb_map_t *recomb_map, tsk_table_collection_t *tables, gsl_rng *rng) {
+msp_alloc(msp_t *self, size_t num_samples, sample_t *samples, recomb_map_t *recomb_map,
+    tsk_table_collection_t *tables, gsl_rng *rng)
+{
     int ret = -1;
     size_t j;
 
@@ -477,7 +477,7 @@ msp_alloc(msp_t *self,
 
     /* And rescale the rates */
     self->gene_conversion_rate = self->model.generation_rate_to_model_rate(
-            &self->model, self->gene_conversion_rate);
+        &self->model, self->gene_conversion_rate);
 
     if (num_samples > 0) {
         if (num_samples < 2 || samples == NULL || self->tables->nodes.num_rows > 0) {
@@ -559,20 +559,20 @@ msp_alloc_memory_blocks(msp_t *self)
     uint32_t j;
 
     /* Allocate the memory heaps */
-    ret = object_heap_init(&self->avl_node_heap, sizeof(avl_node_t),
-           self->avl_node_block_size, NULL);
+    ret = object_heap_init(
+        &self->avl_node_heap, sizeof(avl_node_t), self->avl_node_block_size, NULL);
     if (ret != 0) {
         goto out;
     }
     ret = object_heap_init(&self->node_mapping_heap, sizeof(node_mapping_t),
-           self->node_mapping_block_size, NULL);
+        self->node_mapping_block_size, NULL);
     if (ret != 0) {
         goto out;
     }
     /* allocate the segments and Fenwick trees */
     for (j = 0; j < self->num_labels; j++) {
         ret = object_heap_init(&self->segment_heap[j], sizeof(segment_t),
-               self->segment_block_size, segment_init);
+            self->segment_block_size, segment_init);
         if (ret != 0) {
             goto out;
         }
@@ -658,7 +658,7 @@ msp_free(msp_t *self)
     return ret;
 }
 
-static inline avl_node_t * MSP_WARN_UNUSED
+static inline avl_node_t *MSP_WARN_UNUSED
 msp_alloc_avl_node(msp_t *self)
 {
     avl_node_t *ret = NULL;
@@ -801,7 +801,7 @@ out:
 }
 
 static void
-msp_print_segment_chain(msp_t * MSP_UNUSED(self), segment_t *head, FILE *out)
+msp_print_segment_chain(msp_t *MSP_UNUSED(self), segment_t *head, FILE *out)
 {
     segment_t *s = head;
 
@@ -847,10 +847,10 @@ msp_verify_segments(msp_t *self, bool verify_breakpoints)
                     assert(u->right_mass == r_mass);
                     if (u->prev != NULL) {
                         s = recomb_map_mass_between(
-                                &self->recomb_map, u->prev->right, u->right);
+                            &self->recomb_map, u->prev->right, u->right);
                     } else {
                         s = recomb_map_mass_between_left_exclusive(
-                                &self->recomb_map, u->left, u->right);
+                            &self->recomb_map, u->left, u->right);
                     }
                     ss = fenwick_get_value(&self->links[k], u->id);
                     total_mass += ss;
@@ -865,23 +865,21 @@ msp_verify_segments(msp_t *self, bool verify_breakpoints)
                     u = u->next;
                 }
                 s = recomb_map_mass_between_left_exclusive(
-                        &self->recomb_map, left, right);
+                    &self->recomb_map, left, right);
                 alt_total_mass += s;
                 node = node->next;
             }
         }
-        assert(doubles_almost_equal(
-                    total_mass, fenwick_get_total(&self->links[k]), 1e-6));
+        assert(
+            doubles_almost_equal(total_mass, fenwick_get_total(&self->links[k]), 1e-6));
         assert(doubles_almost_equal(total_mass, alt_total_mass, 1e-6));
         assert(label_segments == object_heap_get_num_allocated(&self->segment_heap[k]));
     }
-    total_avl_nodes = msp_get_num_ancestors(self)
-            + avl_count(&self->breakpoints)
-            + avl_count(&self->overlap_counts);
-    assert(total_avl_nodes == object_heap_get_num_allocated(
-                &self->avl_node_heap));
+    total_avl_nodes = msp_get_num_ancestors(self) + avl_count(&self->breakpoints)
+                      + avl_count(&self->overlap_counts);
+    assert(total_avl_nodes == object_heap_get_num_allocated(&self->avl_node_heap));
     assert(total_avl_nodes - msp_get_num_ancestors(self)
-            == object_heap_get_num_allocated(&self->node_mapping_heap));
+           == object_heap_get_num_allocated(&self->node_mapping_heap));
     if (total_avl_nodes == label_segments) {
         /* do nothing - this is just to keep the compiler happy when
          * asserts are turned off.
@@ -1013,15 +1011,16 @@ msp_verify_overlaps(msp_t *self)
     segment_t *u;
     uint32_t j, label, count;
     overlap_counter_t counter;
-    int remaining_samples = (int) (self->num_sampling_events - self->next_sampling_event);
+    int remaining_samples
+        = (int) (self->num_sampling_events - self->next_sampling_event);
 
     int ok = overlap_counter_alloc(&counter, self->sequence_length, remaining_samples);
     assert(ok == 0);
 
     for (label = 0; label < self->num_labels; label++) {
         for (j = 0; j < self->num_populations; j++) {
-            for (node = (&self->populations[j].ancestors[label])->head;
-                    node != NULL; node = node->next) {
+            for (node = (&self->populations[j].ancestors[label])->head; node != NULL;
+                 node = node->next) {
                 u = (segment_t *) node->item;
                 while (u != NULL) {
                     overlap_counter_increment_interval(&counter, u->left, u->right);
@@ -1058,8 +1057,7 @@ msp_print_state(msp_t *self, FILE *out)
     sampling_event_t *se;
     double v;
     uint32_t j, k;
-    segment_t **ancestors = malloc(msp_get_num_ancestors(self)
-            * sizeof(segment_t *));
+    segment_t **ancestors = malloc(msp_get_num_ancestors(self) * sizeof(segment_t *));
 
     if (ancestors == NULL && msp_get_num_ancestors(self) != 0) {
         ret = MSP_ERR_NO_MEMORY;
@@ -1073,12 +1071,12 @@ msp_print_state(msp_t *self, FILE *out)
     fprintf(out, "model reference_size = %f\n", self->model.reference_size);
     if (self->model.type == MSP_MODEL_BETA) {
         fprintf(out, "\tbeta coalescent parameters: alpha = %f, truncation_point = %f\n",
-                self->model.params.beta_coalescent.alpha,
-                self->model.params.beta_coalescent.truncation_point);
+            self->model.params.beta_coalescent.alpha,
+            self->model.params.beta_coalescent.truncation_point);
     } else if (self->model.type == MSP_MODEL_DIRAC) {
         fprintf(out, "\tdirac coalescent parameters: psi = %f, c = %f\n",
-                self->model.params.dirac_coalescent.psi,
-                self->model.params.dirac_coalescent.c);
+            self->model.params.dirac_coalescent.psi,
+            self->model.params.dirac_coalescent.c);
     } else if (self->model.type == MSP_MODEL_SWEEP) {
         fprintf(out, "\tsweep @ locus = %f\n", self->model.params.sweep.locus);
         self->model.params.sweep.print_state(&self->model.params.sweep, out);
@@ -1086,13 +1084,14 @@ msp_print_state(msp_t *self, FILE *out)
     fprintf(out, "n = %d\n", self->num_samples);
     fprintf(out, "m = %f\n", self->sequence_length);
     fprintf(out, "gene_conversion_rate         = %f\n", self->gene_conversion_rate);
-    fprintf(out, "gene_conversion_track_length = %f\n", self->gene_conversion_track_length);
+    fprintf(
+        out, "gene_conversion_track_length = %f\n", self->gene_conversion_track_length);
     fprintf(out, "from_ts    = %p\n", (void *) self->from_ts);
     fprintf(out, "start_time = %f\n", self->start_time);
     fprintf(out, "Samples    = \n");
     for (j = 0; j < self->num_samples; j++) {
-        fprintf(out, "\t%d\tpopulation=%d\ttime=%f\n", j, (int) self->samples[j].population_id,
-                self->samples[j].time);
+        fprintf(out, "\t%d\tpopulation=%d\ttime=%f\n", j,
+            (int) self->samples[j].population_id, self->samples[j].time);
     }
     fprintf(out, "Sampling events:\n");
     for (j = 0; j < self->num_sampling_events; j++) {
@@ -1101,7 +1100,8 @@ msp_print_state(msp_t *self, FILE *out)
         }
         se = &self->sampling_events[j];
         fprintf(out, "\t");
-        fprintf(out, "%d @ %f in deme %d\n", (int) se->sample, se->time, (int) se->population_id);
+        fprintf(out, "%d @ %f in deme %d\n", (int) se->sample, se->time,
+            (int) se->population_id);
     }
     fprintf(out, "Demographic events:\n");
     for (de = self->demographic_events_head; de != NULL; de = de->next) {
@@ -1115,8 +1115,8 @@ msp_print_state(msp_t *self, FILE *out)
     for (j = 0; j < self->num_populations; j++) {
         fprintf(out, "\t");
         for (k = 0; k < self->num_populations; k++) {
-            fprintf(out, "%0.3f ",
-                self->migration_matrix[j * self->num_populations + k]);
+            fprintf(
+                out, "%0.3f ", self->migration_matrix[j * self->num_populations + k]);
         }
         fprintf(out, "\n");
     }
@@ -1124,8 +1124,7 @@ msp_print_state(msp_t *self, FILE *out)
     fprintf(out, "Population sizes\n");
     for (j = 0; j < self->num_labels; j++) {
         fprintf(out, "label %d\n", j);
-        fprintf(out, "\trecomb_mass = %f\n",
-                fenwick_get_total(&self->links[j]));
+        fprintf(out, "\trecomb_mass = %f\n", fenwick_get_total(&self->links[j]));
         for (k = 0; k < self->num_populations; k++) {
             fprintf(out, "\tpop_size[%d] = %d\n", k,
                 avl_count(&self->populations[k].ancestors[j]));
@@ -1150,8 +1149,8 @@ msp_print_state(msp_t *self, FILE *out)
             v = fenwick_get_value(&self->links[k], j);
             if (v != 0) {
                 fprintf(out, "\t%ld\ti=%d l=%f r=%f v=%d prev=%p next=%p\n", (long) v,
-                        (int) u->id, u->left, u->right,
-                        (int) u->value, (void *) u->prev, (void *) u->next);
+                    (int) u->id, u->left, u->right, (int) u->value, (void *) u->prev,
+                    (void *) u->next);
             }
         }
     }
@@ -1172,7 +1171,7 @@ msp_print_state(msp_t *self, FILE *out)
     for (j = 0; j < self->num_buffered_edges; j++) {
         edge = &self->buffered_edges[j];
         fprintf(out, "\t%f\t%f\t%d\t%d\n", edge->left, edge->right, edge->parent,
-                edge->child);
+            edge->child);
     }
     fprintf(out, "Memory heaps\n");
     for (j = 0; j < self->num_labels; j++) {
@@ -1193,14 +1192,14 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-msp_record_migration(msp_t *self, double left, double right,
-        node_id_t node, population_id_t source_pop, population_id_t dest_pop)
+msp_record_migration(msp_t *self, double left, double right, node_id_t node,
+    population_id_t source_pop, population_id_t dest_pop)
 {
     int ret = 0;
     double scaled_time = self->model.model_time_to_generations(&self->model, self->time);
 
-    ret = tsk_migration_table_add_row(&self->tables->migrations,
-            left, right, node, source_pop, dest_pop, scaled_time);
+    ret = tsk_migration_table_add_row(
+        &self->tables->migrations, left, right, node, source_pop, dest_pop, scaled_time);
     if (ret < 0) {
         ret = msp_set_tsk_error(ret);
         goto out;
@@ -1218,20 +1217,20 @@ msp_flush_edges(msp_t *self)
     tsk_edge_t edge;
 
     if (self->num_buffered_edges > 0) {
-        ret = tsk_squash_edges(self->buffered_edges, self->num_buffered_edges, &num_edges);
+        ret = tsk_squash_edges(
+            self->buffered_edges, self->num_buffered_edges, &num_edges);
         if (ret != 0) {
             ret = msp_set_tsk_error(ret);
             goto out;
         }
         for (j = 0; j < num_edges; j++) {
             edge = self->buffered_edges[j];
-            ret = tsk_edge_table_add_row(&self->tables->edges,
-                    edge.left, edge.right, edge.parent, edge.child);
+            ret = tsk_edge_table_add_row(
+                &self->tables->edges, edge.left, edge.right, edge.parent, edge.child);
             if (ret < 0) {
                 ret = msp_set_tsk_error(ret);
                 goto out;
             }
-
         }
         self->num_buffered_edges = 0;
     }
@@ -1242,7 +1241,7 @@ out:
 
 static int MSP_WARN_UNUSED
 msp_store_node(msp_t *self, uint32_t flags, double time, population_id_t population_id,
-        tsk_id_t individual)
+    tsk_id_t individual)
 {
     int ret = 0;
     double scaled_time = self->model.model_time_to_generations(&self->model, time);
@@ -1251,8 +1250,8 @@ msp_store_node(msp_t *self, uint32_t flags, double time, population_id_t populat
     if (ret != 0) {
         goto out;
     }
-    ret = tsk_node_table_add_row(&self->tables->nodes, flags, scaled_time, population_id,
-            individual, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &self->tables->nodes, flags, scaled_time, population_id, individual, NULL, 0);
     if (ret < 0) {
         goto out;
     }
@@ -1273,7 +1272,8 @@ msp_store_edge(msp_t *self, double left, double right, node_id_t parent, node_id
     if (self->num_buffered_edges == self->max_buffered_edges - 1) {
         /* Grow the array */
         self->max_buffered_edges *= 2;
-        edge = realloc(self->buffered_edges, self->max_buffered_edges * sizeof(tsk_edge_t));
+        edge = realloc(
+            self->buffered_edges, self->max_buffered_edges * sizeof(tsk_edge_t));
         if (edge == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
@@ -1332,7 +1332,7 @@ out:
 
 static int MSP_WARN_UNUSED
 msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
-        population_id_t dest_pop, label_id_t dest_label)
+    population_id_t dest_pop, label_id_t dest_label)
 {
     int ret = 0;
     segment_t *ind, *x, *y, *new_ind;
@@ -1343,7 +1343,8 @@ msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
     msp_free_avl_node(self, node);
 
     if (self->store_full_arg) {
-        ret = msp_store_node(self, MSP_NODE_IS_MIG_EVENT, self->time, dest_pop, TSK_NULL);
+        ret = msp_store_node(
+            self, MSP_NODE_IS_MIG_EVENT, self->time, dest_pop, TSK_NULL);
         if (ret != 0) {
             goto out;
         }
@@ -1357,8 +1358,8 @@ msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
         new_ind = ind;
         for (x = ind; x != NULL; x = x->next) {
             if (self->store_migrations) {
-                ret = msp_record_migration(self, x->left, x->right, x->value,
-                        x->population_id, dest_pop);
+                ret = msp_record_migration(
+                    self, x->left, x->right, x->value, x->population_id, dest_pop);
                 if (ret != 0) {
                     goto out;
                 }
@@ -1371,9 +1372,8 @@ msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
         new_ind = NULL;
         y = NULL;
         for (x = ind; x != NULL; x = x->next) {
-            y = msp_alloc_segment(self, x->left, x->right,
-                    x->left_mass, x->right_mass, x->value,
-                    x->population_id, dest_label, y, NULL);
+            y = msp_alloc_segment(self, x->left, x->right, x->left_mass, x->right_mass,
+                x->value, x->population_id, dest_label, y, NULL);
             if (new_ind == NULL) {
                 new_ind = y;
             } else {
@@ -1725,7 +1725,7 @@ msp_free_pedigree(msp_t *self)
 
 int MSP_WARN_UNUSED
 msp_set_pedigree(msp_t *self, size_t num_rows, tsk_id_t *inds, tsk_id_t *parents,
-        double *times, tsk_flags_t *is_sample)
+    double *times, tsk_flags_t *is_sample)
 {
     int ret;
     size_t i, j;
@@ -1818,7 +1818,7 @@ msp_pedigree_load_pop(msp_t *self)
 
     // Move segments from population into pedigree samples
     i = 0;
-    while(avl_count(&pop->ancestors[label]) > 0) {
+    while (avl_count(&pop->ancestors[label]) > 0) {
         node = pop->ancestors[label].head;
         sample_ix = i / ploidy;
         sample_ind = self->pedigree->samples[sample_ix];
@@ -1840,8 +1840,8 @@ out:
 }
 
 int MSP_WARN_UNUSED
-msp_pedigree_add_individual_segment(msp_t *self, individual_t *ind,
-        segment_t *segment, size_t parent_ix)
+msp_pedigree_add_individual_segment(
+    msp_t *self, individual_t *ind, segment_t *segment, size_t parent_ix)
 {
     int ret;
     avl_node_t *node;
@@ -1933,7 +1933,8 @@ msp_print_individual(msp_t *self, individual_t ind, FILE *out)
 {
     size_t j;
 
-    fprintf(out, "ID: %d, TSK_ID %u - Time: %f, Parents: [", ind.id, ind.tsk_id, ind.time);
+    fprintf(
+        out, "ID: %d, TSK_ID %u - Time: %f, Parents: [", ind.id, ind.tsk_id, ind.time);
 
     for (j = 0; j < self->pedigree->ploidy; j++) {
         if (ind.parents[j] != NULL) {
@@ -1971,7 +1972,7 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
     double k_mass;
     segment_t *y, *z, *tail;
     segment_t s1, s2;
-    segment_t *seg_tails[] = {&s1, &s2};
+    segment_t *seg_tails[] = { &s1, &s2 };
 
     k = msp_dtwf_generate_breakpoint(self, x->left);
     s1.next = NULL;
@@ -1996,9 +1997,8 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
             } else {
                 tail = seg_tails[ix];
             }
-            z = msp_alloc_segment(self, k, x->right,
-                    k_mass, x->right_mass, x->value,
-                    x->population_id, x->label, tail, x->next);
+            z = msp_alloc_segment(self, k, x->right, k_mass, x->right_mass, x->value,
+                x->population_id, x->label, tail, x->next);
             if (z == NULL) {
                 ret = MSP_ERR_NO_MEMORY;
                 goto out;
@@ -2021,8 +2021,7 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
             assert(x->left < x->right);
             x = z;
             k = msp_dtwf_generate_breakpoint(self, k);
-        }
-        else if (x->right <= k && y != NULL && y->left >= k) {
+        } else if (x->right <= k && y != NULL && y->left >= k) {
             // Recombine in gap between segment and the next
             x->next = NULL;
             y->prev = NULL;
@@ -2057,9 +2056,9 @@ out:
     return ret;
 }
 
-
 static double
-msp_init_segments_and_compute_breakpoint(msp_t *self, label_id_t label, segment_t **x_ret, segment_t **y_ret)
+msp_init_segments_and_compute_breakpoint(
+    msp_t *self, label_id_t label, segment_t **x_ret, segment_t **y_ret)
 {
     double h, t, k;
     segment_t *x, *y;
@@ -2091,9 +2090,8 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
     k = msp_init_segments_and_compute_breakpoint(self, label, &x, &y);
     k_mass = recomb_map_position_to_mass(&self->recomb_map, k);
     if (y->left < k) {
-        z = msp_alloc_segment(self, k, y->right,
-                k_mass, y->right_mass, y->value,
-                y->population_id, y->label, NULL, y->next);
+        z = msp_alloc_segment(self, k, y->right, k_mass, y->right_mass, y->value,
+            y->population_id, y->label, NULL, y->next);
         if (z == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
@@ -2129,7 +2127,8 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
     }
     if (self->store_full_arg) {
         /* Store the edges for the LHS */
-        ret = msp_store_node(self, MSP_NODE_IS_RE_EVENT, self->time, lhs_tail->population_id, TSK_NULL);
+        ret = msp_store_node(
+            self, MSP_NODE_IS_RE_EVENT, self->time, lhs_tail->population_id, TSK_NULL);
         if (ret != 0) {
             goto out;
         }
@@ -2138,7 +2137,8 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
             goto out;
         }
         /* Store the edges for the RHS */
-        ret = msp_store_node(self, MSP_NODE_IS_RE_EVENT, self->time, z->population_id, TSK_NULL);
+        ret = msp_store_node(
+            self, MSP_NODE_IS_RE_EVENT, self->time, z->population_id, TSK_NULL);
         if (ret != 0) {
             goto out;
         }
@@ -2162,15 +2162,15 @@ out:
 
 /* Helper function for doing GC */
 static int MSP_WARN_UNUSED
-msp_cut_right_break(msp_t *self, segment_t *lhs_tail, segment_t *y, segment_t *new_segment,
-        double track_end)
+msp_cut_right_break(msp_t *self, segment_t *lhs_tail, segment_t *y,
+    segment_t *new_segment, double track_end)
 {
     int ret = 0;
     double track_end_mass = recomb_map_position_to_mass(&self->recomb_map, track_end);
     assert(lhs_tail != NULL);
     lhs_tail->next = new_segment;
     msp_set_segment_mass(self, new_segment, lhs_tail);
-    if (y->next != NULL){
+    if (y->next != NULL) {
         y->next->prev = new_segment;
     }
     y->next = NULL;
@@ -2213,7 +2213,7 @@ msp_gene_conversion_within_event(msp_t *self, label_id_t label)
     k_plus_tl_mass = recomb_map_position_to_mass(&self->recomb_map, k + tl);
     assert(k >= 0 && k < self->sequence_length);
     /* Check if the gene conversion falls between segments and hence has no effect */
-    if (y->left >= k + tl){
+    if (y->left >= k + tl) {
         self->num_gc_events++;
         self->num_noneffective_gc_events++;
         return 0;
@@ -2226,31 +2226,28 @@ msp_gene_conversion_within_event(msp_t *self, label_id_t label)
         /* Both breaks are within the same segment */
         if (k <= y->left) {
             y->prev = NULL;
-            z2 = msp_alloc_segment(self, k + tl, y->right,
-                    k_plus_tl_mass, y->right_mass, y->value,
-                    y->population_id, y->label, x, y->next);
+            z2 = msp_alloc_segment(self, k + tl, y->right, k_plus_tl_mass, y->right_mass,
+                y->value, y->population_id, y->label, x, y->next);
             if (z2 == NULL) {
                 ret = MSP_ERR_NO_MEMORY;
                 goto out;
             }
             lhs_tail = x;
             ret = msp_cut_right_break(self, lhs_tail, y, z2, k + tl);
-            if (ret != 0){
+            if (ret != 0) {
                 goto out;
             }
             z = y;
         } else {
-            z = msp_alloc_segment(self, k, k + tl,
-                    k_mass, k_plus_tl_mass, y->value,
-                    y->population_id, y->label, NULL, NULL);
-            z2 = msp_alloc_segment(self, k + tl, y->right,
-                    k_plus_tl_mass, y->right_mass, y->value,
-                    y->population_id, y->label, y, y->next);
+            z = msp_alloc_segment(self, k, k + tl, k_mass, k_plus_tl_mass, y->value,
+                y->population_id, y->label, NULL, NULL);
+            z2 = msp_alloc_segment(self, k + tl, y->right, k_plus_tl_mass, y->right_mass,
+                y->value, y->population_id, y->label, y, y->next);
             if (z == NULL || z2 == NULL) {
                 ret = MSP_ERR_NO_MEMORY;
                 goto out;
             }
-            if (y->next != NULL){
+            if (y->next != NULL) {
                 y->next->prev = z2;
             }
             y->next = z2;
@@ -2274,12 +2271,12 @@ msp_gene_conversion_within_event(msp_t *self, label_id_t label)
             }
             lhs_tail = y;
         }
-    } else{
+    } else {
         /* Breaks are in separate segments */
 
         /* Get the segment y2 containing the end of the conversion tract*/
         y2 = y;
-        while(y2 != NULL && k + tl >= y2->right){
+        while (y2 != NULL && k + tl >= y2->right) {
             y2 = y2->next;
         }
         /* Process left break */
@@ -2291,9 +2288,8 @@ msp_gene_conversion_within_event(msp_t *self, label_id_t label)
             z = y;
             lhs_tail = x;
         } else {
-            z = msp_alloc_segment(self, k, y->right,
-                    k_mass, y->right_mass, y->value,
-                    y->population_id, y->label, NULL, y->next);
+            z = msp_alloc_segment(self, k, y->right, k_mass, y->right_mass, y->value,
+                y->population_id, y->label, NULL, y->next);
             if (z == NULL) {
                 ret = MSP_ERR_NO_MEMORY;
                 goto out;
@@ -2319,15 +2315,15 @@ msp_gene_conversion_within_event(msp_t *self, label_id_t label)
         if (y2 != NULL) {
             if (y2->left < k + tl) {
                 z2 = msp_alloc_segment(self, k + tl, y2->right,
-                        recomb_map_position_to_mass(&self->recomb_map, k + tl),
-                        y2->right_mass, y2->value,
-                        y2->population_id, y2->label, lhs_tail, y2->next);
+                    recomb_map_position_to_mass(&self->recomb_map, k + tl),
+                    y2->right_mass, y2->value, y2->population_id, y2->label, lhs_tail,
+                    y2->next);
                 if (z2 == NULL) {
                     ret = MSP_ERR_NO_MEMORY;
                     goto out;
                 }
                 ret = msp_cut_right_break(self, lhs_tail, y2, z2, k + tl);
-                if (ret != 0){
+                if (ret != 0) {
                     goto out;
                 }
                 if (z2->prev == NULL) {
@@ -2376,7 +2372,7 @@ msp_get_cleft_total(msp_t *self)
                 while (u->next != NULL) {
                     u = u->next;
                 }
-                right = u -> right;
+                right = u->right;
                 dist = right - left;
                 ret += 1 - pow(x, dist - 1);
             }
@@ -2404,14 +2400,14 @@ msp_find_cleft_individual(msp_t *self, double rvalue, size_t *segment_id, double
         for (label = 0; label < (label_id_t) self->num_labels; label++) {
             population_ancestors = &self->populations[j].ancestors[label];
             for (node = population_ancestors->head; node != NULL; node = node->next) {
-                if (rvalue > 0){
+                if (rvalue > 0) {
                     u = (segment_t *) node->item;
                     left = u->left;
                     head_id = u->id;
                     while (u->next != NULL) {
                         u = u->next;
                     }
-                    right = u -> right;
+                    right = u->right;
                     distance = right - left;
                     rvalue -= 1 - pow(x, distance - 1);
                 }
@@ -2453,20 +2449,19 @@ msp_gene_conversion_left_event(msp_t *self, label_id_t label)
     k = y->left + tl;
     k_mass = recomb_map_position_to_mass(&self->recomb_map, k);
 
-    while (y->right <= k){
+    while (y->right <= k) {
         y = y->next;
     }
     x = y->prev;
-    if (y->left < k){
+    if (y->left < k) {
         /*make new segment*/
-        z = msp_alloc_segment(self, k, y->right,
-                k_mass, y->right_mass, y->value,
-                y->population_id, y->label, NULL, y->next);
+        z = msp_alloc_segment(self, k, y->right, k_mass, y->right_mass, y->value,
+            y->population_id, y->label, NULL, y->next);
         if (z == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
         }
-        if (y->next != NULL){
+        if (y->next != NULL) {
             y->next->prev = z;
         }
         y->next = NULL;
@@ -2518,7 +2513,7 @@ msp_reject_ca_event(msp_t *self, segment_t *a, segment_t *b)
              * be strictly greater than zero, as it doesn't allow
              * directly adjacent segments to coalesce */
             if ((model == MSP_MODEL_SMC_PRIME && overlap >= 0)
-                    || (overlap > 0)) { /* SMC */
+                || (overlap > 0)) { /* SMC */
                 ret = 0;
                 break;
             }
@@ -2537,7 +2532,7 @@ msp_set_segment_left_endpoint(msp_t *self, segment_t *seg, double left)
 
 static int MSP_WARN_UNUSED
 msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t label,
-        segment_t *a, segment_t *b)
+    segment_t *a, segment_t *b)
 {
     int ret = 0;
     bool coalescence = false;
@@ -2578,9 +2573,8 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                 x = x->next;
                 alpha->next = NULL;
             } else if (x->left != y->left) {
-                alpha = msp_alloc_segment(self, x->left, y->left,
-                        x->left_mass, y->left_mass, x->value,
-                        x->population_id, x->label, NULL, NULL);
+                alpha = msp_alloc_segment(self, x->left, y->left, x->left_mass,
+                    y->left_mass, x->value, x->population_id, x->label, NULL, NULL);
                 if (alpha == NULL) {
                     ret = MSP_ERR_NO_MEMORY;
                     goto out;
@@ -2637,10 +2631,9 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                         r = nm->left;
                     }
                     alpha = msp_alloc_segment(self, l, r,
-                            recomb_map_position_to_mass(&self->recomb_map, l),
-                            recomb_map_position_to_mass(&self->recomb_map, r),
-                            v, population_id, label,
-                            NULL, NULL);
+                        recomb_map_position_to_mass(&self->recomb_map, l),
+                        recomb_map_position_to_mass(&self->recomb_map, r), v,
+                        population_id, label, NULL, NULL);
                     if (alpha == NULL) {
                         ret = MSP_ERR_NO_MEMORY;
                         goto out;
@@ -2684,7 +2677,8 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                     // we pre-empt the fact that values will be set equal later
                     defrag_required |= z->right == alpha->left;
                 } else {
-                    defrag_required |= z->right == alpha->left && z->value == alpha->value;
+                    defrag_required
+                        |= z->right == alpha->left && z->value == alpha->value;
                 }
                 z->next = alpha;
                 msp_set_segment_mass(self, alpha, z);
@@ -2694,8 +2688,9 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
         }
     }
     if (self->store_full_arg) {
-        if (! coalescence) {
-            ret = msp_store_node(self, MSP_NODE_IS_CA_EVENT, self->time, population_id, TSK_NULL);
+        if (!coalescence) {
+            ret = msp_store_node(
+                self, MSP_NODE_IS_CA_EVENT, self->time, population_id, TSK_NULL);
             if (ret != 0) {
                 goto out;
             }
@@ -2716,7 +2711,6 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
         if (ret != 0) {
             goto out;
         }
-
     }
 out:
     return ret;
@@ -2759,7 +2753,7 @@ msp_priority_queue_pop(msp_t *self, avl_tree_t *Q)
  */
 static int MSP_WARN_UNUSED
 msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
-        label_id_t label, segment_t **merged_segment, tsk_id_t individual)
+    label_id_t label, segment_t **merged_segment, tsk_id_t individual)
 {
     int ret = MSP_ERR_GENERIC;
     bool coalescence = false;
@@ -2804,10 +2798,8 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
         if (h == 1) {
             x = H[0];
             if (node != NULL && next_l < x->right) {
-                alpha = msp_alloc_segment(self, x->left, next_l,
-                        x->left_mass, next_l_mass,
-                        x->value,
-                        x->population_id, x->label, NULL, NULL);
+                alpha = msp_alloc_segment(self, x->left, next_l, x->left_mass,
+                    next_l_mass, x->value, x->population_id, x->label, NULL, NULL);
                 if (alpha == NULL) {
                     ret = MSP_ERR_NO_MEMORY;
                     goto out;
@@ -2874,10 +2866,9 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                     r = nm->left;
                 }
                 alpha = msp_alloc_segment(self, l, r,
-                        recomb_map_position_to_mass(&self->recomb_map, l),
-                        recomb_map_position_to_mass(&self->recomb_map, r),
-                        v, population_id,
-                        label, NULL, NULL);
+                    recomb_map_position_to_mass(&self->recomb_map, l),
+                    recomb_map_position_to_mass(&self->recomb_map, r), v, population_id,
+                    label, NULL, NULL);
                 if (alpha == NULL) {
                     ret = MSP_ERR_NO_MEMORY;
                     goto out;
@@ -2905,8 +2896,8 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                 } else {
                     /* If we've fully coalesced, we stop tracking the segment in
                        the pedigree. */
-                    if (self->pedigree != NULL &&
-                            self->pedigree->state == MSP_PED_STATE_CLIMBING) {
+                    if (self->pedigree != NULL
+                        && self->pedigree->state == MSP_PED_STATE_CLIMBING) {
                         if (!set_merged) {
                             *merged_segment = NULL;
                         }
@@ -2920,10 +2911,10 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                 msp_set_single_segment_mass(self, alpha);
                 /* Pedigree doesn't currently track lineages in Populations, so
                    keep reference to merged segments instead */
-                if (self->pedigree != NULL &&
-                        self->pedigree->state == MSP_PED_STATE_CLIMBING) {
+                if (self->pedigree != NULL
+                    && self->pedigree->state == MSP_PED_STATE_CLIMBING) {
                     assert(merged_segment != NULL);
-                    set_merged = true; //TODO: Must be better way of checking this
+                    set_merged = true; // TODO: Must be better way of checking this
                     *merged_segment = alpha;
                 } else {
                     ret = msp_insert_individual(self, alpha);
@@ -2936,8 +2927,8 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                     // we pre-empt the fact that values will be set equal later
                     defrag_required |= z->right == alpha->left;
                 } else {
-                    defrag_required |=
-                        z->right == alpha->left && z->value == alpha->value;
+                    defrag_required
+                        |= z->right == alpha->left && z->value == alpha->value;
                 }
                 z->next = alpha;
                 msp_set_segment_mass(self, alpha, z);
@@ -2947,8 +2938,9 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
         }
     }
     if (self->store_full_arg) {
-        if (! coalescence) {
-            ret = msp_store_node(self, MSP_NODE_IS_CA_EVENT, self->time, population_id, individual);
+        if (!coalescence) {
+            ret = msp_store_node(
+                self, MSP_NODE_IS_CA_EVENT, self->time, population_id, individual);
             if (ret != 0) {
                 goto out;
             }
@@ -3044,9 +3036,9 @@ msp_insert_sample(msp_t *self, node_id_t sample, population_id_t population)
     double seq_len = self->sequence_length;
     segment_t *u;
 
-    u = msp_alloc_segment(self, 0, seq_len,
-            0, recomb_map_position_to_mass(&self->recomb_map, seq_len),
-            sample, population, 0, NULL, NULL);
+    u = msp_alloc_segment(self, 0, seq_len, 0,
+        recomb_map_position_to_mass(&self->recomb_map, seq_len), sample, population, 0,
+        NULL, NULL);
     if (u == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
@@ -3061,10 +3053,8 @@ out:
 }
 
 static inline int
-msp_allocate_root_segments(msp_t *self, tsk_tree_t *tree,
-        double left, double right,
-        segment_t * restrict *root_segments_head,
-        segment_t * restrict *root_segments_tail)
+msp_allocate_root_segments(msp_t *self, tsk_tree_t *tree, double left, double right,
+    segment_t *restrict *root_segments_head, segment_t *restrict *root_segments_tail)
 {
     int ret = 0;
     tsk_table_collection_t *tables = self->from_ts->tables;
@@ -3084,10 +3074,9 @@ msp_allocate_root_segments(msp_t *self, tsk_tree_t *tree,
         }
         if (root_segments_head[root] == NULL) {
             seg = msp_alloc_segment(self, left, right,
-                    recomb_map_position_to_mass(&self->recomb_map, left),
-                    recomb_map_position_to_mass(&self->recomb_map, right),
-                    root, population, label,
-                    NULL, NULL);
+                recomb_map_position_to_mass(&self->recomb_map, left),
+                recomb_map_position_to_mass(&self->recomb_map, right), root, population,
+                label, NULL, NULL);
             if (seg == NULL) {
                 ret = MSP_ERR_NO_MEMORY;
                 goto out;
@@ -3101,10 +3090,9 @@ msp_allocate_root_segments(msp_t *self, tsk_tree_t *tree,
                 tail->right_mass = recomb_map_position_to_mass(&self->recomb_map, right);
             } else {
                 seg = msp_alloc_segment(self, left, right,
-                        recomb_map_position_to_mass(&self->recomb_map, left),
-                        recomb_map_position_to_mass(&self->recomb_map, right),
-                        root, population, label,
-                        tail, NULL);
+                    recomb_map_position_to_mass(&self->recomb_map, left),
+                    recomb_map_position_to_mass(&self->recomb_map, right), root,
+                    population, label, tail, NULL);
                 if (seg == NULL) {
                     ret = MSP_ERR_NO_MEMORY;
                     goto out;
@@ -3153,8 +3141,8 @@ msp_reset_from_ts(msp_t *self)
         overlap = 0;
         if (num_roots > 1) {
             overlap = num_roots;
-            ret = msp_allocate_root_segments(self, &t, t.left, t.right,
-                    root_segments_head, root_segments_tail);
+            ret = msp_allocate_root_segments(
+                self, &t, t.left, t.right, root_segments_head, root_segments_tail);
             if (ret != 0) {
                 goto out;
             }
@@ -3231,8 +3219,8 @@ msp_reset_from_samples(msp_t *self)
         if (self->pedigree != NULL) {
             /* If we're doing pedigree simulations, assign 'ploidy' nodes
              * per individual. */
-            assert(self->pedigree->num_samples * self->pedigree->ploidy ==
-                    self->num_samples);
+            assert(self->pedigree->num_samples * self->pedigree->ploidy
+                   == self->num_samples);
             sample_idx = (size_t) u / self->pedigree->ploidy;
 
             // TODO: When pedigrees and populations are properly sorted out,
@@ -3241,8 +3229,8 @@ msp_reset_from_samples(msp_t *self)
             id_str_len = (tsk_size_t) ceil(log10(ind->id + 1));
             sprintf(id_str, "%d", ind->id);
             if (ind->tsk_id == TSK_NULL) {
-                ret = tsk_individual_table_add_row(&self->tables->individuals, 0,
-                        NULL, 0, id_str, id_str_len);
+                ret = tsk_individual_table_add_row(
+                    &self->tables->individuals, 0, NULL, 0, id_str, id_str_len);
                 if (ret < 0) {
                     goto out;
                 }
@@ -3250,9 +3238,8 @@ msp_reset_from_samples(msp_t *self)
             }
             tsk_ind = ind->tsk_id;
         }
-        ret = msp_store_node(self, TSK_NODE_IS_SAMPLE,
-                self->samples[u].time,
-                self->samples[u].population_id, tsk_ind);
+        ret = msp_store_node(self, TSK_NODE_IS_SAMPLE, self->samples[u].time,
+            self->samples[u].population_id, tsk_ind);
         if (ret != 0) {
             goto out;
         }
@@ -3279,7 +3266,7 @@ msp_apply_demographic_events(msp_t *self)
     /* Process all events with equal time in one block. */
     self->time = self->next_demographic_event->time;
     while (self->next_demographic_event != NULL
-            && self->next_demographic_event->time == self->time) {
+           && self->next_demographic_event->time == self->time) {
         /* We skip ahead to the start time for the next demographic
          * event, and use its change_state method to update the
          * state of the simulation.
@@ -3336,8 +3323,8 @@ msp_reset(msp_t *self)
         goto out;
     }
     self->next_demographic_event = self->demographic_events_head;
-    memcpy(self->migration_matrix, self->initial_migration_matrix,
-            N * N * sizeof(double));
+    memcpy(
+        self->migration_matrix, self->initial_migration_matrix, N * N * sizeof(double));
     self->next_sampling_event = 0;
     self->num_re_events = 0;
     self->num_gc_events = 0;
@@ -3377,8 +3364,8 @@ msp_initialise_from_samples(msp_t *self)
     self->num_sampling_events = self->num_samples - initial_samples;
     self->sampling_events = NULL;
     if (self->num_sampling_events > 0) {
-        self->sampling_events = malloc(self->num_sampling_events *
-                sizeof(sampling_event_t));
+        self->sampling_events
+            = malloc(self->num_sampling_events * sizeof(sampling_event_t));
         if (self->sampling_events == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
@@ -3388,15 +3375,14 @@ msp_initialise_from_samples(msp_t *self)
             if (self->samples[j].time > self->start_time) {
                 self->sampling_events[k].sample = (node_id_t) j;
                 self->sampling_events[k].time = self->samples[j].time;
-                self->sampling_events[k].population_id =
-                    self->samples[j].population_id;
+                self->sampling_events[k].population_id = self->samples[j].population_id;
                 k++;
             }
         }
         assert(k == self->num_sampling_events);
         /* Now we must sort the sampling events by time. */
-        qsort(self->sampling_events, self->num_sampling_events,
-                sizeof(sampling_event_t), cmp_sampling_event);
+        qsort(self->sampling_events, self->num_sampling_events, sizeof(sampling_event_t),
+            cmp_sampling_event);
     }
 out:
     return ret;
@@ -3421,7 +3407,7 @@ msp_initialise_from_ts(msp_t *self)
     root_time = 0.0;
     for (j = 0; j < num_nodes; j++) {
         model_time = self->model.generations_to_model_time(
-                &self->model, self->tables->nodes.time[j]);
+            &self->model, self->tables->nodes.time[j]);
         root_time = GSL_MAX(model_time, root_time);
         /* TODO we can catch ancient samples here and insert them as sampling
          * events, if we wish to support this. */
@@ -3512,7 +3498,8 @@ get_population_size(population_t *pop, double t)
 /* Given the specified rate, return the waiting time until the next common ancestor
  * event for the specified population */
 static double
-msp_get_common_ancestor_waiting_time_from_rate(msp_t *self, population_t *pop, double lambda)
+msp_get_common_ancestor_waiting_time_from_rate(
+    msp_t *self, population_t *pop, double lambda)
 {
     double ret = DBL_MAX;
     double alpha = pop->growth_rate;
@@ -3565,9 +3552,8 @@ static int MSP_WARN_UNUSED
 msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
 {
     int ret = 0;
-    double lambda, t_temp, t_wait, ca_t_wait, re_t_wait,
-           gc_in_t_wait, gc_left_t_wait, mig_t_wait,
-           sampling_event_time, demographic_event_time;
+    double lambda, t_temp, t_wait, ca_t_wait, re_t_wait, gc_in_t_wait, gc_left_t_wait,
+        mig_t_wait, sampling_event_time, demographic_event_time;
     double recomb_mass, total_recomb_rate;
     uint32_t j, k, n;
     population_id_t ca_pop_id, mig_source_pop, mig_dest_pop;
@@ -3599,13 +3585,14 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
         if (self->gene_conversion_rate > 0) {
             /* Gene conversion within segments */
             if (recomb_mass > 0.0) {
-                lambda = recomb_map_mass_to_position(
-                    &self->recomb_map, recomb_mass) * self->gene_conversion_rate;
+                lambda = recomb_map_mass_to_position(&self->recomb_map, recomb_mass)
+                         * self->gene_conversion_rate;
             } else {
-                total_recomb_rate = recomb_map_get_total_recombination_rate(
-                                        &self->recomb_map);
+                total_recomb_rate
+                    = recomb_map_get_total_recombination_rate(&self->recomb_map);
                 if (total_recomb_rate == 0.0) {
-                    printf("recombination rate zero and gene conversion rate > 0 currently not supported\n");
+                    printf("recombination rate zero and gene conversion rate > 0 "
+                           "currently not supported\n");
                     assert(total_recomb_rate > 0.0);
                 } else {
                     lambda = 0.0;
@@ -3619,7 +3606,7 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
             /* Gene conversion to the left of initial segments */
             gc_left_t_wait = DBL_MAX;
             lambda = msp_get_cleft_total(self) * self->gene_conversion_rate
-                * self->gene_conversion_track_length;
+                     * self->gene_conversion_track_length;
             if (lambda != 0.0) {
                 gc_left_t_wait = gsl_ran_exponential(self->rng, 1.0 / lambda);
             }
@@ -3629,7 +3616,8 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
         ca_t_wait = DBL_MAX;
         ca_pop_id = 0;
         for (j = 0; j < self->num_populations; j++) {
-            t_temp = self->get_common_ancestor_waiting_time(self, (population_id_t) j, label);
+            t_temp = self->get_common_ancestor_waiting_time(
+                self, (population_id_t) j, label);
             if (t_temp < ca_t_wait) {
                 ca_t_wait = t_temp;
                 ca_pop_id = (population_id_t) j;
@@ -3659,13 +3647,12 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
                 }
             }
         }
-        t_wait = GSL_MIN(mig_t_wait,
-            GSL_MIN(gc_in_t_wait,
-                GSL_MIN(gc_left_t_wait,
-                    GSL_MIN(re_t_wait, ca_t_wait))));
+        t_wait = GSL_MIN(
+            mig_t_wait, GSL_MIN(gc_in_t_wait,
+                            GSL_MIN(gc_left_t_wait, GSL_MIN(re_t_wait, ca_t_wait))));
         if (self->next_demographic_event == NULL
-                && self->next_sampling_event == self->num_sampling_events
-                && t_wait == DBL_MAX) {
+            && self->next_sampling_event == self->num_sampling_events
+            && t_wait == DBL_MAX) {
             ret = MSP_ERR_INFINITE_WAITING_TIME;
             goto out;
         }
@@ -3683,7 +3670,7 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
          * any of the events would cause the time to be >= max_time, we exit
          */
         if (sampling_event_time < t_temp
-                && sampling_event_time < demographic_event_time) {
+            && sampling_event_time < demographic_event_time) {
             se = &self->sampling_events[self->next_sampling_event];
             if (se->time >= max_time) {
                 ret = MSP_EXIT_MAX_TIME;
@@ -3691,9 +3678,9 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
             }
             self->time = se->time;
             /* Add in all samples with this time */
-            while (self->next_sampling_event < self->num_sampling_events &&
-                    self->sampling_events[self->next_sampling_event].time
-                        == sampling_event_time) {
+            while (self->next_sampling_event < self->num_sampling_events
+                   && self->sampling_events[self->next_sampling_event].time
+                          == sampling_event_time) {
                 se = self->sampling_events + self->next_sampling_event;
                 ret = msp_insert_sample(self, se->sample, se->population_id);
                 if (ret != 0) {
@@ -3795,8 +3782,8 @@ msp_pedigree_climb(msp_t *self)
                 sprintf(id_str, "%d", parent->id);
                 id_str_len = (tsk_size_t) ceil(log10(parent->id + 1));
                 assert(id_str_len > 0);
-                ret = tsk_individual_table_add_row(&self->tables->individuals, 0,
-                        NULL, 0, id_str, id_str_len);
+                ret = tsk_individual_table_add_row(
+                    &self->tables->individuals, 0, NULL, 0, id_str, id_str_len);
                 if (ret < 0) {
                     goto out;
                 }
@@ -3809,8 +3796,8 @@ msp_pedigree_climb(msp_t *self)
 
             /* Merge segments inherited from this ind and recombine */
             // TODO: Make sure population gets properly set when more than one
-            ret = msp_merge_ancestors(self, segments, 0, 0, &merged_segment,
-                    node_tsk_id);
+            ret = msp_merge_ancestors(
+                self, segments, 0, 0, &merged_segment, node_tsk_id);
             if (ret != 0) {
                 goto out;
             }
@@ -3920,7 +3907,7 @@ msp_dtwf_generation(msp_t *self)
         // Allocate memory for linked list of offspring per parent
         parents = calloc(N, sizeof(segment_list_t *));
         segment_mem = malloc(msp_get_num_ancestors(self) * sizeof(segment_list_t));
-        if (parents == NULL || segment_mem == NULL){
+        if (parents == NULL || segment_mem == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
         }
@@ -3975,7 +3962,7 @@ msp_dtwf_generation(msp_t *self)
                 }
             }
             // Merge segments in each parental chromosome
-            for (i = 0; i < 2; i ++) {
+            for (i = 0; i < 2; i++) {
                 segments_to_merge = avl_count(&Q[i]);
                 if (segments_to_merge == 1) {
                     msp_priority_queue_pop(self, &Q[i]);
@@ -3984,11 +3971,11 @@ msp_dtwf_generation(msp_t *self)
                     if (segments_to_merge == 2) {
                         ind1 = msp_priority_queue_pop(self, &Q[i]);
                         ind2 = msp_priority_queue_pop(self, &Q[i]);
-                        ret = msp_merge_two_ancestors(self,
-                                (population_id_t) j, label, ind1, ind2);
+                        ret = msp_merge_two_ancestors(
+                            self, (population_id_t) j, label, ind1, ind2);
                     } else {
-                        ret = msp_merge_ancestors(self,
-                                &Q[i], (population_id_t) j, label, NULL, TSK_NULL);
+                        ret = msp_merge_ancestors(
+                            self, &Q[i], (population_id_t) j, label, NULL, TSK_NULL);
                     }
                 }
                 if (ret != 0) {
@@ -4008,8 +3995,9 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-msp_store_simultaneous_migration_events(msp_t *self, avl_tree_t *nodes,
-       population_id_t source_pop, label_id_t label) {
+msp_store_simultaneous_migration_events(
+    msp_t *self, avl_tree_t *nodes, population_id_t source_pop, label_id_t label)
+{
     int ret = 0;
     uint32_t j;
     avl_node_t *node;
@@ -4030,8 +4018,9 @@ msp_store_simultaneous_migration_events(msp_t *self, avl_tree_t *nodes,
 }
 
 static int MSP_WARN_UNUSED
-msp_simultaneous_migration_event(msp_t *self, avl_tree_t *nodes,
-        population_id_t source_pop, population_id_t dest_pop) {
+msp_simultaneous_migration_event(
+    msp_t *self, avl_tree_t *nodes, population_id_t source_pop, population_id_t dest_pop)
+{
     int ret = 0;
     avl_node_t *node;
     size_t index;
@@ -4082,7 +4071,7 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
     n = malloc(self->num_populations * sizeof(int));
     mig_tmp = malloc(self->num_populations * sizeof(double));
     if (n == NULL || mig_tmp == NULL) {
-        ret  = MSP_ERR_NO_MEMORY;
+        ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
 
@@ -4100,9 +4089,9 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
 
         /* Following SLiM, we perform migrations prior to selecting
          * parents for the current generation */
-        node_trees = malloc(self->num_populations * self->num_populations
-                * sizeof(avl_tree_t));
-        if (node_trees == NULL){
+        node_trees
+            = malloc(self->num_populations * self->num_populations * sizeof(avl_tree_t));
+        if (node_trees == NULL) {
             ret = MSP_ERR_NO_MEMORY;
             goto out;
         }
@@ -4121,8 +4110,7 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
 
             mig_tmp[j] = 1 - sum;
             N = avl_count(&self->populations[j].ancestors[label]);
-            gsl_ran_multinomial(
-                    self->rng, self->num_populations, N, mig_tmp, n);
+            gsl_ran_multinomial(self->rng, self->num_populations, N, mig_tmp, n);
 
             for (k = 0; k < self->num_populations; k++) {
                 if (k == j) {
@@ -4142,7 +4130,7 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
 
                 for (i = 0; i < n[k]; i++) {
                     ret = msp_store_simultaneous_migration_events(
-                            self, nodes, mig_source_pop, label);
+                        self, nodes, mig_source_pop, label);
                     if (ret != 0) {
                         goto out;
                     }
@@ -4158,7 +4146,7 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
                 mig_source_pop = (population_id_t) j;
                 mig_dest_pop = (population_id_t) k;
                 ret = msp_simultaneous_migration_event(
-                        self, nodes, mig_source_pop, mig_dest_pop);
+                    self, nodes, mig_source_pop, mig_dest_pop);
                 if (ret != 0) {
                     goto out;
                 }
@@ -4172,8 +4160,8 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
          * generation, and throw off the time between generations. We avoid
          * this by saving the current time and returning to it. */
         cur_time = self->time;
-        while (self->next_demographic_event != NULL &&
-                self->next_demographic_event->time <= cur_time) {
+        while (self->next_demographic_event != NULL
+               && self->next_demographic_event->time <= cur_time) {
             if (self->next_demographic_event->time >= max_time) {
                 ret = MSP_EXIT_MAX_TIME;
                 goto out;
@@ -4189,8 +4177,8 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
             goto out;
         }
 
-        while (self->next_sampling_event < self->num_sampling_events &&
-                self->sampling_events[self->next_sampling_event].time <= self->time) {
+        while (self->next_sampling_event < self->num_sampling_events
+               && self->sampling_events[self->next_sampling_event].time <= self->time) {
             se = self->sampling_events + self->next_sampling_event;
             /* The sampling event doesn't modify the tables, so we don't need to
              * catch it here */
@@ -4289,8 +4277,8 @@ msp_change_label(msp_t *self, segment_t *ind, label_id_t label)
 }
 
 static int
-msp_sweep_recombination_event(msp_t *self, label_id_t label,
-        double sweep_locus, double population_frequency)
+msp_sweep_recombination_event(
+    msp_t *self, label_id_t label, double sweep_locus, double population_frequency)
 {
     int ret = 0;
     segment_t *lhs, *rhs;
@@ -4341,8 +4329,8 @@ msp_run_sweep(msp_t *self)
     double recomb_mass;
     unsigned long events = 0;
     label_id_t label;
-    double rec_rates[] = {0.0, 0.0};
-    double sweep_pop_sizes[] = {0.0, 0.0};
+    double rec_rates[] = { 0.0, 0.0 };
+    double sweep_pop_sizes[] = { 0.0, 0.0 };
     double event_prob, event_rand, tmp_rand, e_sum, pop_size;
     double p_coal_b, p_coal_B, total_rate, sweep_pop_tot_rate;
     double p_rec_b, p_rec_B;
@@ -4364,7 +4352,7 @@ msp_run_sweep(msp_t *self)
      * and max_steps parameters. */
 
     ret = model->params.sweep.generate_trajectory(
-            &model->params.sweep, self, &num_steps, &time, &allele_frequency);
+        &model->params.sweep, self, &num_steps, &time, &allele_frequency);
     if (ret != 0) {
         goto out;
     }
@@ -4391,10 +4379,10 @@ msp_run_sweep(msp_t *self)
             sweep_dt = time[curr_step] - time[curr_step - 1];
             /* using pop sizes grabbed from get_population_size */
             pop_size = get_population_size(&self->populations[0], time[curr_step]);
-            p_coal_B = ((sweep_pop_sizes[1] * (sweep_pop_sizes[1] - 1) ) * 0.5)
-                / allele_frequency[curr_step] * sweep_dt / pop_size;
-            p_coal_b = ((sweep_pop_sizes[0] * (sweep_pop_sizes[0] - 1) ) * 0.5)
-                / (1.0 - allele_frequency[curr_step]) * sweep_dt / pop_size;
+            p_coal_B = ((sweep_pop_sizes[1] * (sweep_pop_sizes[1] - 1)) * 0.5)
+                       / allele_frequency[curr_step] * sweep_dt / pop_size;
+            p_coal_b = ((sweep_pop_sizes[0] * (sweep_pop_sizes[0] - 1)) * 0.5)
+                       / (1.0 - allele_frequency[curr_step]) * sweep_dt / pop_size;
             p_rec_b = rec_rates[0] * sweep_dt;
             p_rec_B = rec_rates[1] * sweep_dt;
             sweep_pop_tot_rate = p_coal_b + p_coal_B + p_rec_b + p_rec_B;
@@ -4423,16 +4411,16 @@ msp_run_sweep(msp_t *self)
                 e_sum += rec_rates[0];
                 if (tmp_rand < e_sum / sweep_pop_tot_rate) {
                     /* recomb in b background */
-                    ret = msp_sweep_recombination_event(self, 0, sweep_locus,
-                        (1.0 - allele_frequency[curr_step - 1]));
+                    ret = msp_sweep_recombination_event(
+                        self, 0, sweep_locus, (1.0 - allele_frequency[curr_step - 1]));
                 } else {
                     /* recomb in B background */
-                    ret = msp_sweep_recombination_event(self, 1, sweep_locus,
-                        allele_frequency[curr_step - 1]);
+                    ret = msp_sweep_recombination_event(
+                        self, 1, sweep_locus, allele_frequency[curr_step - 1]);
                 }
             }
         }
-        if (ret != 0){
+        if (ret != 0) {
             goto out;
         }
         /*msp_print_state(self, stdout);*/
@@ -4440,15 +4428,15 @@ msp_run_sweep(msp_t *self)
     /* Check if any demographic events should have happened during the
      * event and raise an error if so. This is to keep computing population
      * sizes simple */
-    if (self->next_demographic_event != NULL &&
-            self->next_demographic_event->time <= self->time) {
+    if (self->next_demographic_event != NULL
+        && self->next_demographic_event->time <= self->time) {
         ret = MSP_ERR_EVENTS_DURING_SWEEP;
         goto out;
     }
     /* We could implement sampling events during a sweep if we wanted
      * to easily enough. Is this a sensible feature? */
     if (self->next_sampling_event < self->num_sampling_events
-            && self->sampling_events[self->next_sampling_event].time <= self->time) {
+        && self->sampling_events[self->next_sampling_event].time <= self->time) {
         ret = MSP_ERR_EVENTS_DURING_SWEEP;
         goto out;
     }
@@ -4481,12 +4469,11 @@ msp_run(msp_t *self, double max_time, unsigned long max_events)
         ret = MSP_ERR_BAD_STATE;
         goto out;
     }
-    if (self->store_full_arg && ! (
-            self->model.type == MSP_MODEL_HUDSON
-            || self->model.type == MSP_MODEL_SMC
-            || self->model.type == MSP_MODEL_SMC_PRIME
-            || self->model.type == MSP_MODEL_BETA
-            || self->model.type == MSP_MODEL_DIRAC)) {
+    if (self->store_full_arg
+        && !(self->model.type == MSP_MODEL_HUDSON || self->model.type == MSP_MODEL_SMC
+               || self->model.type == MSP_MODEL_SMC_PRIME
+               || self->model.type == MSP_MODEL_BETA
+               || self->model.type == MSP_MODEL_DIRAC)) {
         /* We currently only support the full ARG recording on the standard
          * coalescent, SMC, or multiple merger coalescents. */
         ret = MSP_ERR_UNSUPPORTED_OPERATION;
@@ -4500,8 +4487,7 @@ msp_run(msp_t *self, double max_time, unsigned long max_events)
     } else if (self->model.type == MSP_MODEL_DTWF) {
         ret = msp_run_dtwf(self, scaled_time, max_events);
     } else if (self->model.type == MSP_MODEL_WF_PED) {
-        if (self->pedigree == NULL ||
-            self->pedigree->state != MSP_PED_STATE_UNCLIMBED) {
+        if (self->pedigree == NULL || self->pedigree->state != MSP_PED_STATE_UNCLIMBED) {
             ret = MSP_ERR_BAD_STATE;
             goto out;
         }
@@ -4555,13 +4541,14 @@ msp_insert_uncoalesced_edges(msp_t *self)
     node_id_t node;
     int64_t edge_start;
     tsk_node_table_t *nodes = &self->tables->nodes;
-    const double current_time = self->model.model_time_to_generations(&self->model,
-            self->time);
+    const double current_time
+        = self->model.model_time_to_generations(&self->model, self->time);
     tsk_bookmark_t bookmark;
 
     for (pop = 0; pop < (population_id_t) self->num_populations; pop++) {
         for (label = 0; label < (label_id_t) self->num_labels; label++) {
-            for (a = self->populations[pop].ancestors[label].head; a != NULL; a = a->next) {
+            for (a = self->populations[pop].ancestors[label].head; a != NULL;
+                 a = a->next) {
                 /* If there are any nodes in the segment chain with the current time,
                  * then we don't make any unary edges for them. This is because (a)
                  * we'd end up edges with the same parent and child time (if we didn't
@@ -4577,8 +4564,8 @@ msp_insert_uncoalesced_edges(msp_t *self)
                 }
                 if (node == TSK_NULL) {
                     /* Add a node for this ancestor */
-                    node = tsk_node_table_add_row(nodes, 0, current_time, pop,
-                            TSK_NULL, NULL, 0);
+                    node = tsk_node_table_add_row(
+                        nodes, 0, current_time, pop, TSK_NULL, NULL, 0);
                     if (node < 0) {
                         ret = msp_set_tsk_error(node);
                         goto out;
@@ -4589,8 +4576,8 @@ msp_insert_uncoalesced_edges(msp_t *self)
                 for (seg = (segment_t *) a->item; seg != NULL; seg = seg->next) {
                     if (seg->value != node) {
                         assert(nodes->time[node] > nodes->time[seg->value]);
-                        ret = tsk_edge_table_add_row(&self->tables->edges,
-                              seg->left, seg->right, node, seg->value);
+                        ret = tsk_edge_table_add_row(&self->tables->edges, seg->left,
+                            seg->right, node, seg->value);
                         if (ret < 0) {
                             ret = msp_set_tsk_error(ret);
                             goto out;
@@ -4604,7 +4591,7 @@ msp_insert_uncoalesced_edges(msp_t *self)
     /* Find the first edge with parent == current time */
     edge_start = ((int64_t) self->tables->edges.num_rows) - 1;
     while (edge_start >= 0
-            && nodes->time[self->tables->edges.parent[edge_start]] == current_time) {
+           && nodes->time[self->tables->edges.parent[edge_start]] == current_time) {
         edge_start--;
     }
     memset(&bookmark, 0, sizeof(bookmark));
@@ -4662,12 +4649,12 @@ msp_debug_demography(msp_t *self, double *end_time)
         ret = MSP_ERR_BAD_STATE;
         goto out;
     }
-    if (! first_call && self->next_demographic_event != NULL) {
+    if (!first_call && self->next_demographic_event != NULL) {
         de = self->next_demographic_event;
 
         /* Add in historical samples more recent than next demographic event */
         while (self->next_sampling_event < self->num_sampling_events
-                && self->sampling_events[self->next_sampling_event].time <= de->time) {
+               && self->sampling_events[self->next_sampling_event].time <= de->time) {
             se = self->sampling_events + self->next_sampling_event;
             ret = msp_insert_sample(self, se->sample, se->population_id);
             if (ret != 0) {
@@ -4691,8 +4678,8 @@ out:
 
 /* Used for high-level debugging. */
 int MSP_WARN_UNUSED
-msp_compute_population_size(msp_t *self, size_t population_id, double time,
-        double *pop_size)
+msp_compute_population_size(
+    msp_t *self, size_t population_id, double time, double *pop_size)
 {
     int ret = 0;
     population_t *pop;
@@ -4708,8 +4695,8 @@ msp_compute_population_size(msp_t *self, size_t population_id, double time,
         *pop_size = model->reference_size * pop->initial_size;
     } else {
         dt = model->generations_to_model_time(model, time) - pop->start_time;
-        *pop_size = model->reference_size * pop->initial_size
-            * exp(-pop->growth_rate * dt);
+        *pop_size
+            = model->reference_size * pop->initial_size * exp(-pop->growth_rate * dt);
     }
 out:
     return ret;
@@ -4821,7 +4808,6 @@ msp_get_num_migrations(msp_t *self)
     return (size_t) self->tables->migrations.num_rows;
 }
 
-
 int MSP_WARN_UNUSED
 msp_get_ancestors(msp_t *self, segment_t **ancestors)
 {
@@ -4835,8 +4821,7 @@ msp_get_ancestors(msp_t *self, segment_t **ancestors)
     for (j = 0; j < self->num_populations; j++) {
         for (label = 0; label < (label_id_t) self->num_labels; label++) {
             population_ancestors = &self->populations[j].ancestors[label];
-            for (node = population_ancestors->head;
-                    node != NULL; node = node->next) {
+            for (node = population_ancestors->head; node != NULL; node = node->next) {
                 ancestors[k] = (segment_t *) node->item;
                 k++;
             }
@@ -4871,8 +4856,8 @@ msp_get_migration_matrix(msp_t *self, double *migration_matrix)
     simulation_model_t *model = &self->model;
 
     for (j = 0; j < N * N; j++) {
-        migration_matrix[j] = model->model_rate_to_generation_rate(
-                model, self->migration_matrix[j]);
+        migration_matrix[j]
+            = model->model_rate_to_generation_rate(model, self->migration_matrix[j]);
     }
     return 0;
 }
@@ -4894,8 +4879,8 @@ msp_get_samples(msp_t *self, sample_t **samples)
 }
 
 int MSP_WARN_UNUSED
-msp_get_population_configuration(msp_t *self, size_t population_id, double *initial_size,
-        double *growth_rate)
+msp_get_population_configuration(
+    msp_t *self, size_t population_id, double *initial_size, double *growth_rate)
 {
     int ret = 0;
     population_t *pop;
@@ -4970,8 +4955,8 @@ out:
 /* Population parameter change */
 
 static int
-msp_change_single_population_parameters(msp_t *self, size_t population_id,
-        double time, double initial_size, double growth_rate)
+msp_change_single_population_parameters(msp_t *self, size_t population_id, double time,
+    double initial_size, double growth_rate)
 {
     int ret = 0;
     double dt;
@@ -5007,22 +4992,20 @@ msp_change_population_parameters(msp_t *self, demographic_event_t *event)
 {
     int ret = 0;
     population_id_t pid = event->params.population_parameters_change.population_id;
-    double initial_size =
-        event->params.population_parameters_change.initial_size;
-    double growth_rate =
-        event->params.population_parameters_change.growth_rate;
+    double initial_size = event->params.population_parameters_change.initial_size;
+    double growth_rate = event->params.population_parameters_change.growth_rate;
 
     if (pid == -1) {
         for (pid = 0; pid < (int) self->num_populations; pid++) {
-            ret = msp_change_single_population_parameters(self, (size_t) pid,
-                    event->time, initial_size, growth_rate);
+            ret = msp_change_single_population_parameters(
+                self, (size_t) pid, event->time, initial_size, growth_rate);
             if (ret != 0) {
                 goto out;
             }
         }
     } else {
-        ret = msp_change_single_population_parameters(self, (size_t) pid,
-                event->time, initial_size, growth_rate);
+        ret = msp_change_single_population_parameters(
+            self, (size_t) pid, event->time, initial_size, growth_rate);
         if (ret != 0) {
             goto out;
         }
@@ -5032,22 +5015,21 @@ out:
 }
 
 static void
-msp_print_population_parameters_change(msp_t * MSP_UNUSED(self),
-        demographic_event_t *event, FILE *out)
+msp_print_population_parameters_change(
+    msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
 {
     fprintf(out,
-            "%f\tpopulation_parameters_change: %d -> initial_size=%f, growth_rate=%f\n",
-            event->time,
-            (int) event->params.population_parameters_change.population_id,
-            event->params.population_parameters_change.initial_size,
-            event->params.population_parameters_change.growth_rate);
+        "%f\tpopulation_parameters_change: %d -> initial_size=%f, growth_rate=%f\n",
+        event->time, (int) event->params.population_parameters_change.population_id,
+        event->params.population_parameters_change.initial_size,
+        event->params.population_parameters_change.growth_rate);
 }
 
 /* Adds a population parameter change event. Time and growth_rate are measured in
  * units of generations, and the initial size is an absolute value. */
 int
-msp_add_population_parameters_change(msp_t *self, double time, int population_id,
-        double initial_size, double growth_rate)
+msp_add_population_parameters_change(
+    msp_t *self, double time, int population_id, double initial_size, double growth_rate)
 {
     int ret = -1;
     demographic_event_t *de;
@@ -5058,7 +5040,7 @@ msp_add_population_parameters_change(msp_t *self, double time, int population_id
         goto out;
     }
     if (initial_size <= 0) {
-        assert(! gsl_isnan(initial_size));
+        assert(!gsl_isnan(initial_size));
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
@@ -5110,14 +5092,13 @@ msp_change_migration_rate(msp_t *self, demographic_event_t *event)
     int index = event->params.migration_rate_change.matrix_index;
     int N = (int) self->num_populations;
     simulation_model_t *model = &self->model;
-    double rate = model->generation_rate_to_model_rate(model,
-        event->params.migration_rate_change.migration_rate);
+    double rate = model->generation_rate_to_model_rate(
+        model, event->params.migration_rate_change.migration_rate);
 
     if (index == -1) {
         for (index = 0; index < N * N; index++) {
             if (index % (N + 1) != 0) {
-                ret = msp_change_migration_matrix_entry(self, (size_t) index,
-                        rate);
+                ret = msp_change_migration_matrix_entry(self, (size_t) index, rate);
                 if (ret != 0) {
                     goto out;
                 }
@@ -5134,20 +5115,19 @@ out:
 }
 
 static void
-msp_print_migration_rate_change(msp_t * MSP_UNUSED(self),
-        demographic_event_t *event, FILE *out)
+msp_print_migration_rate_change(
+    msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
 {
-    fprintf(out, "%f\tmigration_rate_change: %d -> %f\n",
-            event->time,
-            event->params.migration_rate_change.matrix_index,
-            event->params.migration_rate_change.migration_rate);
+    fprintf(out, "%f\tmigration_rate_change: %d -> %f\n", event->time,
+        event->params.migration_rate_change.matrix_index,
+        event->params.migration_rate_change.migration_rate);
 }
 
 /* Add a migration rate change event. Time and migration rate are measured in
  * units of generations. */
 int MSP_WARN_UNUSED
-msp_add_migration_rate_change(msp_t *self, double time, int matrix_index,
-        double migration_rate)
+msp_add_migration_rate_change(
+    msp_t *self, double time, int matrix_index, double migration_rate)
 {
     int ret = -1;
     demographic_event_t *de;
@@ -5218,19 +5198,18 @@ out:
 }
 
 static void
-msp_print_mass_migration(msp_t * MSP_UNUSED(self), demographic_event_t *event, FILE *out)
+msp_print_mass_migration(msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
 {
-    fprintf(out, "%f\tmass_migration: %d -> %d p = %f\n",
-            event->time,
-            (int) event->params.mass_migration.source,
-            (int) event->params.mass_migration.destination,
-            event->params.mass_migration.proportion);
+    fprintf(out, "%f\tmass_migration: %d -> %d p = %f\n", event->time,
+        (int) event->params.mass_migration.source,
+        (int) event->params.mass_migration.destination,
+        event->params.mass_migration.proportion);
 }
 
 /* Adds a mass migration event. Time is measured in units of generations */
 int MSP_WARN_UNUSED
-msp_add_mass_migration(msp_t *self, double time, int source, int destination,
-        double proportion)
+msp_add_mass_migration(
+    msp_t *self, double time, int source, int destination, double proportion)
 {
     int ret = 0;
     demographic_event_t *de;
@@ -5316,12 +5295,12 @@ out:
 }
 
 static void
-msp_print_simple_bottleneck(msp_t * MSP_UNUSED(self), demographic_event_t *event, FILE *out)
+msp_print_simple_bottleneck(
+    msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
 {
-    fprintf(out, "%f\tsimple_bottleneck: %d I = %f\n",
-            event->time,
-            (int) event->params.simple_bottleneck.population_id,
-            event->params.simple_bottleneck.proportion);
+    fprintf(out, "%f\tsimple_bottleneck: %d I = %f\n", event->time,
+        (int) event->params.simple_bottleneck.population_id,
+        event->params.simple_bottleneck.proportion);
 }
 
 /* Add a simple bottleneck event. Time is measured in generations */
@@ -5391,15 +5370,14 @@ msp_instantaneous_bottleneck(msp_t *self, demographic_event_t *event)
     avl_nodes = malloc(n * sizeof(avl_node_t *));
     pi = malloc(2 * n * sizeof(node_id_t));
     sets = malloc(2 * n * sizeof(avl_tree_t));
-    if (lineages == NULL || avl_nodes == NULL || pi == NULL
-            || sets == NULL) {
+    if (lineages == NULL || avl_nodes == NULL || pi == NULL || sets == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
     for (u = 0; u < (node_id_t) n; u++) {
         lineages[u] = u;
     }
-    for (u = 0; u < (node_id_t) (2 * n); u++) {
+    for (u = 0; u < (node_id_t)(2 * n); u++) {
         pi[u] = TSK_NULL;
     }
     j = 0;
@@ -5417,8 +5395,8 @@ msp_instantaneous_bottleneck(msp_t *self, demographic_event_t *event)
     while (j > 0) {
         rate = j + 1;
         rate = rate * j;
-        t += msp_get_common_ancestor_waiting_time_from_rate(self,
-                &self->populations[population_id], rate);
+        t += msp_get_common_ancestor_waiting_time_from_rate(
+            self, &self->populations[population_id], rate);
         if (t >= T2) {
             break;
         }
@@ -5429,7 +5407,7 @@ msp_instantaneous_bottleneck(msp_t *self, demographic_event_t *event)
         pi[lineages[k]] = parent;
         lineages[k] = lineages[j];
         j--;
-        k = j > 0 ? (uint32_t) gsl_rng_uniform_int(self->rng, j): 0;
+        k = j > 0 ? (uint32_t) gsl_rng_uniform_int(self->rng, j) : 0;
         pi[lineages[k]] = parent;
         lineages[k] = parent;
         parent++;
@@ -5468,7 +5446,8 @@ msp_instantaneous_bottleneck(msp_t *self, demographic_event_t *event)
     }
     for (j = 0; j < num_roots; j++) {
         if (lineages[j] >= (node_id_t) n) {
-            ret = msp_merge_ancestors(self, &sets[lineages[j]], population_id, label, NULL, TSK_NULL);
+            ret = msp_merge_ancestors(
+                self, &sets[lineages[j]], population_id, label, NULL, TSK_NULL);
             if (ret != 0) {
                 goto out;
             }
@@ -5491,20 +5470,19 @@ out:
 }
 
 static void
-msp_print_instantaneous_bottleneck(msp_t *MSP_UNUSED(self),
-        demographic_event_t *event, FILE *out)
+msp_print_instantaneous_bottleneck(
+    msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
 {
-    fprintf(out, "%f\tinstantaneous_bottleneck: %d T2 = %f\n",
-            event->time,
-            (int) event->params.instantaneous_bottleneck.population_id,
-            event->params.instantaneous_bottleneck.strength);
+    fprintf(out, "%f\tinstantaneous_bottleneck: %d T2 = %f\n", event->time,
+        (int) event->params.instantaneous_bottleneck.population_id,
+        event->params.instantaneous_bottleneck.strength);
 }
 
 /* Add an instantaneous bottleneck event. Time and strength are measured in generations
  */
 int MSP_WARN_UNUSED
-msp_add_instantaneous_bottleneck(msp_t *self, double time, int population_id,
-        double strength)
+msp_add_instantaneous_bottleneck(
+    msp_t *self, double time, int population_id, double strength)
 {
     int ret = 0;
     demographic_event_t *de;
@@ -5524,8 +5502,8 @@ msp_add_instantaneous_bottleneck(msp_t *self, double time, int population_id,
         goto out;
     }
     de->params.instantaneous_bottleneck.population_id = population_id;
-    de->params.instantaneous_bottleneck.strength =
-        model->generations_to_model_time(model, strength);
+    de->params.instantaneous_bottleneck.strength
+        = model->generations_to_model_time(model, strength);
     de->change_state = msp_instantaneous_bottleneck;
     de->print_state = msp_print_instantaneous_bottleneck;
     ret = 0;
@@ -5552,7 +5530,7 @@ msp_census_event(msp_t *self, demographic_event_t *event)
             ancestors = &self->populations[i].ancestors[j];
             node = ancestors->head;
 
-            while (node != NULL){
+            while (node != NULL) {
                 seg = (segment_t *) node->item;
 
                 while (seg != NULL) {
@@ -5562,8 +5540,8 @@ msp_census_event(msp_t *self, demographic_event_t *event)
                         goto out;
                     }
                     ret = tsk_node_table_add_row(&self->tables->nodes,
-                            MSP_NODE_IS_CEN_EVENT, time, (population_id_t) i, TSK_NULL,
-                            NULL, 0);
+                        MSP_NODE_IS_CEN_EVENT, time, (population_id_t) i, TSK_NULL, NULL,
+                        0);
                     if (ret < 0) {
                         goto out;
                     }
@@ -5587,10 +5565,9 @@ out:
 }
 
 static void
-msp_print_census_event(msp_t * MSP_UNUSED(self), demographic_event_t *event, FILE *out)
+msp_print_census_event(msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
 {
-    fprintf(out, "%f\tcensus_event:\n",
-            event->time);
+    fprintf(out, "%f\tcensus_event:\n", event->time);
 }
 
 int MSP_WARN_UNUSED
@@ -5650,8 +5627,8 @@ std_model_rate_to_generation_rate(simulation_model_t *model, double rate)
 }
 
 static double
-msp_std_get_common_ancestor_waiting_time(msp_t *self, population_id_t pop_id,
-        label_id_t label)
+msp_std_get_common_ancestor_waiting_time(
+    msp_t *self, population_id_t pop_id, label_id_t label)
 {
     population_t *pop = &self->populations[pop_id];
     double n = (double) avl_count(&pop->ancestors[label]);
@@ -5661,8 +5638,8 @@ msp_std_get_common_ancestor_waiting_time(msp_t *self, population_id_t pop_id,
 }
 
 static int MSP_WARN_UNUSED
-msp_std_common_ancestor_event(msp_t *self, population_id_t population_id,
-        label_id_t label)
+msp_std_common_ancestor_event(
+    msp_t *self, population_id_t population_id, label_id_t label)
 {
     int ret = 0;
     uint32_t j, n;
@@ -5733,8 +5710,8 @@ dirac_model_rate_to_generation_rate(simulation_model_t *model, double rate)
 }
 
 static double
-msp_dirac_get_common_ancestor_waiting_time(msp_t *self, population_id_t pop_id,
-        label_id_t label)
+msp_dirac_get_common_ancestor_waiting_time(
+    msp_t *self, population_id_t pop_id, label_id_t label)
 {
     population_t *pop = &self->populations[pop_id];
     unsigned int n = (unsigned int) avl_count(&pop->ancestors[label]);
@@ -5777,19 +5754,19 @@ msp_dirac_common_ancestor_event(msp_t *self, population_id_t pop_id, label_id_t 
         msp_free_avl_node(self, y_node);
         ret = msp_merge_two_ancestors(self, pop_id, label, x, y);
     } else {
-        for (j = 0; j < 4; j++){
+        for (j = 0; j < 4; j++) {
             avl_init_tree(&Q[j], cmp_segment_queue, NULL);
         }
         num_participants = gsl_ran_binomial(self->rng, psi, n);
-        ret = msp_multi_merger_common_ancestor_event(self, ancestors, Q,
-                                                     num_participants);
+        ret = msp_multi_merger_common_ancestor_event(
+            self, ancestors, Q, num_participants);
         if (ret < 0) {
             goto out;
         }
         /* All the lineages that have been assigned to the particular pots can now be
          * merged.
          */
-        for (j = 0; j < 4; j++){
+        for (j = 0; j < 4; j++) {
             ret = msp_merge_ancestors(self, &Q[j], pop_id, label, NULL, TSK_NULL);
             if (ret < 0) {
                 goto out;
@@ -5811,8 +5788,9 @@ beta_model_compute_timescale(simulation_model_t *model)
     double truncation_point = model->params.beta_coalescent.truncation_point;
     double reference_size = model->reference_size;
     double m = 2.0 + exp(alpha * log(2) + (1 - alpha) * log(3) - log(alpha - 1));
-    double timescale = exp(alpha * log(m) + (alpha - 1) * log(reference_size)
-        - log(alpha)) / gsl_sf_beta_inc(2 - alpha, alpha, truncation_point);
+    double timescale
+        = exp(alpha * log(m) + (alpha - 1) * log(reference_size) - log(alpha))
+          / gsl_sf_beta_inc(2 - alpha, alpha, truncation_point);
     return timescale;
 }
 
@@ -5841,8 +5819,8 @@ beta_model_rate_to_generation_rate(simulation_model_t *model, double rate)
 }
 
 static double
-msp_beta_get_common_ancestor_waiting_time(msp_t *self, population_id_t pop_id,
-        label_id_t label)
+msp_beta_get_common_ancestor_waiting_time(
+    msp_t *self, population_id_t pop_id, label_id_t label)
 {
     population_t *pop = &self->populations[pop_id];
     unsigned int n = (unsigned int) avl_count(&pop->ancestors[label]);
@@ -5854,12 +5832,12 @@ msp_beta_get_common_ancestor_waiting_time(msp_t *self, population_id_t pop_id,
 }
 
 int MSP_WARN_UNUSED
-msp_multi_merger_common_ancestor_event(msp_t *self, avl_tree_t *ancestors,
-                                       avl_tree_t *Q, uint32_t k)
+msp_multi_merger_common_ancestor_event(
+    msp_t *self, avl_tree_t *ancestors, avl_tree_t *Q, uint32_t k)
 {
     int ret = 0;
     uint32_t j, i, l;
-    avl_node_t  *node, *q_node;
+    avl_node_t *node, *q_node;
     segment_t *u;
     uint32_t pot_size;
     uint32_t cumul_pot_size = 0;
@@ -5905,29 +5883,25 @@ msp_beta_common_ancestor_event(msp_t *self, population_id_t pop_id, label_id_t l
     avl_tree_t *ancestors, Q[4]; /* MSVC won't let us use num_pots here */
     double beta_x, u, increment;
 
-    for (j = 0; j < 4; j++){
+    for (j = 0; j < 4; j++) {
         avl_init_tree(&Q[j], cmp_segment_queue, NULL);
     }
     ancestors = &self->populations[pop_id].ancestors[label];
     n = avl_count(ancestors);
-    beta_x = ran_inc_beta(self->rng,
-                 2.0 - self->model.params.beta_coalescent.alpha,
-                 self->model.params.beta_coalescent.alpha,
-                 self->model.params.beta_coalescent.truncation_point);
+    beta_x = ran_inc_beta(self->rng, 2.0 - self->model.params.beta_coalescent.alpha,
+        self->model.params.beta_coalescent.alpha,
+        self->model.params.beta_coalescent.truncation_point);
 
     /* We calculate the probability of accepting the event */
     if (beta_x > 1e-9) {
-        u = (n - 1) * log(1 - beta_x)
-            + log(1 + (n - 1) * beta_x);
-        u = exp(log(1 - exp(u)) - 2 * log(beta_x)
-            - gsl_sf_lnchoose(n, 2));
+        u = (n - 1) * log(1 - beta_x) + log(1 + (n - 1) * beta_x);
+        u = exp(log(1 - exp(u)) - 2 * log(beta_x) - gsl_sf_lnchoose(n, 2));
     } else {
         /* For very small values of beta_x we need a polynomial expansion
          * for numerical stability */
         u = 0;
         for (j = 2; j <= n; j += 2) {
-            increment = (j - 1) * exp(gsl_sf_lnchoose(n, j)
-                + (j - 2) * log(beta_x));
+            increment = (j - 1) * exp(gsl_sf_lnchoose(n, j) + (j - 2) * log(beta_x));
             if (increment / u < 1e-12) {
                 /* We truncate the expansion adaptively once the increment
                  * becomes negligible. */
@@ -5936,8 +5910,7 @@ msp_beta_common_ancestor_event(msp_t *self, population_id_t pop_id, label_id_t l
             u += increment;
         }
         for (j = 3; j <= n; j += 2) {
-            increment = (j - 1) * exp(gsl_sf_lnchoose(n, j)
-                + (j - 2) * log(beta_x));
+            increment = (j - 1) * exp(gsl_sf_lnchoose(n, j) + (j - 2) * log(beta_x));
             if (increment / u < 1e-12) {
                 break;
             }
@@ -5950,18 +5923,17 @@ msp_beta_common_ancestor_event(msp_t *self, population_id_t pop_id, label_id_t l
         do {
             /* Rejection sampling for the number of participants */
             num_participants = 2 + gsl_ran_binomial(self->rng, beta_x, n - 2);
-        } while (gsl_rng_uniform(self->rng) >
-            1 / gsl_sf_choose(num_participants, 2));
+        } while (gsl_rng_uniform(self->rng) > 1 / gsl_sf_choose(num_participants, 2));
 
-        ret = msp_multi_merger_common_ancestor_event(self, ancestors, Q,
-                                                     num_participants);
+        ret = msp_multi_merger_common_ancestor_event(
+            self, ancestors, Q, num_participants);
         if (ret < 0) {
             goto out;
         }
 
         /* All the lineages that have been assigned to the particular pots can now be
-        * merged.
-        */
+         * merged.
+         */
         for (j = 0; j < 4; j++) {
             ret = msp_merge_ancestors(self, &Q[j], pop_id, label, NULL, TSK_NULL);
             if (ret < 0) {
@@ -5973,7 +5945,6 @@ msp_beta_common_ancestor_event(msp_t *self, population_id_t pop_id, label_id_t l
 out:
     return ret;
 }
-
 
 /**************************************************************
  * Discrete Time Wright Fisher
@@ -6013,17 +5984,17 @@ static double
 genic_selection_stochastic_forwards(double dt, double freq, double alpha, double u)
 {
     double ux = (alpha * freq * (1 - freq)) / tanh(alpha * freq);
-    int sign = u < 0.5? 1: -1;
+    int sign = u < 0.5 ? 1 : -1;
     return freq + (ux * dt) + sign * sqrt(freq * (1.0 - freq) * dt);
 }
 
 static int
 genic_selection_generate_trajectory(sweep_t *self, msp_t *simulator,
-        size_t *ret_num_steps, double **ret_time, double **ret_allele_frequency)
+    size_t *ret_num_steps, double **ret_time, double **ret_allele_frequency)
 {
     int ret = 0;
-    genic_selection_trajectory_t trajectory =
-        self->trajectory_params.genic_selection_trajectory;
+    genic_selection_trajectory_t trajectory
+        = self->trajectory_params.genic_selection_trajectory;
     gsl_rng *rng = simulator->rng;
     size_t max_steps = 64;
     double *time = malloc(max_steps * sizeof(*time));
@@ -6063,9 +6034,9 @@ genic_selection_generate_trajectory(sweep_t *self, msp_t *simulator,
         }
         time[num_steps] = t;
         allele_frequency[num_steps] = x;
-        x = 1.0 - genic_selection_stochastic_forwards(
-                trajectory.dt, 1.0 - x, trajectory.alpha * current_size,
-                gsl_rng_uniform(rng));
+        x = 1.0
+            - genic_selection_stochastic_forwards(trajectory.dt, 1.0 - x,
+                  trajectory.alpha * current_size, gsl_rng_uniform(rng));
         t += trajectory.dt;
         num_steps++;
     }
@@ -6088,8 +6059,8 @@ out:
 static void
 genic_selection_print_state(sweep_t *self, FILE *out)
 {
-    genic_selection_trajectory_t *trajectory =
-        &self->trajectory_params.genic_selection_trajectory;
+    genic_selection_trajectory_t *trajectory
+        = &self->trajectory_params.genic_selection_trajectory;
 
     fprintf(out, "\tGenic selection trajectory\n");
     fprintf(out, "\t\tstart_frequency = %f\n", trajectory->start_frequency);
@@ -6151,33 +6122,32 @@ msp_unscale_model_times(msp_t *self)
 
     self->start_time = self->model.model_time_to_generations(model, self->start_time);
     self->time = self->model.model_time_to_generations(model, self->time);
-    self->gene_conversion_rate = self->model.model_rate_to_generation_rate(
-            model, self->gene_conversion_rate);
+    self->gene_conversion_rate
+        = self->model.model_rate_to_generation_rate(model, self->gene_conversion_rate);
     recomb_map_convert_rates(&self->recomb_map,
-            (msp_convert_func) self->model.model_rate_to_generation_rate,
-            &self->model);
+        (msp_convert_func) self->model.model_rate_to_generation_rate, &self->model);
     msp_reset_all_segment_masses(self);
     /* Samples */
     for (j = 0; j < self->num_samples; j++) {
-        self->samples[j].time = model->model_time_to_generations(
-                model, self->samples[j].time);
+        self->samples[j].time
+            = model->model_time_to_generations(model, self->samples[j].time);
     }
     /* Sampling events */
     for (j = 0; j < self->num_sampling_events; j++) {
-        self->sampling_events[j].time = model->model_time_to_generations(
-                model, self->sampling_events[j].time);
+        self->sampling_events[j].time
+            = model->model_time_to_generations(model, self->sampling_events[j].time);
     }
     /* Growth rates and start times for populations */
     for (j = 0; j < self->num_populations; j++) {
         self->populations[j].growth_rate = model->model_rate_to_generation_rate(
-                model, self->populations[j].growth_rate);
-        self->populations[j].start_time = model->model_time_to_generations(
-                model, self->populations[j].start_time);
+            model, self->populations[j].growth_rate);
+        self->populations[j].start_time
+            = model->model_time_to_generations(model, self->populations[j].start_time);
     }
     /* Migration rates */
     for (j = 0; j < gsl_pow_2(self->num_populations); j++) {
-        self->migration_matrix[j] = model->model_rate_to_generation_rate(
-                model, self->migration_matrix[j]);
+        self->migration_matrix[j]
+            = model->model_rate_to_generation_rate(model, self->migration_matrix[j]);
     }
     /* Demographic events */
     for (de = self->demographic_events_head; de != NULL; de = de->next) {
@@ -6196,33 +6166,32 @@ msp_rescale_model_times(msp_t *self)
 
     self->time = model->generations_to_model_time(model, self->time);
     self->start_time = model->generations_to_model_time(model, self->start_time);
-    self->gene_conversion_rate = model->generation_rate_to_model_rate(
-            model, self->gene_conversion_rate);
+    self->gene_conversion_rate
+        = model->generation_rate_to_model_rate(model, self->gene_conversion_rate);
     recomb_map_convert_rates(&self->recomb_map,
-            (msp_convert_func) self->model.generation_rate_to_model_rate,
-            &self->model);
+        (msp_convert_func) self->model.generation_rate_to_model_rate, &self->model);
     msp_reset_all_segment_masses(self);
     /* Samples */
     for (j = 0; j < self->num_samples; j++) {
-        self->samples[j].time = model->generations_to_model_time(
-                model, self->samples[j].time);
+        self->samples[j].time
+            = model->generations_to_model_time(model, self->samples[j].time);
     }
     /* Sampling events */
     for (j = 0; j < self->num_sampling_events; j++) {
-        self->sampling_events[j].time = model->generations_to_model_time(
-                model, self->sampling_events[j].time);
+        self->sampling_events[j].time
+            = model->generations_to_model_time(model, self->sampling_events[j].time);
     }
     /* Growth rates and start times for populations */
     for (j = 0; j < self->num_populations; j++) {
         self->populations[j].growth_rate = model->generation_rate_to_model_rate(
-                model, self->populations[j].growth_rate);
-        self->populations[j].start_time = model->generations_to_model_time(
-                model, self->populations[j].start_time);
+            model, self->populations[j].growth_rate);
+        self->populations[j].start_time
+            = model->generations_to_model_time(model, self->populations[j].start_time);
     }
     /* Migration rates */
     for (j = 0; j < gsl_pow_2(self->num_populations); j++) {
-        self->migration_matrix[j] = model->generation_rate_to_model_rate(
-                model, self->migration_matrix[j]);
+        self->migration_matrix[j]
+            = model->generation_rate_to_model_rate(model, self->migration_matrix[j]);
     }
     /* Demographic events */
     for (de = self->demographic_events_head; de != NULL; de = de->next) {
@@ -6237,12 +6206,9 @@ msp_set_simulation_model(msp_t *self, int model, double reference_size)
     int ret = 0;
 
     if (model != MSP_MODEL_HUDSON && model != MSP_MODEL_SMC
-            && model != MSP_MODEL_SMC_PRIME
-            && model != MSP_MODEL_DIRAC
-            && model != MSP_MODEL_BETA
-            && model != MSP_MODEL_DTWF
-            && model != MSP_MODEL_WF_PED
-            && model != MSP_MODEL_SWEEP) {
+        && model != MSP_MODEL_SMC_PRIME && model != MSP_MODEL_DIRAC
+        && model != MSP_MODEL_BETA && model != MSP_MODEL_DTWF
+        && model != MSP_MODEL_WF_PED && model != MSP_MODEL_SWEEP) {
         ret = MSP_ERR_BAD_MODEL;
         goto out;
     }
@@ -6292,7 +6258,7 @@ out:
 int
 msp_set_simulation_model_smc(msp_t *self, double reference_size)
 {
-    int ret =  msp_set_simulation_model(self, MSP_MODEL_SMC, reference_size);
+    int ret = msp_set_simulation_model(self, MSP_MODEL_SMC, reference_size);
     if (ret != 0) {
         goto out;
     }
@@ -6304,7 +6270,7 @@ out:
 int
 msp_set_simulation_model_smc_prime(msp_t *self, double reference_size)
 {
-    int ret =  msp_set_simulation_model(self, MSP_MODEL_SMC_PRIME, reference_size);
+    int ret = msp_set_simulation_model(self, MSP_MODEL_SMC_PRIME, reference_size);
     if (ret != 0) {
         goto out;
     }
@@ -6353,13 +6319,13 @@ int
 msp_set_simulation_model_dirac(msp_t *self, double reference_size, double psi, double c)
 {
     int ret = 0;
-/* We assume to be in the limit where N is infinite*/
+    /* We assume to be in the limit where N is infinite*/
     if (psi <= 0 || psi > 1.0) {
         ret = MSP_ERR_BAD_PSI;
         goto out;
     }
 
-    if (c < 0.0 ) {
+    if (c < 0.0) {
         ret = MSP_ERR_BAD_C;
         goto out;
     }
@@ -6381,8 +6347,8 @@ out:
 }
 
 int
-msp_set_simulation_model_beta(msp_t *self, double reference_size, double alpha,
-        double truncation_point)
+msp_set_simulation_model_beta(
+    msp_t *self, double reference_size, double alpha, double truncation_point)
 {
     int ret = 0;
 
@@ -6417,13 +6383,13 @@ out:
 
 int
 msp_set_simulation_model_sweep_genic_selection(msp_t *self, double reference_size,
-        double position, double start_frequency, double end_frequency,
-        double alpha, double dt)
+    double position, double start_frequency, double end_frequency, double alpha,
+    double dt)
 {
     int ret = 0;
     simulation_model_t *model = &self->model;
-    genic_selection_trajectory_t *trajectory =
-        &model->params.sweep.trajectory_params.genic_selection_trajectory;
+    genic_selection_trajectory_t *trajectory
+        = &model->params.sweep.trajectory_params.genic_selection_trajectory;
     double L = recomb_map_get_sequence_length(&self->recomb_map);
 
     /* Check the inputs to make sure they make sense */
@@ -6431,8 +6397,8 @@ msp_set_simulation_model_sweep_genic_selection(msp_t *self, double reference_siz
         ret = MSP_ERR_BAD_SWEEP_POSITION;
         goto out;
     }
-    if (start_frequency <= 0.0 || start_frequency >= 1.0
-            || end_frequency <= 0.0 || end_frequency >= 1.0) {
+    if (start_frequency <= 0.0 || start_frequency >= 1.0 || end_frequency <= 0.0
+        || end_frequency >= 1.0) {
         ret = MSP_ERR_BAD_ALLELE_FREQUENCY;
         goto out;
     }

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -20,7 +20,6 @@
 #ifndef __MSPRIME_H__
 #define __MSPRIME_H__
 
-
 #include <stdio.h>
 #include <stdbool.h>
 
@@ -43,25 +42,25 @@
 
 /* Exit codes from msp_run to distinguish different reasons for exiting
  * before coalescence. */
-#define MSP_EXIT_MAX_EVENTS     1
-#define MSP_EXIT_MAX_TIME       2
+#define MSP_EXIT_MAX_EVENTS 1
+#define MSP_EXIT_MAX_TIME 2
 
-#define MSP_NODE_IS_RE_EVENT    (1u << 17)
-#define MSP_NODE_IS_CA_EVENT    (1u << 18)
-#define MSP_NODE_IS_MIG_EVENT   (1u << 19)
-#define MSP_NODE_IS_CEN_EVENT   (1u << 20)
+#define MSP_NODE_IS_RE_EVENT (1u << 17)
+#define MSP_NODE_IS_CA_EVENT (1u << 18)
+#define MSP_NODE_IS_MIG_EVENT (1u << 19)
+#define MSP_NODE_IS_CEN_EVENT (1u << 20)
 
 /* Flags for verify */
-#define MSP_VERIFY_BREAKPOINTS  (1 << 1)
+#define MSP_VERIFY_BREAKPOINTS (1 << 1)
 
 /* Flags for mutgen */
-#define MSP_KEEP_SITES  1
-#define MSP_DISCRETE_SITES  2
+#define MSP_KEEP_SITES 1
+#define MSP_DISCRETE_SITES 2
 
 /* Pedigree states */
-#define MSP_PED_STATE_UNCLIMBED         0
-#define MSP_PED_STATE_CLIMBING          1
-#define MSP_PED_STATE_CLIMB_COMPLETE    2
+#define MSP_PED_STATE_UNCLIMBED 0
+#define MSP_PED_STATE_CLIMBING 1
+#define MSP_PED_STATE_CLIMB_COMPLETE 2
 
 /* FIXME: Using these typedefs to keep the diff size small on the initial
  * tskit transition. Can remove later. */
@@ -169,7 +168,7 @@ typedef struct _sweep_t {
         genic_selection_trajectory_t genic_selection_trajectory;
     } trajectory_params;
     int (*generate_trajectory)(struct _sweep_t *self, struct _msp_t *simulator,
-            size_t *num_steps, double **time, double **allele_frequency);
+        size_t *num_steps, double **time, double **allele_frequency);
     void (*print_state)(struct _sweep_t *self, FILE *out);
 } sweep_t;
 
@@ -187,8 +186,10 @@ typedef struct _simulation_model_t {
     /* Time and rate conversions */
     double (*model_time_to_generations)(struct _simulation_model_t *model, double t);
     double (*generations_to_model_time)(struct _simulation_model_t *model, double g);
-    double (*generation_rate_to_model_rate)(struct _simulation_model_t *model, double rg);
-    double (*model_rate_to_generation_rate)(struct _simulation_model_t *model, double rm);
+    double (*generation_rate_to_model_rate)(
+        struct _simulation_model_t *model, double rg);
+    double (*model_rate_to_generation_rate)(
+        struct _simulation_model_t *model, double rm);
 } simulation_model_t;
 
 typedef struct {
@@ -270,9 +271,9 @@ typedef struct _msp_t {
     /* Methods for getting the waiting time until the next common ancestor
      * event and the event are defined by the simulation model */
     double (*get_common_ancestor_waiting_time)(
-            struct _msp_t *self, population_id_t pop, label_id_t label);
-    int (*common_ancestor_event)(struct _msp_t *selt,
-            population_id_t pop, label_id_t label);
+        struct _msp_t *self, population_id_t pop, label_id_t label);
+    int (*common_ancestor_event)(
+        struct _msp_t *selt, population_id_t pop, label_id_t label);
 } msp_t;
 
 /* Demographic events */
@@ -342,22 +343,21 @@ typedef struct {
     mutation_model_t *model;
 } mutgen_t;
 
-int msp_alloc(msp_t *self,
-        size_t num_samples, sample_t *samples,
-        recomb_map_t *recomb_map, tsk_table_collection_t *from_ts_tables, gsl_rng *rng);
+int msp_alloc(msp_t *self, size_t num_samples, sample_t *samples,
+    recomb_map_t *recomb_map, tsk_table_collection_t *from_ts_tables, gsl_rng *rng);
 int msp_set_start_time(msp_t *self, double start_time);
 int msp_set_simulation_model_hudson(msp_t *self, double population_size);
 int msp_set_simulation_model_smc(msp_t *self, double population_size);
 int msp_set_simulation_model_smc_prime(msp_t *self, double population_size);
 int msp_set_simulation_model_dtwf(msp_t *self, double population_size);
 int msp_set_simulation_model_wf_ped(msp_t *self, double population_size);
-int msp_set_simulation_model_dirac(msp_t *self, double population_size, double psi,
-    double c);
-int msp_set_simulation_model_beta(msp_t *self, double population_size, double alpha,
-        double truncation_point);
+int msp_set_simulation_model_dirac(
+    msp_t *self, double population_size, double psi, double c);
+int msp_set_simulation_model_beta(
+    msp_t *self, double population_size, double alpha, double truncation_point);
 int msp_set_simulation_model_sweep_genic_selection(msp_t *self, double population_size,
-        double position, double start_frequency, double end_frequency,
-        double alpha, double dt);
+    double position, double start_frequency, double end_frequency, double alpha,
+    double dt);
 
 int msp_set_store_migrations(msp_t *self, bool store_migrations);
 int msp_set_store_full_arg(msp_t *self, bool store_full_arg);
@@ -367,35 +367,34 @@ int msp_set_gene_conversion_rate(msp_t *self, double rate, double track_length);
 int msp_set_node_mapping_block_size(msp_t *self, size_t block_size);
 int msp_set_segment_block_size(msp_t *self, size_t block_size);
 int msp_set_avl_node_block_size(msp_t *self, size_t block_size);
-int msp_set_migration_matrix(msp_t *self, size_t size,
-        double *migration_matrix);
-int msp_set_population_configuration(msp_t *self, int population_id,
-        double initial_size, double growth_rate);
+int msp_set_migration_matrix(msp_t *self, size_t size, double *migration_matrix);
+int msp_set_population_configuration(
+    msp_t *self, int population_id, double initial_size, double growth_rate);
 
-int msp_add_population_parameters_change(msp_t *self, double time,
-        int population_id, double size, double growth_rate);
-int msp_add_migration_rate_change(msp_t *self, double time, int matrix_index,
-        double migration_rate);
-int msp_add_mass_migration(msp_t *self, double time, int source, int dest,
-        double proportion);
-int msp_add_simple_bottleneck(msp_t *self, double time, int population_id,
-        double intensity);
-int msp_add_instantaneous_bottleneck(msp_t *self, double time, int population_id,
-        double strength);
+int msp_add_population_parameters_change(
+    msp_t *self, double time, int population_id, double size, double growth_rate);
+int msp_add_migration_rate_change(
+    msp_t *self, double time, int matrix_index, double migration_rate);
+int msp_add_mass_migration(
+    msp_t *self, double time, int source, int dest, double proportion);
+int msp_add_simple_bottleneck(
+    msp_t *self, double time, int population_id, double intensity);
+int msp_add_instantaneous_bottleneck(
+    msp_t *self, double time, int population_id, double strength);
 int msp_add_census_event(msp_t *self, double time);
 
 int alloc_individual(individual_t *ind, size_t ploidy);
 int msp_alloc_pedigree(msp_t *self, size_t num_inds, size_t ploidy);
 int msp_free_pedigree(msp_t *self);
 int msp_set_pedigree(msp_t *self, size_t num_rows, int *inds, int *parents,
-        double *times, uint32_t *is_sample);
+    double *times, uint32_t *is_sample);
 int msp_pedigree_load_pop(msp_t *self);
 void msp_check_samples(msp_t *self);
 int msp_pedigree_build_ind_queue(msp_t *self);
 int msp_pedigree_push_ind(msp_t *self, individual_t *ind);
 int msp_pedigree_pop_ind(msp_t *self, individual_t **ind);
-int msp_pedigree_add_individual_segment(msp_t *self, individual_t *ind,
-        segment_t *segment, size_t parent_ix);
+int msp_pedigree_add_individual_segment(
+    msp_t *self, individual_t *ind, segment_t *segment, size_t parent_ix);
 int msp_pedigree_climb(msp_t *self);
 void msp_print_pedigree_inds(msp_t *self, FILE *out);
 
@@ -413,14 +412,14 @@ int msp_get_breakpoints(msp_t *self, size_t *breakpoints);
 int msp_get_migration_matrix(msp_t *self, double *migration_matrix);
 int msp_get_num_migration_events(msp_t *self, size_t *num_migration_events);
 int msp_get_samples(msp_t *self, sample_t **samples);
-int msp_get_population_configuration(msp_t *self, size_t population_id,
-        double *initial_size, double *growth_rate);
-int msp_compute_population_size(msp_t *self, size_t population_id,
-        double time, double *pop_size);
+int msp_get_population_configuration(
+    msp_t *self, size_t population_id, double *initial_size, double *growth_rate);
+int msp_compute_population_size(
+    msp_t *self, size_t population_id, double time, double *pop_size);
 int msp_is_completed(msp_t *self);
 
-simulation_model_t * msp_get_model(msp_t *self);
-const char * msp_get_model_name(msp_t *self);
+simulation_model_t *msp_get_model(msp_t *self);
+const char *msp_get_model_name(msp_t *self);
 bool msp_get_store_migrations(msp_t *self);
 double msp_get_recombination_rate(msp_t *self);
 double msp_get_gene_conversion_rate(msp_t *self);
@@ -442,10 +441,10 @@ size_t msp_get_num_rejected_common_ancestor_events(msp_t *self);
 size_t msp_get_num_recombination_events(msp_t *self);
 size_t msp_get_num_gene_conversion_events(msp_t *self);
 
-int interval_map_alloc(interval_map_t *self, size_t size,
-        double *position, double *value);
-int interval_map_alloc_single(interval_map_t *self,
-        double sequence_length, double value);
+int interval_map_alloc(
+    interval_map_t *self, size_t size, double *position, double *value);
+int interval_map_alloc_single(
+    interval_map_t *self, double sequence_length, double value);
 int interval_map_free(interval_map_t *self);
 void interval_map_print_state(interval_map_t *self, FILE *out);
 double interval_map_get_sequence_length(interval_map_t *self);
@@ -453,12 +452,12 @@ size_t interval_map_get_size(interval_map_t *self);
 size_t interval_map_get_num_intervals(interval_map_t *self);
 size_t interval_map_get_index(interval_map_t *self, double x);
 
-typedef double (*msp_convert_func) (void *obj, double rate);
+typedef double (*msp_convert_func)(void *obj, double rate);
 
-int recomb_map_alloc_uniform(recomb_map_t *self,
-        double sequence_length, double rate, bool discrete);
-int recomb_map_alloc(recomb_map_t *self,
-        size_t size, double *position, double *rate, bool discrete);
+int recomb_map_alloc_uniform(
+    recomb_map_t *self, double sequence_length, double rate, bool discrete);
+int recomb_map_alloc(
+    recomb_map_t *self, size_t size, double *position, double *rate, bool discrete);
 int recomb_map_copy(recomb_map_t *to, recomb_map_t *from);
 int recomb_map_free(recomb_map_t *self);
 double recomb_map_get_sequence_length(recomb_map_t *self);
@@ -471,28 +470,30 @@ int recomb_map_get_rates(recomb_map_t *self, double *rates);
 
 void recomb_map_print_state(recomb_map_t *self, FILE *out);
 
-double recomb_map_mass_between_left_exclusive(recomb_map_t *self, double left, double right);
+double recomb_map_mass_between_left_exclusive(
+    recomb_map_t *self, double left, double right);
 double recomb_map_mass_between(recomb_map_t *self, double left, double right);
 double recomb_map_mass_to_position(recomb_map_t *self, double mass);
 double recomb_map_position_to_mass(recomb_map_t *self, double position);
 double recomb_map_shift_by_mass(recomb_map_t *self, double pos, double mass);
 double recomb_map_sample_poisson(recomb_map_t *self, gsl_rng *rng, double start);
 
-int mutation_model_alloc(mutation_model_t *self, size_t num_alleles,
-        char **alleles, double *root_distribution, double *transition_matrix);
+int mutation_model_alloc(mutation_model_t *self, size_t num_alleles, char **alleles,
+    double *root_distribution, double *transition_matrix);
 int mutation_model_free(mutation_model_t *self);
 size_t mutation_model_get_num_alleles(mutation_model_t *self);
 void mutation_model_print_state(mutation_model_t *self, FILE *out);
 int mutation_model_factory(mutation_model_t *self, int model);
 
 int mutgen_alloc(mutgen_t *self, gsl_rng *rng, interval_map_t *rate_map,
-        mutation_model_t *model, size_t mutation_block_size);
+    mutation_model_t *model, size_t mutation_block_size);
 int mutgen_set_time_interval(mutgen_t *self, double start_time, double end_time);
 int mutgen_free(mutgen_t *self);
 int mutgen_generate(mutgen_t *self, tsk_table_collection_t *tables, int flags);
 void mutgen_print_state(mutgen_t *self, FILE *out);
 
 /* Functions exposed here for unit testing. Not part of public API. */
-int msp_multi_merger_common_ancestor_event(msp_t *self, avl_tree_t *ancestors, avl_tree_t *Q, uint32_t k);
+int msp_multi_merger_common_ancestor_event(
+    msp_t *self, avl_tree_t *ancestors, avl_tree_t *Q, uint32_t k);
 
 #endif /*__MSPRIME_H__*/

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -114,7 +114,7 @@ sort_mutations(site_t *site)
             if (k == num_mutations - 1) {
                 m->next = NULL;
             } else {
-                m->next = p[k+1];
+                m->next = p[k + 1];
             }
         }
     }
@@ -205,8 +205,8 @@ out:
 }
 
 int MSP_WARN_UNUSED
-mutation_model_alloc(mutation_model_t *self, size_t num_alleles,
-        char **alleles, double *root_distribution, double *transition_matrix)
+mutation_model_alloc(mutation_model_t *self, size_t num_alleles, char **alleles,
+    double *root_distribution, double *transition_matrix)
 {
     int ret = 0;
 
@@ -217,18 +217,18 @@ mutation_model_alloc(mutation_model_t *self, size_t num_alleles,
     }
     self->alleles = calloc(num_alleles, sizeof(*self->alleles));
     self->root_distribution = malloc(num_alleles * sizeof(*self->root_distribution));
-    self->transition_matrix = malloc(num_alleles * num_alleles
-        * sizeof(*self->transition_matrix));
+    self->transition_matrix
+        = malloc(num_alleles * num_alleles * sizeof(*self->transition_matrix));
     if (self->alleles == NULL || self->root_distribution == NULL
-            || self->transition_matrix == NULL) {
+        || self->transition_matrix == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
     self->num_alleles = num_alleles;
     memcpy(self->root_distribution, root_distribution,
-            num_alleles * sizeof(*root_distribution));
+        num_alleles * sizeof(*root_distribution));
     memcpy(self->transition_matrix, transition_matrix,
-            num_alleles * num_alleles * sizeof(*transition_matrix));
+        num_alleles * num_alleles * sizeof(*transition_matrix));
     ret = mutation_model_copy_alleles(self, alleles);
     if (ret != 0) {
         goto out;
@@ -276,19 +276,16 @@ mutation_model_allele_index(mutation_model_t *self, const char *allele, size_t l
     return ret;
 }
 
-static const char *binary_alleles[] = {"0", "1"};
-static double binary_model_root_distribution[] = {1.0, 0.0};
-static double binary_model_transition_matrix[] = {0.0, 1.0, 1.0, 0.0};
+static const char *binary_alleles[] = { "0", "1" };
+static double binary_model_root_distribution[] = { 1.0, 0.0 };
+static double binary_model_transition_matrix[] = { 0.0, 1.0, 1.0, 0.0 };
 
 #define ONE_THIRD (1.0 / 3.0)
-static const char *acgt_alleles[] = {"A", "C", "G", "T"};
-static double jukes_cantor_model_root_distribution[] = {0.25, 0.25, 0.25, 0.25};
-static double jukes_cantor_model_transition_matrix[] =
-        {0.0, ONE_THIRD, ONE_THIRD, ONE_THIRD,
-        ONE_THIRD, 0.0, ONE_THIRD, ONE_THIRD,
-        ONE_THIRD, ONE_THIRD, 0.0, ONE_THIRD,
-        ONE_THIRD, ONE_THIRD, ONE_THIRD, 0.0};
-
+static const char *acgt_alleles[] = { "A", "C", "G", "T" };
+static double jukes_cantor_model_root_distribution[] = { 0.25, 0.25, 0.25, 0.25 };
+static double jukes_cantor_model_transition_matrix[]
+    = { 0.0, ONE_THIRD, ONE_THIRD, ONE_THIRD, ONE_THIRD, 0.0, ONE_THIRD, ONE_THIRD,
+          ONE_THIRD, ONE_THIRD, 0.0, ONE_THIRD, ONE_THIRD, ONE_THIRD, ONE_THIRD, 0.0 };
 
 /* Populates this mutation model instance with simple mutation model.
  *
@@ -307,10 +304,10 @@ mutation_model_factory(mutation_model_t *self, int model)
      * about discarding const qualifiers. */
     if (model == 0) {
         ret = mutation_model_alloc(self, 2, (char **) (uintptr_t *) binary_alleles,
-                binary_model_root_distribution, binary_model_transition_matrix);
+            binary_model_root_distribution, binary_model_transition_matrix);
     } else if (model == 1) {
         ret = mutation_model_alloc(self, 4, (char **) (uintptr_t *) acgt_alleles,
-                jukes_cantor_model_root_distribution, jukes_cantor_model_transition_matrix);
+            jukes_cantor_model_root_distribution, jukes_cantor_model_transition_matrix);
     }
     return ret;
 }
@@ -362,15 +359,13 @@ mutgen_print_state(mutgen_t *self, FILE *out)
     for (a = self->sites.head; a != NULL; a = a->next) {
         s = (site_t *) a->item;
         fprintf(out, "%f\t%.*s\t%.*s\t(%d)\t%d\n", s->position,
-                (int) s->ancestral_state_length, s->ancestral_state,
-                (int) s->metadata_length, s->metadata,
-                s->new, (int) s->mutations_length);
+            (int) s->ancestral_state_length, s->ancestral_state,
+            (int) s->metadata_length, s->metadata, s->new, (int) s->mutations_length);
         for (m = s->mutations; m != NULL; m = m->next) {
             parent_id = m->parent == NULL ? TSK_NULL : m->parent->id;
-            fprintf(out, "\t(%d)\t%f\t%d\t%d\t%.*s\t%.*s\t(%d)\t%d\n",
-                    m->id, m->time, m->node, parent_id,
-                    (int) m->derived_state_length, m->derived_state,
-                    (int) m->metadata_length, m->metadata, m->new, m->keep);
+            fprintf(out, "\t(%d)\t%f\t%d\t%d\t%.*s\t%.*s\t(%d)\t%d\n", m->id, m->time,
+                m->node, parent_id, (int) m->derived_state_length, m->derived_state,
+                (int) m->metadata_length, m->metadata, m->new, m->keep);
         }
     }
     mutgen_check_state(self);
@@ -378,7 +373,7 @@ mutgen_print_state(mutgen_t *self, FILE *out)
 
 int MSP_WARN_UNUSED
 mutgen_alloc(mutgen_t *self, gsl_rng *rng, interval_map_t *rate_map,
-        mutation_model_t *model, size_t block_size)
+    mutation_model_t *model, size_t block_size)
 {
     int ret = 0;
     size_t j;
@@ -453,12 +448,14 @@ mutgen_init_allocator(mutgen_t *self, tsk_table_collection_t *tables)
      * We need to add one because the assert trips when the block size is equal
      * to chunk size (probably wrongly).
      */
-    self->block_size = GSL_MAX(self->block_size, 1 + tables->sites.ancestral_state_length);
+    self->block_size
+        = GSL_MAX(self->block_size, 1 + tables->sites.ancestral_state_length);
     self->block_size = GSL_MAX(self->block_size, 1 + tables->sites.metadata_length);
-    self->block_size = GSL_MAX(self->block_size, 1 + tables->mutations.derived_state_length);
+    self->block_size
+        = GSL_MAX(self->block_size, 1 + tables->mutations.derived_state_length);
     self->block_size = GSL_MAX(self->block_size, 1 + tables->mutations.metadata_length);
-    self->block_size = GSL_MAX(self->block_size,
-            (1 + tables->mutations.num_rows) * sizeof(tsk_mutation_t));
+    self->block_size = GSL_MAX(
+        self->block_size, (1 + tables->mutations.num_rows) * sizeof(tsk_mutation_t));
     ret = tsk_blkalloc_init(&self->allocator, self->block_size);
     if (ret != 0) {
         ret = msp_set_tsk_error(ret);
@@ -469,10 +466,9 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_site(mutgen_t *self, double position, bool new,
-        const char *ancestral_state, tsk_size_t ancestral_state_length,
-        const char *metadata, tsk_size_t metadata_length,
-        avl_node_t **avl_nodep)
+mutgen_add_site(mutgen_t *self, double position, bool new, const char *ancestral_state,
+    tsk_size_t ancestral_state_length, const char *metadata, tsk_size_t metadata_length,
+    avl_node_t **avl_nodep)
 {
     int ret = 0;
     char *buff;
@@ -522,10 +518,9 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_mutation(mutgen_t *self, site_t *site,
-        tsk_id_t id, node_id_t node, double time, bool new,
-        const char *derived_state, tsk_size_t derived_state_length,
-        const char *metadata, tsk_size_t metadata_length)
+mutgen_add_mutation(mutgen_t *self, site_t *site, tsk_id_t id, node_id_t node,
+    double time, bool new, const char *derived_state, tsk_size_t derived_state_length,
+    const char *metadata, tsk_size_t metadata_length)
 {
     int ret = 0;
     char *buff;
@@ -536,8 +531,7 @@ mutgen_add_mutation(mutgen_t *self, site_t *site,
         goto out;
     }
     memset(mutation, 0, sizeof(*mutation));
-    mutation->id = id,
-    mutation->node = node;
+    mutation->id = id, mutation->node = node;
     mutation->parent = NULL;
     mutation->time = time;
     mutation->new = new;
@@ -589,12 +583,12 @@ mutgen_initialise_sites(mutgen_t *self, tsk_table_collection_t *tables)
         }
         state = sites->ancestral_state + sites->ancestral_state_offset[site_id];
         length = sites->ancestral_state_offset[site_id + 1]
-                    - sites->ancestral_state_offset[site_id];
+                 - sites->ancestral_state_offset[site_id];
         metadata = sites->metadata + sites->metadata_offset[site_id];
-        metadata_length = sites->metadata_offset[site_id + 1]
-                    - sites->metadata_offset[site_id];
-        ret = mutgen_add_site(self, sites->position[site_id], false,
-                    state, length, metadata, metadata_length, &avl_node);
+        metadata_length
+            = sites->metadata_offset[site_id + 1] - sites->metadata_offset[site_id];
+        ret = mutgen_add_site(self, sites->position[site_id], false, state, length,
+            metadata, metadata_length, &avl_node);
         if (ret != 0) {
             goto out;
         }
@@ -603,14 +597,13 @@ mutgen_initialise_sites(mutgen_t *self, tsk_table_collection_t *tables)
             assert(j < mutations->num_rows);
             state = mutations->derived_state + mutations->derived_state_offset[j];
             length = mutations->derived_state_offset[j + 1]
-                        - mutations->derived_state_offset[j];
+                     - mutations->derived_state_offset[j];
             metadata = mutations->metadata + mutations->metadata_offset[j];
-            metadata_length = mutations->metadata_offset[j + 1]
-                        - mutations->metadata_offset[j];
-            ret = mutgen_add_mutation(self,
-                    (site_t *) avl_node->item, (int) j,
-                    mutations->node[j], nodes->time[mutations->node[j]], false,
-                    state, length, metadata, metadata_length);
+            metadata_length
+                = mutations->metadata_offset[j + 1] - mutations->metadata_offset[j];
+            ret = mutgen_add_mutation(self, (site_t *) avl_node->item, (int) j,
+                mutations->node[j], nodes->time[mutations->node[j]], false, state,
+                length, metadata, metadata_length);
             if (ret != 0) {
                 goto out;
             }
@@ -623,7 +616,8 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_populate_tables(mutgen_t *self, tsk_site_table_t *sites, tsk_mutation_table_t *mutations)
+mutgen_populate_tables(
+    mutgen_t *self, tsk_site_table_t *sites, tsk_mutation_table_t *mutations)
 {
     int ret = 0;
     tsk_id_t site_id, mutation_id, parent_id;
@@ -644,10 +638,9 @@ mutgen_populate_tables(mutgen_t *self, tsk_site_table_t *sites, tsk_mutation_tab
                     parent_id = m->parent->id;
                     assert(parent_id != TSK_NULL);
                 }
-                mutation_id = tsk_mutation_table_add_row(mutations, site_id,
-                                m->node, parent_id,
-                                m->derived_state, m->derived_state_length,
-                                m->metadata, m->metadata_length);
+                mutation_id = tsk_mutation_table_add_row(mutations, site_id, m->node,
+                    parent_id, m->derived_state, m->derived_state_length, m->metadata,
+                    m->metadata_length);
                 if (mutation_id < 0) {
                     ret = msp_set_tsk_error(mutation_id);
                     goto out;
@@ -660,7 +653,7 @@ mutgen_populate_tables(mutgen_t *self, tsk_site_table_t *sites, tsk_mutation_tab
         /* Omit any new sites that have no mutations */
         if ((!site->new) || num_mutations > 0) {
             ret = tsk_site_table_add_row(sites, site->position, site->ancestral_state,
-                    site->ancestral_state_length, site->metadata, site->metadata_length);
+                site->ancestral_state_length, site->metadata, site->metadata_length);
             if (ret < 0) {
                 goto out;
             }
@@ -673,7 +666,8 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_place_mutations(mutgen_t *self, tsk_table_collection_t *tables, bool discrete_sites)
+mutgen_place_mutations(
+    mutgen_t *self, tsk_table_collection_t *tables, bool discrete_sites)
 {
     /* The mutation model for discrete sites is that there is
      * a unit of "mutation mass" on each integer, so that
@@ -733,16 +727,14 @@ mutgen_place_mutations(mutgen_t *self, tsk_table_collection_t *tables, bool disc
                 assert(site_left <= position && position < site_right);
                 assert(branch_start <= time && time < branch_end);
                 if (avl_node == NULL) {
-                    ret = mutgen_add_site(self, position, true,
-                            NULL, 0, NULL, 0, &avl_node);
+                    ret = mutgen_add_site(
+                        self, position, true, NULL, 0, NULL, 0, &avl_node);
                     if (ret != 0) {
                         goto out;
                     }
                 }
-                ret = mutgen_add_mutation(self,
-                        (site_t *) avl_node->item,
-                        TSK_NULL, child, time, true,
-                        NULL, 0, NULL, 0);
+                ret = mutgen_add_mutation(self, (site_t *) avl_node->item, TSK_NULL,
+                    child, time, true, NULL, 0, NULL, 0);
                 if (ret != 0) {
                     goto out;
                 }
@@ -820,7 +812,7 @@ out:
 
 static int MSP_WARN_UNUSED
 mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_mutation,
-        tsk_size_t num_nodes, site_t *site)
+    tsk_size_t num_nodes, site_t *site)
 {
     int ret = 0;
     int ai, pa, da;
@@ -843,8 +835,8 @@ mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_muta
          * because it's ok if we don't try to add a mutation to the site,
          * e.g., if it is kept and we're doing infinite sites, or if we're
          * mutating a different part of the genome  */
-        ai = mutation_model_allele_index(self->model,
-                site->ancestral_state, site->ancestral_state_length);
+        ai = mutation_model_allele_index(
+            self->model, site->ancestral_state, site->ancestral_state_length);
     }
 
     /* Create a mapping from mutations to nodes in bottom_mutation. If we see
@@ -867,8 +859,8 @@ mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_muta
                 goto out;
             }
             if (mut->new) {
-                pa = mutation_model_allele_index(self->model,
-                        parent_mut->derived_state, parent_mut->derived_state_length);
+                pa = mutation_model_allele_index(self->model, parent_mut->derived_state,
+                    parent_mut->derived_state_length);
             }
         }
         if (mut->new) {
@@ -962,8 +954,8 @@ mutgen_apply_mutations(mutgen_t *self, tsk_table_collection_t *tables)
             if (site->position >= right) {
                 break;
             }
-            ret = mutgen_choose_alleles(self, parent, bottom_mutation,
-                    nodes.num_rows, site);
+            ret = mutgen_choose_alleles(
+                self, parent, bottom_mutation, nodes.num_rows, site);
             if (ret != 0) {
                 goto out;
             }
@@ -978,7 +970,6 @@ out:
     msp_safe_free(bottom_mutation);
     return ret;
 }
-
 
 int MSP_WARN_UNUSED
 mutgen_generate(mutgen_t *self, tsk_table_collection_t *tables, int flags)

--- a/lib/object_heap.c
+++ b/lib/object_heap.c
@@ -40,8 +40,7 @@ object_heap_print_state(object_heap_t *self, FILE *out)
     fprintf(out, "\ttop = %d\n", (int) self->top);
     fprintf(out, "\tblock_size = %d\n", (int) self->block_size);
     fprintf(out, "\tnum_blocks = %d\n", (int) self->num_blocks);
-    fprintf(out, "\ttotal allocated = %d\n",
-            (int) object_heap_get_num_allocated(self));
+    fprintf(out, "\ttotal allocated = %d\n", (int) object_heap_get_num_allocated(self));
 }
 
 static void
@@ -99,7 +98,7 @@ out:
 /*
  * Returns the jth object in the memory buffers.
  */
-inline void * MSP_WARN_UNUSED
+inline void *MSP_WARN_UNUSED
 object_heap_get_object(object_heap_t *self, size_t index)
 {
     void *ret = NULL;
@@ -119,7 +118,7 @@ object_heap_empty(object_heap_t *self)
     return self->top == 0;
 }
 
-inline void * MSP_WARN_UNUSED
+inline void *MSP_WARN_UNUSED
 object_heap_alloc_object(object_heap_t *self)
 {
     void *ret = NULL;
@@ -141,7 +140,7 @@ object_heap_free_object(object_heap_t *self, void *obj)
 
 int MSP_WARN_UNUSED
 object_heap_init(object_heap_t *self, size_t object_size, size_t block_size,
-        void (*init_object)(void **, size_t))
+    void (*init_object)(void **, size_t))
 {
     int ret = -1;
 

--- a/lib/object_heap.h
+++ b/lib/object_heap.h
@@ -40,12 +40,12 @@ typedef struct {
 extern size_t object_heap_get_num_allocated(object_heap_t *self);
 extern void object_heap_print_state(object_heap_t *self, FILE *out);
 extern int object_heap_expand(object_heap_t *self);
-extern void * object_heap_get_object(object_heap_t *self, size_t index);
+extern void *object_heap_get_object(object_heap_t *self, size_t index);
 extern int object_heap_empty(object_heap_t *self);
-extern void * object_heap_alloc_object(object_heap_t *self);
+extern void *object_heap_alloc_object(object_heap_t *self);
 extern void object_heap_free_object(object_heap_t *self, void *obj);
 extern int object_heap_init(object_heap_t *self, size_t object_size, size_t block_size,
-        void (*init_object)(void **, size_t));
+    void (*init_object)(void **, size_t));
 extern void object_heap_free(object_heap_t *self);
 
 #endif

--- a/lib/recomb_map.c
+++ b/lib/recomb_map.c
@@ -56,18 +56,18 @@ out:
 }
 
 int MSP_WARN_UNUSED
-recomb_map_alloc_uniform(recomb_map_t *self, double sequence_length,
-        double rate, bool discrete)
+recomb_map_alloc_uniform(
+    recomb_map_t *self, double sequence_length, double rate, bool discrete)
 {
-    double positions[] = {0.0, sequence_length};
-    double rates[] = {rate, 0.0};
+    double positions[] = { 0.0, sequence_length };
+    double rates[] = { rate, 0.0 };
 
     return recomb_map_alloc(self, 2, positions, rates, discrete);
 }
 
 int MSP_WARN_UNUSED
-recomb_map_alloc(recomb_map_t *self, size_t size, double *position, double *rate,
-        bool discrete)
+recomb_map_alloc(
+    recomb_map_t *self, size_t size, double *position, double *rate, bool discrete)
 {
     int ret = 0;
 
@@ -95,8 +95,8 @@ out:
 int
 recomb_map_copy(recomb_map_t *to, recomb_map_t *from)
 {
-    return recomb_map_alloc(to, from->map.size,
-            from->map.position, from->map.value, from->discrete);
+    return recomb_map_alloc(
+        to, from->map.size, from->map.position, from->map.value, from->discrete);
 }
 
 int
@@ -240,7 +240,8 @@ recomb_map_get_positions(recomb_map_t *self, double *position)
     return 0;
 }
 
-int recomb_map_get_rates(recomb_map_t *self, double *rate)
+int
+recomb_map_get_rates(recomb_map_t *self, double *rate)
 {
     memcpy(rate, self->map.value, sizeof(double) * self->map.size);
     return 0;

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -33,18 +33,17 @@
 #include <gsl/gsl_randist.h>
 #include <CUnit/Basic.h>
 
-
 #define ALPHABET_BINARY 0
 #define ALPHABET_NUCLEOTIDE 1
 
 /* Global variables used for test in state in the test suite */
 
-char * _tmp_file_name;
-FILE * _devnull;
+char *_tmp_file_name;
+FILE *_devnull;
 
 static void
-verify_simulator_tsk_treeseq_equality(msp_t *msp, tsk_treeseq_t *tree_seq,
-        mutgen_t *mutgen, double scale)
+verify_simulator_tsk_treeseq_equality(
+    msp_t *msp, tsk_treeseq_t *tree_seq, mutgen_t *mutgen, double scale)
 {
     int ret;
     uint32_t num_samples = msp_get_num_samples(msp);
@@ -54,19 +53,15 @@ verify_simulator_tsk_treeseq_equality(msp_t *msp, tsk_treeseq_t *tree_seq,
     node_id_t *sample_ids;
 
     CU_ASSERT_EQUAL_FATAL(
-            tsk_treeseq_get_num_samples(tree_seq),
-            msp_get_num_samples(msp));
+        tsk_treeseq_get_num_samples(tree_seq), msp_get_num_samples(msp));
+    CU_ASSERT_EQUAL_FATAL(tsk_treeseq_get_num_edges(tree_seq), msp_get_num_edges(msp));
     CU_ASSERT_EQUAL_FATAL(
-            tsk_treeseq_get_num_edges(tree_seq),
-            msp_get_num_edges(msp));
-    CU_ASSERT_EQUAL_FATAL(
-            tsk_treeseq_get_num_migrations(tree_seq),
-            msp_get_num_migrations(msp));
+        tsk_treeseq_get_num_migrations(tree_seq), msp_get_num_migrations(msp));
     ret = msp_get_samples(msp, &samples);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FATAL(tsk_treeseq_get_num_nodes(tree_seq) >= num_samples);
     CU_ASSERT_TRUE(tsk_migration_table_equals(
-                &msp->tables->migrations, &tree_seq->tables->migrations))
+        &msp->tables->migrations, &tree_seq->tables->migrations))
 
     for (j = 0; j < num_samples; j++) {
         ret = tsk_treeseq_get_node(tree_seq, j, &node);
@@ -137,7 +132,8 @@ test_fenwick_expand(void)
         CU_ASSERT(fenwick_expand(&t1, 2 * n) == 0);
         CU_ASSERT_EQUAL(t1.size, t2.size);
         CU_ASSERT_EQUAL(memcmp(t1.tree, t2.tree, (t2.size + 1) * sizeof(int64_t)), 0);
-        CU_ASSERT_EQUAL(memcmp(t1.values, t2.values, (t2.size + 1) * sizeof(int64_t)), 0);
+        CU_ASSERT_EQUAL(
+            memcmp(t1.values, t2.values, (t2.size + 1) * sizeof(int64_t)), 0);
         CU_ASSERT(fenwick_free(&t1) == 0);
         CU_ASSERT(fenwick_free(&t2) == 0);
     }
@@ -149,7 +145,7 @@ test_single_locus_two_populations(void)
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 0.0}, {1, 40.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 0.0 }, { 1, 40.0 } };
     tsk_table_collection_t tables;
     tsk_edge_table_t *edges;
     tsk_node_table_t *nodes;
@@ -237,7 +233,7 @@ test_single_locus_many_populations(void)
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     uint32_t num_populations = 500;
-    sample_t samples[] = {{0, 0.0}, {num_populations - 1, 0.0}};
+    sample_t samples[] = { { 0, 0.0 }, { num_populations - 1, 0.0 } };
     uint32_t n = 2;
     recomb_map_t recomb_map;
     tsk_table_collection_t tables;
@@ -283,7 +279,7 @@ test_dtwf_simultaneous_historical_samples(void)
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0}, {0, 1.1}, {0, 1.2}};
+    sample_t samples[] = { { 0, 0 }, { 0, 1.1 }, { 0, 1.2 } };
     tsk_node_table_t *nodes;
     uint32_t n = 3;
     recomb_map_t recomb_map;
@@ -333,7 +329,7 @@ test_single_locus_historical_sample(void)
     int ret, j;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 101.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 101.0 } };
     tsk_edge_table_t *edges;
     tsk_node_table_t *nodes;
     uint32_t n = 2;
@@ -399,7 +395,7 @@ test_single_locus_multiple_historical_samples(void)
     int ret, j;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 10.0}, {0, 10.0}, {0, 10.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 10.0 }, { 0, 10.0 }, { 0, 10.0 } };
     /* tsk_edge_table_t *edges; */
     /* tsk_node_table_t *nodes; */
     uint32_t n = 4;
@@ -458,14 +454,14 @@ test_single_locus_historical_sample_start_time(void)
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 10.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 10.0 } };
     tsk_edge_table_t *edges;
     tsk_node_table_t *nodes;
     uint32_t n = 2;
     size_t j, model;
     recomb_map_t recomb_map;
     tsk_table_collection_t tables;
-    double start_times[] = {0, 2, 10, 10.0001, 1000};
+    double start_times[] = { 0, 2, 10, 10.0001, 1000 };
     /* double start_times[] = {0, 2, 9.99}; //10, 1000}; */
     /* double start_times[] = {10.00}; //10, 1000}; */
 
@@ -534,7 +530,7 @@ test_single_locus_historical_sample_end_time(void)
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 10.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 10.0 } };
     tsk_node_table_t *nodes;
     uint32_t n = 2;
     size_t model;
@@ -609,7 +605,7 @@ test_simulator_getters_setters(void)
     uint32_t m = 10;
     sample_t *samples = malloc(n * sizeof(sample_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    double migration_matrix[] = {0, 0, 0, 0};
+    double migration_matrix[] = { 0, 0, 0, 0 };
     double matrix[4], growth_rate, initial_size;
     double Ne = 4;
     size_t migration_events[4];
@@ -631,7 +627,8 @@ test_simulator_getters_setters(void)
     }
     CU_ASSERT_EQUAL(msp_alloc(&msp, 0, NULL, NULL, NULL, rng), MSP_ERR_BAD_PARAM_VALUE);
     msp_free(&msp);
-    CU_ASSERT_EQUAL(msp_alloc(&msp, n, samples, NULL, NULL, rng), MSP_ERR_BAD_PARAM_VALUE);
+    CU_ASSERT_EQUAL(
+        msp_alloc(&msp, n, samples, NULL, NULL, rng), MSP_ERR_BAD_PARAM_VALUE);
     msp_free(&msp);
     ret = msp_alloc(&msp, 0, samples, &recomb_map, &tables, rng);
     msp_free(&msp);
@@ -642,8 +639,8 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SAMPLES);
     msp_free(&msp);
     samples[0].time = -1.0;
-    CU_ASSERT_EQUAL(msp_alloc(&msp, n, samples, &recomb_map, &tables, rng),
-            MSP_ERR_BAD_PARAM_VALUE);
+    CU_ASSERT_EQUAL(
+        msp_alloc(&msp, n, samples, &recomb_map, &tables, rng), MSP_ERR_BAD_PARAM_VALUE);
     msp_free(&msp);
     samples[0].time = 0.0;
 
@@ -651,19 +648,14 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(msp_set_dimensions(&msp, 0, 1), MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_dimensions(&msp, 1, 0), MSP_ERR_BAD_PARAM_VALUE);
-    CU_ASSERT_EQUAL(msp_set_node_mapping_block_size(&msp, 0),
-            MSP_ERR_BAD_PARAM_VALUE);
-    CU_ASSERT_EQUAL(msp_set_segment_block_size(&msp, 0),
-            MSP_ERR_BAD_PARAM_VALUE);
-    CU_ASSERT_EQUAL(msp_set_avl_node_block_size(&msp, 0),
-            MSP_ERR_BAD_PARAM_VALUE);
+    CU_ASSERT_EQUAL(msp_set_node_mapping_block_size(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
+    CU_ASSERT_EQUAL(msp_set_segment_block_size(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
+    CU_ASSERT_EQUAL(msp_set_avl_node_block_size(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_num_populations(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
-    CU_ASSERT_EQUAL(
-            msp_set_population_configuration(&msp, -1, 0, 0),
-            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
-    CU_ASSERT_EQUAL(
-            msp_set_population_configuration(&msp, 3, 0, 0),
-            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+    CU_ASSERT_EQUAL(msp_set_population_configuration(&msp, -1, 0, 0),
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+    CU_ASSERT_EQUAL(msp_set_population_configuration(&msp, 3, 0, 0),
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
 
     ret = msp_set_simulation_model_hudson(&msp, Ne);
     CU_ASSERT_EQUAL(msp_get_model(&msp)->type, MSP_MODEL_HUDSON);
@@ -671,27 +663,22 @@ test_simulator_getters_setters(void)
 
     ret = msp_set_num_populations(&msp, 2);
     CU_ASSERT_EQUAL(ret, 0);
-    CU_ASSERT_EQUAL(
-            msp_get_population_configuration(&msp, 3, NULL, NULL),
-            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+    CU_ASSERT_EQUAL(msp_get_population_configuration(&msp, 3, NULL, NULL),
+        MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     ret = msp_set_population_configuration(&msp, 0, 2 * Ne, 0.5);
     CU_ASSERT_EQUAL(ret, 0);
 
     CU_ASSERT_EQUAL(
-            msp_set_migration_matrix(&msp, 0, NULL),
-            MSP_ERR_BAD_MIGRATION_MATRIX);
-    CU_ASSERT_EQUAL(
-            msp_set_migration_matrix(&msp, 3, migration_matrix),
-            MSP_ERR_BAD_MIGRATION_MATRIX);
+        msp_set_migration_matrix(&msp, 0, NULL), MSP_ERR_BAD_MIGRATION_MATRIX);
+    CU_ASSERT_EQUAL(msp_set_migration_matrix(&msp, 3, migration_matrix),
+        MSP_ERR_BAD_MIGRATION_MATRIX);
     migration_matrix[0] = 1;
-    CU_ASSERT_EQUAL(
-            msp_set_migration_matrix(&msp, 4, migration_matrix),
-            MSP_ERR_BAD_MIGRATION_MATRIX);
+    CU_ASSERT_EQUAL(msp_set_migration_matrix(&msp, 4, migration_matrix),
+        MSP_ERR_BAD_MIGRATION_MATRIX);
     migration_matrix[0] = 0;
     migration_matrix[1] = -1;
-    CU_ASSERT_EQUAL(
-            msp_set_migration_matrix(&msp, 4, migration_matrix),
-            MSP_ERR_BAD_MIGRATION_MATRIX);
+    CU_ASSERT_EQUAL(msp_set_migration_matrix(&msp, 4, migration_matrix),
+        MSP_ERR_BAD_MIGRATION_MATRIX);
 
     migration_matrix[1] = 1;
     migration_matrix[2] = 1;
@@ -754,7 +741,7 @@ test_demographic_events(void)
     uint32_t m = 10;
     sample_t *samples = malloc(n * sizeof(sample_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    double migration_matrix[] = {0, 1, 1, 0};
+    double migration_matrix[] = { 0, 1, 1, 0 };
     double last_time, time, pop_size;
     recomb_map_t recomb_map;
     tsk_table_collection_t tables;
@@ -801,62 +788,45 @@ test_demographic_events(void)
             CU_ASSERT_EQUAL(ret, 0);
         }
 
-        CU_ASSERT_EQUAL(
-            msp_add_mass_migration(&msp, 10, -1, 0, 1),
+        CU_ASSERT_EQUAL(msp_add_mass_migration(&msp, 10, -1, 0, 1),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
         CU_ASSERT_EQUAL(
-            msp_add_mass_migration(&msp, 10, 2, 0, 1),
-            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+            msp_add_mass_migration(&msp, 10, 2, 0, 1), MSP_ERR_POPULATION_OUT_OF_BOUNDS);
         CU_ASSERT_EQUAL(
-            msp_add_mass_migration(&msp, 10, 0, 0, 1),
-            MSP_ERR_SOURCE_DEST_EQUAL);
+            msp_add_mass_migration(&msp, 10, 0, 0, 1), MSP_ERR_SOURCE_DEST_EQUAL);
         CU_ASSERT_EQUAL(
-            msp_add_mass_migration(&msp, 10, 0, 1, -5),
-            MSP_ERR_BAD_PROPORTION);
+            msp_add_mass_migration(&msp, 10, 0, 1, -5), MSP_ERR_BAD_PROPORTION);
 
-        CU_ASSERT_EQUAL(
-            msp_add_migration_rate_change(&msp, 10, -2, 2.0),
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, -2, 2.0),
             MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
         CU_ASSERT_EQUAL(
-            msp_add_migration_rate_change(&msp, 10, -1, -2.0),
-            MSP_ERR_BAD_PARAM_VALUE);
-        CU_ASSERT_EQUAL(
-            msp_add_migration_rate_change(&msp, 10, 3, 2.0),
+            msp_add_migration_rate_change(&msp, 10, -1, -2.0), MSP_ERR_BAD_PARAM_VALUE);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, 3, 2.0),
             MSP_ERR_DIAGONAL_MIGRATION_MATRIX_INDEX);
 
-        CU_ASSERT_EQUAL(
-            msp_add_population_parameters_change(&msp, 10, -2, 0, 0),
+        CU_ASSERT_EQUAL(msp_add_population_parameters_change(&msp, 10, -2, 0, 0),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
-        CU_ASSERT_EQUAL(
-            msp_add_population_parameters_change(&msp, 10, -1, -1, 0),
+        CU_ASSERT_EQUAL(msp_add_population_parameters_change(&msp, 10, -1, -1, 0),
             MSP_ERR_BAD_PARAM_VALUE);
         CU_ASSERT_EQUAL(
             msp_add_population_parameters_change(&msp, 10, -1, GSL_NAN, GSL_NAN),
             MSP_ERR_BAD_PARAM_VALUE);
 
-        CU_ASSERT_EQUAL(
-            msp_add_simple_bottleneck(&msp, 10, -1, 0),
+        CU_ASSERT_EQUAL(msp_add_simple_bottleneck(&msp, 10, -1, 0),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
         CU_ASSERT_EQUAL(
-            msp_add_simple_bottleneck(&msp, 10, 0, -1),
-            MSP_ERR_BAD_PROPORTION);
+            msp_add_simple_bottleneck(&msp, 10, 0, -1), MSP_ERR_BAD_PROPORTION);
         CU_ASSERT_EQUAL(
-            msp_add_simple_bottleneck(&msp, 10, 0, 1.1),
-            MSP_ERR_BAD_PROPORTION);
+            msp_add_simple_bottleneck(&msp, 10, 0, 1.1), MSP_ERR_BAD_PROPORTION);
 
-        CU_ASSERT_EQUAL(
-            msp_add_instantaneous_bottleneck(&msp, 10, 2, 0),
+        CU_ASSERT_EQUAL(msp_add_instantaneous_bottleneck(&msp, 10, 2, 0),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
         CU_ASSERT_EQUAL(
-            msp_add_simple_bottleneck(&msp, 10, 0, -1),
-            MSP_ERR_BAD_PROPORTION);
-        CU_ASSERT_EQUAL_FATAL(
-            msp_add_simple_bottleneck(&msp, 10, -1, 0),
+            msp_add_simple_bottleneck(&msp, 10, 0, -1), MSP_ERR_BAD_PROPORTION);
+        CU_ASSERT_EQUAL_FATAL(msp_add_simple_bottleneck(&msp, 10, -1, 0),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
 
-        CU_ASSERT_EQUAL(
-            msp_add_census_event(&msp, -0.5),
-            MSP_ERR_BAD_PARAM_VALUE);
+        CU_ASSERT_EQUAL(msp_add_census_event(&msp, -0.5), MSP_ERR_BAD_PARAM_VALUE);
 
         ret = msp_add_census_event(&msp, 0.05);
         CU_ASSERT_EQUAL(ret, 0);
@@ -896,26 +866,19 @@ test_demographic_events(void)
             CU_ASSERT_EQUAL(ret, 0);
         }
 
-        CU_ASSERT_EQUAL(
-                msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5),
-                MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
-        CU_ASSERT_EQUAL(
-                msp_add_migration_rate_change(&msp, 0.2, 1, 2.0),
-                MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
-        CU_ASSERT_EQUAL(
-                msp_add_population_parameters_change(&msp, 0.4, 0, 0.5, 1.0),
-                MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
+        CU_ASSERT_EQUAL(msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5),
+            MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
+        CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 0.2, 1, 2.0),
+            MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
+        CU_ASSERT_EQUAL(msp_add_population_parameters_change(&msp, 0.4, 0, 0.5, 1.0),
+            MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
 
-        CU_ASSERT_EQUAL(
-                msp_add_simple_bottleneck(&msp, 0.7, 0, 1.0),
-                MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
-        CU_ASSERT_EQUAL(
-                msp_add_instantaneous_bottleneck(&msp, 0.8, 0, 1.0),
-                MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
+        CU_ASSERT_EQUAL(msp_add_simple_bottleneck(&msp, 0.7, 0, 1.0),
+            MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
+        CU_ASSERT_EQUAL(msp_add_instantaneous_bottleneck(&msp, 0.8, 0, 1.0),
+            MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
 
-        CU_ASSERT_EQUAL(
-            msp_debug_demography(&msp, &time),
-            MSP_ERR_BAD_STATE);
+        CU_ASSERT_EQUAL(msp_debug_demography(&msp, &time), MSP_ERR_BAD_STATE);
 
         ret = msp_initialise(&msp);
         CU_ASSERT_EQUAL(ret, 0);
@@ -936,18 +899,16 @@ test_demographic_events(void)
                 CU_ASSERT_EQUAL(ret, 0);
                 CU_ASSERT_TRUE(pop_size >= 0);
                 ret = msp_compute_population_size(
-                        &msp, k, last_time + (time - last_time) / 2, &pop_size);
+                    &msp, k, last_time + (time - last_time) / 2, &pop_size);
                 CU_ASSERT_EQUAL(ret, 0);
                 CU_ASSERT_TRUE(pop_size >= 0);
             }
             j++;
             last_time = time;
-        } while (! gsl_isinf(time));
+        } while (!gsl_isinf(time));
         CU_ASSERT_TRUE(j >= 9);
         CU_ASSERT_EQUAL(ret, 0);
-        CU_ASSERT_EQUAL(
-            msp_run(&msp, DBL_MAX, ULONG_MAX),
-            MSP_ERR_BAD_STATE);
+        CU_ASSERT_EQUAL(msp_run(&msp, DBL_MAX, ULONG_MAX), MSP_ERR_BAD_STATE);
         ret = msp_reset(&msp);
         CU_ASSERT_EQUAL(ret, 0);
         msp_print_state(&msp, _devnull);
@@ -1026,7 +987,7 @@ test_dtwf_events_between_generations(void)
     msp_t msp;
     population_t pop;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    double migration_matrix[] = {0, 0, 0, 0};
+    double migration_matrix[] = { 0, 0, 0, 0 };
     recomb_map_t recomb_map;
     tsk_table_collection_t tables;
 
@@ -1329,10 +1290,10 @@ test_pedigree_multi_locus_simulation(void)
     tsk_table_collection_t tables;
     int num_inds = 4;
     int ploidy = 2;
-    tsk_id_t inds[4] = {1, 2, 3, 4};
-    tsk_id_t parents[8] = {2, 3, 2, 3, -1, -1, -1, -1};  // size num_inds * ploidy
-    double times[4] = {0, 0, 1, 1};
-    tsk_flags_t is_sample[4] = {1, 1, 0, 0};
+    tsk_id_t inds[4] = { 1, 2, 3, 4 };
+    tsk_id_t parents[8] = { 2, 3, 2, 3, -1, -1, -1, -1 }; // size num_inds * ploidy
+    double times[4] = { 0, 0, 1, 1 };
+    tsk_flags_t is_sample[4] = { 1, 1, 0, 0 };
     uint32_t N = 4;
     uint32_t n = 2 * ploidy;
     sample_t *samples = malloc(n * sizeof(sample_t));
@@ -1398,10 +1359,10 @@ test_pedigree_specification(void)
     tsk_table_collection_t tables;
     int num_inds = 4;
     int ploidy = 2;
-    tsk_id_t inds[4] = {1, 2, 3, 4};
-    tsk_id_t parents[8] = {2, 3, 2, 3, -1, -1, -1, -1};  // size num_inds * ploidy
-    double times_good[4] = {0, 0, 1, 1};
-    tsk_flags_t is_sample[4] = {1, 1, 0, 0};
+    tsk_id_t inds[4] = { 1, 2, 3, 4 };
+    tsk_id_t parents[8] = { 2, 3, 2, 3, -1, -1, -1, -1 }; // size num_inds * ploidy
+    double times_good[4] = { 0, 0, 1, 1 };
+    tsk_flags_t is_sample[4] = { 1, 1, 0, 0 };
     uint32_t n = 2 * ploidy;
     sample_t *samples = malloc(n * sizeof(sample_t));
     msp_t *msp = malloc(sizeof(msp_t));
@@ -1449,7 +1410,6 @@ test_pedigree_specification(void)
     tsk_table_collection_free(&tables);
 }
 
-
 static void
 test_pedigree_single_locus_simulation(void)
 {
@@ -1462,12 +1422,12 @@ test_pedigree_single_locus_simulation(void)
     tsk_table_collection_t tables;
     int num_inds = 4;
     int ploidy = 2;
-    tsk_id_t inds[4] = {1, 2, 3, 4};
-    tsk_id_t bad_inds[4] = {0, 1, 2, 3};
-    tsk_id_t parents[8] = {2, 3, 2, 3, -1, -1, -1, -1};  // size num_inds * ploidy
-    double times[4] = {0, 0, 1, 1};
-    tsk_flags_t is_sample[4] = {1, 1, 0, 0};
-    tsk_flags_t bad_is_sample[4] = {1, 0, 0, 0};
+    tsk_id_t inds[4] = { 1, 2, 3, 4 };
+    tsk_id_t bad_inds[4] = { 0, 1, 2, 3 };
+    tsk_id_t parents[8] = { 2, 3, 2, 3, -1, -1, -1, -1 }; // size num_inds * ploidy
+    double times[4] = { 0, 0, 1, 1 };
+    tsk_flags_t is_sample[4] = { 1, 1, 0, 0 };
+    tsk_flags_t bad_is_sample[4] = { 1, 0, 0, 0 };
     uint32_t N = 4;
     uint32_t n = 2 * ploidy;
     sample_t *samples = malloc(n * sizeof(sample_t));
@@ -1518,12 +1478,12 @@ test_pedigree_single_locus_simulation(void)
     /* For the single locus sim we should have n-1 coalescent events,
      * counting multiple mergers as multiple coalescent events */
     for (i = 0; i < msp->tables->nodes.num_rows; i++) {
-      num_children = get_num_children(i, &msp->tables->edges);
-      if (num_children > 0) {
-        num_coalescent_events += num_children - 1;
-      }
+        num_children = get_num_children(i, &msp->tables->edges);
+        if (num_children > 0) {
+            num_coalescent_events += num_children - 1;
+        }
     }
-    CU_ASSERT_EQUAL(num_coalescent_events, n-1);
+    CU_ASSERT_EQUAL(num_coalescent_events, n - 1);
 
     ret = msp_finalise_tables(msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1582,7 +1542,6 @@ test_dtwf_deterministic(void)
         CU_ASSERT_EQUAL(tables[j].migrations.num_rows, 0);
         CU_ASSERT(tables[j].nodes.num_rows > 0);
         CU_ASSERT(tables[j].edges.num_rows > 0);
-
     }
     CU_ASSERT_TRUE(tsk_node_table_equals(&tables[0].nodes, &tables[1].nodes));
     CU_ASSERT_TRUE(tsk_edge_table_equals(&tables[0].edges, &tables[1].edges));
@@ -1741,7 +1700,7 @@ test_dtwf_single_locus_simulation(void)
             num_coalescent_events += num_children - 1;
         }
     }
-    CU_ASSERT_EQUAL(num_coalescent_events, n-1);
+    CU_ASSERT_EQUAL(num_coalescent_events, n - 1);
 
     ret = msp_free(msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1943,7 +1902,7 @@ test_dtwf_multi_locus_simulation(void)
     uint32_t n = 100;
     uint32_t m = 10;
     long seed = 10;
-    double migration_matrix[] = {0, 0.1, 0.1, 0};
+    double migration_matrix[] = { 0, 0.1, 0.1, 0 };
     const char *model_name;
     size_t num_ca_events, num_re_events;
     double t;
@@ -2029,7 +1988,7 @@ test_gene_conversion_simulation(void)
     int ret;
     uint32_t n = 100;
     uint32_t m = 100;
-    double track_lengths[] = {1.0, 1.3333, 5, 100};
+    double track_lengths[] = { 1.0, 1.3333, 5, 100 };
     long seed = 10;
     size_t j, num_events, num_ca_events, num_re_events, num_gc_events;
     recomb_map_t recomb_map;
@@ -2098,11 +2057,11 @@ test_likelihood_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 1.0, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -2121,7 +2080,6 @@ test_likelihood_errors(void)
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-
 
     /* Ne <= 0 is an error */
     ret = msp_log_likelihood_arg(&ts, 1, 0, &lik);
@@ -2151,11 +2109,11 @@ test_likelihood_zero_edges(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, TSK_NULL, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_treeseq_init(&ts, &tables, TSK_BUILD_INDEXES);
@@ -2208,8 +2166,8 @@ test_likelihood_three_leaves(void)
 {
     int i;
     int ret;
-    double rho[] = {0.1, 1, 10};
-    double theta[] = {0.1, 1, 10};
+    double rho[] = { 0.1, 1, 10 };
+    double theta[] = { 0.1, 1, 10 };
     double ll_exact;
     double lik = 0;
     double tree_length = 19.0 / 8;
@@ -2220,20 +2178,25 @@ test_likelihood_three_leaves(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 3, 2);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 4, 2);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 5, 1);
@@ -2312,8 +2275,8 @@ test_likelihood_two_mrcas(void)
 {
     int i;
     int ret;
-    double rho[] = {0.1, 1, 10};
-    double theta[] = {0.1, 1, 10};
+    double rho[] = { 0.1, 1, 10 };
+    double theta[] = { 0.1, 1, 10 };
     double ll_exact;
     double lik = 0;
     double tree_length = 1.5;
@@ -2324,27 +2287,33 @@ test_likelihood_two_mrcas(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 2, 1);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 3, 1);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 4, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 6, 2);
@@ -2407,8 +2376,8 @@ test_likelihood_material_overhang(void)
 {
     int i;
     int ret;
-    double rho[] = {0.1, 1, 10};
-    double theta[] = {0.1, 1, 10};
+    double rho[] = { 0.1, 1, 10 };
+    double theta[] = { 0.1, 1, 10 };
     double ll_exact;
     double lik = 0;
     double tree_length = 81.0 / 50;
@@ -2419,27 +2388,33 @@ test_likelihood_material_overhang(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 2, 1);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 3, 1);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.7, 4, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.7, 1, 5, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 6, 2);
@@ -2510,8 +2485,8 @@ test_likelihood_material_gap(void)
 {
     int i;
     int ret;
-    double rho[] = {0.1, 1, 10};
-    double theta[] = {0.1, 1, 10};
+    double rho[] = { 0.1, 1, 10 };
+    double theta[] = { 0.1, 1, 10 };
     double ll_exact;
     double lik = 0;
     double tree_length = 0.84;
@@ -2522,27 +2497,33 @@ test_likelihood_material_gap(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 2, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 3, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 4, 3);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 3);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 6, 2);
@@ -2622,8 +2603,8 @@ test_likelihood_recombination_in_material_gap(void)
 {
     int i;
     int ret;
-    double rho[] = {0.1, 1, 10};
-    double theta[] = {0.1, 1, 10};
+    double rho[] = { 0.1, 1, 10 };
+    double theta[] = { 0.1, 1, 10 };
     double ll_exact;
     double lik = 0;
     double tree_length = 1.34;
@@ -2634,27 +2615,33 @@ test_likelihood_recombination_in_material_gap(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tables.sequence_length = 1;
 
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 2, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 3, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 4, 3);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 3);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 6, 2);
@@ -2668,9 +2655,11 @@ test_likelihood_recombination_in_material_gap(void)
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 8, 6);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.4, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.4, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables.nodes, MSP_NODE_IS_RE_EVENT, 0.4, 0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.4, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 9, 4);
@@ -2750,12 +2739,12 @@ test_multi_locus_simulation(void)
     uint32_t m = 100;
     long seed = 10;
     int model;
-    double migration_matrix[] = {0, 1, 1, 0};
+    double migration_matrix[] = { 0, 1, 1, 0 };
     size_t migration_events[4];
-    int models[] = {MSP_MODEL_HUDSON, MSP_MODEL_SMC, MSP_MODEL_SMC_PRIME};
-    const char *model_names[] = {"hudson", "smc", "smc_prime"};
+    int models[] = { MSP_MODEL_HUDSON, MSP_MODEL_SMC, MSP_MODEL_SMC_PRIME };
+    const char *model_names[] = { "hudson", "smc", "smc_prime" };
     const char *model_name;
-    bool store_full_arg[] = {true, false};
+    bool store_full_arg[] = { true, false };
     size_t j, k;
     recomb_map_t recomb_map;
     tsk_table_collection_t tables;
@@ -2820,11 +2809,11 @@ test_multi_locus_simulation(void)
             CU_ASSERT_EQUAL(ret, 0);
             CU_ASSERT(num_events > n - 1);
             CU_ASSERT_EQUAL(1 + num_events,
-                    /* diagonals must be zero here */
-                    migration_events[1] + migration_events[2] +
-                    msp_get_num_recombination_events(msp) +
-                    msp_get_num_common_ancestor_events(msp) +
-                    msp_get_num_rejected_common_ancestor_events(msp));
+                /* diagonals must be zero here */
+                migration_events[1] + migration_events[2]
+                    + msp_get_num_recombination_events(msp)
+                    + msp_get_num_common_ancestor_events(msp)
+                    + msp_get_num_rejected_common_ancestor_events(msp));
             if (models[j] == MSP_MODEL_HUDSON) {
                 CU_ASSERT_EQUAL(msp_get_num_rejected_common_ancestor_events(msp), 0);
             }
@@ -2839,11 +2828,11 @@ test_multi_locus_simulation(void)
             CU_ASSERT_EQUAL(ret, 0);
             ret = msp_get_num_migration_events(msp, migration_events);
             CU_ASSERT_EQUAL(ret, 0);
-            CU_ASSERT_EQUAL(1 + num_events,
-                    migration_events[1] + migration_events[2] +
-                    msp_get_num_recombination_events(msp) +
-                    msp_get_num_common_ancestor_events(msp) +
-                    msp_get_num_rejected_common_ancestor_events(msp));
+            CU_ASSERT_EQUAL(
+                1 + num_events, migration_events[1] + migration_events[2]
+                                    + msp_get_num_recombination_events(msp)
+                                    + msp_get_num_common_ancestor_events(msp)
+                                    + msp_get_num_rejected_common_ancestor_events(msp));
             if (models[j] == MSP_MODEL_HUDSON) {
                 CU_ASSERT_EQUAL(msp_get_num_rejected_common_ancestor_events(msp), 0);
             }
@@ -2872,7 +2861,7 @@ test_simulation_replicates(void)
     double mutation_rate = 2;
     size_t num_replicates = 10;
     long seed = 10;
-    double migration_matrix[] = {0, 1, 1, 0};
+    double migration_matrix[] = { 0, 1, 1, 0 };
     size_t j;
     sample_t *samples = malloc(n * sizeof(sample_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
@@ -3081,8 +3070,8 @@ test_large_bottleneck_simulation(void)
     ret = msp_alloc(msp, n, samples, &recomb_map, &tables, rng);
     CU_ASSERT_EQUAL(ret, 0);
     for (j = 0; j < num_bottlenecks; j++) {
-        ret = msp_add_simple_bottleneck(msp, bottlenecks[j].time, 0,
-                bottlenecks[j].parameter);
+        ret = msp_add_simple_bottleneck(
+            msp, bottlenecks[j].time, 0, bottlenecks[j].parameter);
         CU_ASSERT_EQUAL(ret, 0);
     }
     ret = msp_initialise(msp);
@@ -3120,17 +3109,17 @@ test_large_bottleneck_simulation(void)
     tsk_table_collection_free(&tables);
 }
 
-#define check_time_change(msp, t) \
-    do { \
-        const double tol = 1e-4; \
-        double g, t2; \
-        g = (msp)->model.model_time_to_generations(&(msp)->model, t); \
-        t2 = (msp)->model.generations_to_model_time(&(msp)->model, g); \
-        CU_ASSERT_DOUBLE_EQUAL(t, t2, tol); \
-        g = (msp)->model.model_rate_to_generation_rate(&(msp)->model, t); \
-        t2 = (msp)->model.generation_rate_to_model_rate(&(msp)->model, g); \
-        CU_ASSERT_DOUBLE_EQUAL(t, t2, tol); \
-    } while(0)
+#define check_time_change(msp, t)                                                       \
+    do {                                                                                \
+        const double tol = 1e-4;                                                        \
+        double g, t2;                                                                   \
+        g = (msp)->model.model_time_to_generations(&(msp)->model, t);                   \
+        t2 = (msp)->model.generations_to_model_time(&(msp)->model, g);                  \
+        CU_ASSERT_DOUBLE_EQUAL(t, t2, tol);                                             \
+        g = (msp)->model.model_rate_to_generation_rate(&(msp)->model, t);               \
+        t2 = (msp)->model.generation_rate_to_model_rate(&(msp)->model, g);              \
+        CU_ASSERT_DOUBLE_EQUAL(t, t2, tol);                                             \
+    } while (0)
 
 static void
 check_model_time_change_consistency(double population_size, double t)
@@ -3140,10 +3129,10 @@ check_model_time_change_consistency(double population_size, double t)
     msp_t msp;
     const unsigned int n = 10;
     const double N2 = population_size * population_size;
-    const double psis[] = {1e-6, 0.01, 0.5, 0.9, 1};
-    const double cs[] = {0.01*N2, 0.5*N2, 0.99*N2};
-    const double alphas[] = {1.1, 1.5, 1.9};
-    const double truncation_points[] = {0.1, 0.5, 0.9, 1};
+    const double psis[] = { 1e-6, 0.01, 0.5, 0.9, 1 };
+    const double cs[] = { 0.01 * N2, 0.5 * N2, 0.99 * N2 };
+    const double alphas[] = { 1.1, 1.5, 1.9 };
+    const double truncation_points[] = { 0.1, 0.5, 0.9, 1 };
     sample_t *samples = malloc(n * sizeof(sample_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     recomb_map_t recomb_map;
@@ -3185,8 +3174,8 @@ check_model_time_change_consistency(double population_size, double t)
 
     for (j = 0; j < sizeof(alphas) / sizeof(*alphas); j++) {
         for (k = 0; k < sizeof(truncation_points) / sizeof(*truncation_points); k++) {
-            ret = msp_set_simulation_model_beta(&msp, population_size,
-                    alphas[j], truncation_points[k]);
+            ret = msp_set_simulation_model_beta(
+                &msp, population_size, alphas[j], truncation_points[k]);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             check_time_change(&msp, t);
         }
@@ -3202,7 +3191,7 @@ check_model_time_change_consistency(double population_size, double t)
 static void
 test_model_time_change_consistency(void)
 {
-    double Ns[] = {1e-6, 1, 10, 1e4, 1e9};
+    double Ns[] = { 1e-6, 1, 10, 1e4, 1e9 };
     int i;
     for (i = 0; i < sizeof(Ns) / sizeof(*Ns); i++) {
         check_model_time_change_consistency(Ns[i], 0.0);
@@ -3219,8 +3208,8 @@ test_dirac_coalescent_bad_parameters(void)
     int ret;
     msp_t msp;
     unsigned int n = 10;
-    double cs[] = {-1};
-    double psis[] = {-1e6, 1e6};
+    double cs[] = { -1 };
+    double psis[] = { -1e6, 1e6 };
     sample_t *samples = malloc(n * sizeof(sample_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     recomb_map_t recomb_map;
@@ -3237,11 +3226,11 @@ test_dirac_coalescent_bad_parameters(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     for (j = 0; j < sizeof(cs) / sizeof(*cs); j++) {
-        ret = msp_set_simulation_model_dirac(&msp, 1, 0.1 ,cs[j]);
+        ret = msp_set_simulation_model_dirac(&msp, 1, 0.1, cs[j]);
         CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_C);
     }
     for (j = 0; j < sizeof(psis) / sizeof(*psis); j++) {
-        ret = msp_set_simulation_model_dirac(&msp, 1, psis[j] , 10);
+        ret = msp_set_simulation_model_dirac(&msp, 1, psis[j], 10);
         CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PSI);
     }
 
@@ -3259,8 +3248,8 @@ test_beta_coalescent_bad_parameters(void)
     int ret;
     msp_t msp;
     unsigned int n = 10;
-    double alphas[] = {-1e6, 0, 0.001, 1.0, 2.0, 1e6};
-    double truncation_points[] = {-1e6, 0, 1.001, 1e6};
+    double alphas[] = { -1e6, 0, 0.001, 1.0, 2.0, 1e6 };
+    double truncation_points[] = { -1e6, 0, 1.001, 1e6 };
     sample_t *samples = malloc(n * sizeof(sample_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     recomb_map_t recomb_map;
@@ -3300,11 +3289,11 @@ test_multiple_mergers_simulation(void)
     uint32_t n = 10;
     uint32_t m = 10;
     long seed = 10;
-    bool store_full_arg[] = {true, false};
+    bool store_full_arg[] = { true, false };
     /* These simulations can be slow, so just choose a few param combinations */
-    double beta_params[][2] = {{1.1, 0.5}, {1.99, 1}};
+    double beta_params[][2] = { { 1.1, 0.5 }, { 1.99, 1 } };
     /* TODO what are good psi parameters here? */
-    double psi_params[][2] = {{0.9, 10}, {0.1, 1}};
+    double psi_params[][2] = { { 0.9, 10 }, { 0.1, 1 } };
     sample_t *samples = malloc(n * sizeof(sample_t));
     msp_t *msp = malloc(sizeof(msp_t));
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
@@ -3334,11 +3323,11 @@ test_multiple_mergers_simulation(void)
                 ret = msp_alloc(msp, n, samples, &recomb_map, &tables, rng);
                 CU_ASSERT_EQUAL(ret, 0);
                 if (j == 0) {
-                    ret = msp_set_simulation_model_dirac(msp, 1,
-                            psi_params[p][0], psi_params[p][1]);
+                    ret = msp_set_simulation_model_dirac(
+                        msp, 1, psi_params[p][0], psi_params[p][1]);
                 } else {
-                    ret = msp_set_simulation_model_beta(msp, 1,
-                            beta_params[p][0], beta_params[p][1]);
+                    ret = msp_set_simulation_model_beta(
+                        msp, 1, beta_params[p][0], beta_params[p][1]);
                 }
                 CU_ASSERT_EQUAL(ret, 0);
                 /* TODO check for adding various complications like multiple
@@ -3375,15 +3364,14 @@ test_multiple_mergers_simulation(void)
     tsk_table_collection_free(&tables);
 }
 
-
 static void
 test_simple_recomb_map(void)
 {
     int ret;
     recomb_map_t recomb_map;
     double seq_length;
-    double positions[][2] = {{0.0, 1.0}, {0.0, 100.0}, {0.0, 10000.0}};
-    double rates[] = {0.0, 1.0};
+    double positions[][2] = { { 0.0, 1.0 }, { 0.0, 100.0 }, { 0.0, 10000.0 } };
+    double rates[] = { 0.0, 1.0 };
     size_t j;
 
     for (j = 0; j < 3; j++) {
@@ -3406,8 +3394,7 @@ verify_recomb_maps_equal(recomb_map_t *actual, recomb_map_t *expected)
     CU_ASSERT_EQUAL(actual->map.size, expected->map.size);
     CU_ASSERT_EQUAL(actual->discrete, expected->discrete);
     for (i = 0; i < actual->map.size; i++) {
-        CU_ASSERT_DOUBLE_EQUAL(actual->map.position[i],
-                expected->map.position[i], 0.0);
+        CU_ASSERT_DOUBLE_EQUAL(actual->map.position[i], expected->map.position[i], 0.0);
         CU_ASSERT_DOUBLE_EQUAL(actual->map.value[i], expected->map.value[i], 0.0);
         CU_ASSERT_DOUBLE_EQUAL(actual->cumulative[i], expected->cumulative[i], 1e-6);
     }
@@ -3424,9 +3411,9 @@ test_recomb_map_copy(void)
 {
     int ret = 0;
     recomb_map_t map, other, copy;
-    double positions[] = {0.0, 1.0, 2.0};
-    double rates[] = {1.0, 2.0, 0.0};
-    double other_rates[] = {2.0, 4.0, 0.0};
+    double positions[] = { 0.0, 1.0, 2.0 };
+    double rates[] = { 1.0, 2.0, 0.0 };
+    double other_rates[] = { 2.0, 4.0, 0.0 };
 
     ret = recomb_map_alloc(&map, 3, positions, rates, true);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3451,9 +3438,9 @@ test_recomb_map_errors(void)
 {
     int ret;
     recomb_map_t recomb_map;
-    double positions[] = {0.0, 1.0, 2.0};
-    double rates[] = {1.0, 2.0, 0.0};
-    double short_positions[] = {0.0, 0.25, 0.5};
+    double positions[] = { 0.0, 1.0, 2.0 };
+    double rates[] = { 1.0, 2.0, 0.0 };
+    double short_positions[] = { 0.0, 0.25, 0.5 };
 
     ret = recomb_map_alloc(&recomb_map, 0, positions, rates, true);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_INSUFFICIENT_INTERVALS);
@@ -3537,10 +3524,10 @@ verify_recomb_map(double length, double *positions, double *rates, size_t size)
 static void
 test_recomb_map_examples(void)
 {
-    double p1[] =  {0, 0.05019838393314813, 0.36933662489552865, 1};
-    double r1[] = {3.5510784169955434, 4.184964179610539, 3.800808140657212, 0};
-    double p2[] =  {0, 0.125, 0.875, 1, 4, 8, 16};
-    double r2[] = {0.1, 6.0, 3.333, 2.1, 0.0, 2.2, 0};
+    double p1[] = { 0, 0.05019838393314813, 0.36933662489552865, 1 };
+    double r1[] = { 3.5510784169955434, 4.184964179610539, 3.800808140657212, 0 };
+    double p2[] = { 0, 0.125, 0.875, 1, 4, 8, 16 };
+    double r2[] = { 0.1, 6.0, 3.333, 2.1, 0.0, 2.2, 0 };
 
     verify_recomb_map(1.0, p1, r1, 4);
     verify_recomb_map(1.0, p1, r1, 4);
@@ -3555,8 +3542,8 @@ static void
 test_translate_position_and_recomb_mass(void)
 {
     recomb_map_t map;
-    double p1[] = {0, 6, 13, 20};
-    double r1[] = {3, 0, 1, 0};
+    double p1[] = { 0, 6, 13, 20 };
+    double r1[] = { 3, 0, 1, 0 };
     recomb_map_alloc(&map, 4, p1, r1, true);
 
     /* interval edges */
@@ -3587,8 +3574,8 @@ test_recomb_map_mass_between(void)
 {
     recomb_map_t discrete_map;
     recomb_map_t cont_map;
-    double p1[] = {0, 6, 13, 20};
-    double r1[] = {3, 0, 1, 0};
+    double p1[] = { 0, 6, 13, 20 };
+    double r1[] = { 3, 0, 1, 0 };
     double tol = 1e-9;
 
     recomb_map_alloc(&discrete_map, 4, p1, r1, true);
@@ -3597,9 +3584,9 @@ test_recomb_map_mass_between(void)
     CU_ASSERT_DOUBLE_EQUAL_FATAL(recomb_map_mass_between(&discrete_map, 0, 2), 6, tol);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(recomb_map_mass_between(&cont_map, 0, 2), 6, tol);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(
-            recomb_map_mass_between_left_exclusive(&discrete_map, 0, 2), 3, tol);
+        recomb_map_mass_between_left_exclusive(&discrete_map, 0, 2), 3, tol);
     CU_ASSERT_DOUBLE_EQUAL_FATAL(
-            recomb_map_mass_between_left_exclusive(&cont_map, 0, 2), 6, tol);
+        recomb_map_mass_between_left_exclusive(&cont_map, 0, 2), 6, tol);
 
     recomb_map_free(&discrete_map);
     recomb_map_free(&cont_map);
@@ -3608,48 +3595,48 @@ test_recomb_map_mass_between(void)
 static void
 test_msp_binary_interval_search(void)
 {
-        double values[] = {-10, 10, 20, 30};
-        size_t size = 4;
-        size_t idx;
+    double values[] = { -10, 10, 20, 30 };
+    size_t size = 4;
+    size_t idx;
 
-        // Search from bottom
-        idx = msp_binary_interval_search(-11, values, size);
-        CU_ASSERT_EQUAL(idx, 0);
-        // Exact match returns index of value
-        idx = msp_binary_interval_search(-10, values, size);
-        CU_ASSERT_EQUAL(idx, 0);
-        // values[index-1] < query <= values[index]
-        idx = msp_binary_interval_search(9, values, size);
-        CU_ASSERT_EQUAL(idx, 1);
-        // exact match
-        idx = msp_binary_interval_search(10, values, size);
-        CU_ASSERT_EQUAL(idx, 1);
-        // Within mid interval
-        idx = msp_binary_interval_search(11, values, size);
-        CU_ASSERT_EQUAL(idx, 2);
-        idx = msp_binary_interval_search(19, values, size);
-        CU_ASSERT_EQUAL(idx, 2);
-        // Exact
-        idx = msp_binary_interval_search(20, values, size);
-        CU_ASSERT_EQUAL(idx, 2);
-        // Within
-        idx = msp_binary_interval_search(21, values, size);
-        CU_ASSERT_EQUAL(idx, 3);
-        // Exact
-        idx = msp_binary_interval_search(30, values, size);
-        CU_ASSERT_EQUAL(idx, 3);
-        // from the top - return last element
-        idx = msp_binary_interval_search(31, values, size);
-        CU_ASSERT_EQUAL(idx, 3);
-        // way above - same
-        idx = msp_binary_interval_search(300, values, size);
-        CU_ASSERT_EQUAL(idx, 3);
+    // Search from bottom
+    idx = msp_binary_interval_search(-11, values, size);
+    CU_ASSERT_EQUAL(idx, 0);
+    // Exact match returns index of value
+    idx = msp_binary_interval_search(-10, values, size);
+    CU_ASSERT_EQUAL(idx, 0);
+    // values[index-1] < query <= values[index]
+    idx = msp_binary_interval_search(9, values, size);
+    CU_ASSERT_EQUAL(idx, 1);
+    // exact match
+    idx = msp_binary_interval_search(10, values, size);
+    CU_ASSERT_EQUAL(idx, 1);
+    // Within mid interval
+    idx = msp_binary_interval_search(11, values, size);
+    CU_ASSERT_EQUAL(idx, 2);
+    idx = msp_binary_interval_search(19, values, size);
+    CU_ASSERT_EQUAL(idx, 2);
+    // Exact
+    idx = msp_binary_interval_search(20, values, size);
+    CU_ASSERT_EQUAL(idx, 2);
+    // Within
+    idx = msp_binary_interval_search(21, values, size);
+    CU_ASSERT_EQUAL(idx, 3);
+    // Exact
+    idx = msp_binary_interval_search(30, values, size);
+    CU_ASSERT_EQUAL(idx, 3);
+    // from the top - return last element
+    idx = msp_binary_interval_search(31, values, size);
+    CU_ASSERT_EQUAL(idx, 3);
+    // way above - same
+    idx = msp_binary_interval_search(300, values, size);
+    CU_ASSERT_EQUAL(idx, 3);
 }
 
 static void
 test_msp_binary_interval_search_repeating(void)
 {
-    double values_repeating[] = {0, 10, 10, 30};
+    double values_repeating[] = { 0, 10, 10, 30 };
     size_t size = 4;
     size_t idx;
 
@@ -3664,7 +3651,6 @@ test_msp_binary_interval_search_repeating(void)
     CU_ASSERT_EQUAL(idx, 3);
 }
 
-
 static void
 test_msp_binary_interval_search_edge_cases(void)
 {
@@ -3676,7 +3662,7 @@ test_msp_binary_interval_search_edge_cases(void)
     CU_ASSERT_EQUAL(idx, 0);
 
     // Size 1 list
-    double values_one[] = {10};
+    double values_one[] = { 10 };
 
     // below
     idx = msp_binary_interval_search(9, values_one, 1);
@@ -3689,7 +3675,7 @@ test_msp_binary_interval_search_edge_cases(void)
     CU_ASSERT_EQUAL(idx, 0);
 
     // Size 2 list
-    double values_two[] = {10,20};
+    double values_two[] = { 10, 20 };
     idx = msp_binary_interval_search(9, values_two, 2);
     CU_ASSERT_EQUAL(idx, 0);
     idx = msp_binary_interval_search(10, values_two, 2);
@@ -3702,7 +3688,7 @@ test_msp_binary_interval_search_edge_cases(void)
     CU_ASSERT_EQUAL(idx, 1);
 
     // All zeros
-    double values_zeros[] = {0,0,0};
+    double values_zeros[] = { 0, 0, 0 };
     idx = msp_binary_interval_search(-1, values_zeros, 3);
     CU_ASSERT_EQUAL(idx, 0);
     idx = msp_binary_interval_search(0, values_zeros, 3);
@@ -3711,10 +3697,9 @@ test_msp_binary_interval_search_edge_cases(void)
     CU_ASSERT_EQUAL(idx, 2);
 }
 
-
 static void
 verify_simulate_from(int model, recomb_map_t *recomb_map,
-        tsk_table_collection_t *from_tables, size_t num_replicates)
+    tsk_table_collection_t *from_tables, size_t num_replicates)
 {
     int ret;
     size_t j;
@@ -3776,8 +3761,8 @@ verify_simulate_from(int model, recomb_map_t *recomb_map,
 /* Verify that the initial state we get in a new simulator from calling
  * with from_ts is equivalent to the state in the original simulator */
 static void
-verify_initial_simulate_from_state(msp_t *msp_source, recomb_map_t *recomb_map,
-        tsk_table_collection_t *from_tables)
+verify_initial_simulate_from_state(
+    msp_t *msp_source, recomb_map_t *recomb_map, tsk_table_collection_t *from_tables)
 {
     int ret;
     msp_t msp_dest;
@@ -3803,8 +3788,9 @@ verify_initial_simulate_from_state(msp_t *msp_source, recomb_map_t *recomb_map,
 }
 
 static void
-verify_simple_simulate_from(int model, uint32_t n, size_t num_loci, double sequence_length,
-        double recombination_rate, size_t num_events, size_t num_replicates)
+verify_simple_simulate_from(int model, uint32_t n, size_t num_loci,
+    double sequence_length, double recombination_rate, size_t num_events,
+    size_t num_replicates)
 {
     int ret;
     tsk_table_collection_t tables;
@@ -3815,8 +3801,8 @@ verify_simple_simulate_from(int model, uint32_t n, size_t num_loci, double seque
 
     CU_ASSERT_FATAL(samples != NULL);
     CU_ASSERT_FATAL(rng != NULL);
-    ret = recomb_map_alloc_uniform(&recomb_map, sequence_length,
-            recombination_rate, true);
+    ret = recomb_map_alloc_uniform(
+        &recomb_map, sequence_length, recombination_rate, true);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -3886,7 +3872,7 @@ test_simulate_from_completed(void)
     CU_ASSERT_FATAL(rng != NULL);
     ret = recomb_map_alloc_uniform(&recomb_map, 1.0, recombination_rate, true);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_table_collection_init(&tables,0);
+    ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     memset(samples, 0, n * sizeof(sample_t));
@@ -3928,16 +3914,17 @@ test_simulate_from_incompatible(void)
     /* Add a node so that we get past the first check */
     ret = tsk_population_table_add_row(&from_tables.populations, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_node_table_add_row(&from_tables.nodes, 0, 0.0,
-            0, TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(&from_tables.nodes, 0, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* Malformed tree sequence */
     from_tables.nodes.individual[0] = 100;
     ret = msp_alloc(&msp, 0, NULL, &recomb_map, &from_tables, rng);
     CU_ASSERT_FATAL(msp_is_tsk_error(ret));
-    CU_ASSERT_EQUAL_FATAL(ret ^ (1 << MSP_TSK_ERR_BIT), TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
-    CU_ASSERT_STRING_EQUAL(msp_strerror(ret), tsk_strerror(TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS));
+    CU_ASSERT_EQUAL_FATAL(
+        ret ^ (1 << MSP_TSK_ERR_BIT), TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS);
+    CU_ASSERT_STRING_EQUAL(
+        msp_strerror(ret), tsk_strerror(TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS));
     from_tables.nodes.individual[0] = -1;
     msp_free(&msp);
 
@@ -3956,11 +3943,11 @@ test_simulate_from_incompatible(void)
 
     /* older nodes */
     from_tables.sequence_length = 10.0;
-    ret = tsk_node_table_add_row(&from_tables.nodes, TSK_NODE_IS_SAMPLE, 1.0, 0,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &from_tables.nodes, TSK_NODE_IS_SAMPLE, 1.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&from_tables.nodes, TSK_NODE_IS_SAMPLE, 2.0, 0,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &from_tables.nodes, TSK_NODE_IS_SAMPLE, 2.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = msp_alloc(&msp, 0, NULL, &recomb_map, &from_tables, rng);
     CU_ASSERT_EQUAL(ret, 0);
@@ -4021,10 +4008,10 @@ test_simulate_from_incompatible(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_FATAL(msp_is_tsk_error(ret));
-    CU_ASSERT_EQUAL_FATAL(ret ^ (1 << MSP_TSK_ERR_BIT),
-            TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN);
-    CU_ASSERT_STRING_EQUAL(msp_strerror(ret),
-            tsk_strerror(TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN));
+    CU_ASSERT_EQUAL_FATAL(
+        ret ^ (1 << MSP_TSK_ERR_BIT), TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN);
+    CU_ASSERT_STRING_EQUAL(
+        msp_strerror(ret), tsk_strerror(TSK_ERR_BAD_EDGES_CONTRADICTORY_CHILDREN));
     msp_free(&msp);
 
     gsl_rng_free(rng);
@@ -4108,17 +4095,17 @@ insert_single_tree(tsk_table_collection_t *tables, int alphabet)
     */
     int ret;
     tables->sequence_length = 1.0;
-    ret = tsk_node_table_add_row(&tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = tsk_node_table_add_row(&tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_node_table_add_row(&tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0,
-            TSK_NULL, NULL, 0);
+    ret = tsk_node_table_add_row(
+        &tables->nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables->nodes, 0, 1.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -4170,8 +4157,8 @@ test_mutgen_simple_map(void)
     mutation_model_t mut_model;
     tsk_table_collection_t tables;
     interval_map_t rate_map;
-    double pos[] = {0, 0.1, 0.2, 0.3, 0.4, 1.0};
-    double rate[] = {0, 0.01, 0.02, 0.03, 0.04, 0.0};
+    double pos[] = { 0, 0.1, 0.2, 0.3, 0.4, 1.0 };
+    double rate[] = { 0, 0.01, 0.02, 0.03, 0.04, 0.0 };
 
     CU_ASSERT_FATAL(rng != NULL);
     ret = tsk_table_collection_init(&tables, 0);
@@ -4476,7 +4463,6 @@ test_single_tree_mutgen_keep_sites(void)
     ret = mutgen_generate(&mutgen, &tables, MSP_KEEP_SITES | MSP_DISCRETE_SITES);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_DUPLICATE_SITE_POSITION);
 
-
     mutgen_free(&mutgen);
     mutation_model_free(&mut_model);
     tsk_table_collection_free(&tables);
@@ -4711,13 +4697,13 @@ test_single_tree_mutgen_do_nothing_mutations(void)
     tsk_table_collection_t tables, copy;
     interval_map_t rate_map;
     mutation_model_t mut_model;
-    static const char *binary_alleles[] = {"0", "1"};
-    static double root_distribution[] = {0.5, 0.5};
-    static double transition_matrix[] = {1.0, 0.0, 0.0, 1.0};
+    static const char *binary_alleles[] = { "0", "1" };
+    static double root_distribution[] = { 0.5, 0.5 };
+    static double transition_matrix[] = { 1.0, 0.0, 0.0, 1.0 };
 
     CU_ASSERT_FATAL(rng != NULL);
     ret = mutation_model_alloc(&mut_model, 2, (char **) (uintptr_t *) binary_alleles,
-            root_distribution, transition_matrix);
+        root_distribution, transition_matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = interval_map_alloc_single(&rate_map, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4788,13 +4774,12 @@ test_single_tree_mutgen_many_mutations(void)
 
 static void
 verify_simple_genic_selection_trajectory(
-       double start_frequency, double end_frequency, double alpha,
-       double dt)
+    double start_frequency, double end_frequency, double alpha, double dt)
 {
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 0.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 0.0 } };
     tsk_table_collection_t tables;
     recomb_map_t recomb_map;
     size_t j, num_steps;
@@ -4816,7 +4801,7 @@ verify_simple_genic_selection_trajectory(
 
     /* compute the trajectory */
     ret = msp.model.params.sweep.generate_trajectory(
-            &msp.model.params.sweep, &msp, &num_steps, &time, &allele_frequency);
+        &msp.model.params.sweep, &msp, &num_steps, &time, &allele_frequency);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_FATAL(num_steps > 1);
     CU_ASSERT_EQUAL(time[0], 0);
@@ -4855,7 +4840,7 @@ test_sweep_genic_selection_bad_parameters(void)
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 0.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 0.0 } };
     tsk_table_collection_t tables;
     recomb_map_t recomb_map;
 
@@ -4905,7 +4890,6 @@ test_sweep_genic_selection_bad_parameters(void)
         &msp, 1.0, 5.0, 0.1, 0.9, 0.1, 0.1);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SWEEP_POSITION);
 
-
     ret = msp_set_simulation_model_sweep_genic_selection(
         &msp, 1.0, 0.5, 0.1, 0.9, 0.1, 0.1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4933,7 +4917,7 @@ test_sweep_genic_selection_events(void)
     int ret;
     msp_t msp;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
-    sample_t samples[] = {{0, 0.0}, {0, 0.0}, {0, 0.0}};
+    sample_t samples[] = { { 0, 0.0 }, { 0, 0.0 }, { 0, 0.0 } };
     tsk_table_collection_t tables;
     recomb_map_t recomb_map;
 
@@ -5005,7 +4989,7 @@ verify_sweep_genic_selection(uint32_t num_loci, double growth_rate)
         ret = msp_set_dimensions(&msp, 1, 2);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_simulation_model_sweep_genic_selection(
-                &msp, 1, num_loci / 2, 0.1, 0.9, 0.1, 0.01);
+            &msp, 1, num_loci / 2, 0.1, 0.9, 0.1, 0.01);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_population_configuration(&msp, 0, 1.0, growth_rate);
         CU_ASSERT_EQUAL(ret, 0);
@@ -5020,7 +5004,6 @@ verify_sweep_genic_selection(uint32_t num_loci, double growth_rate)
         CU_ASSERT_EQUAL(tables[j].migrations.num_rows, 0);
         CU_ASSERT(tables[j].nodes.num_rows > 0);
         CU_ASSERT(tables[j].edges.num_rows > 0);
-
     }
     CU_ASSERT_TRUE(tsk_node_table_equals(&tables[0].nodes, &tables[1].nodes));
     CU_ASSERT_TRUE(tsk_edge_table_equals(&tables[0].edges, &tables[1].edges));
@@ -5048,7 +5031,6 @@ test_sweep_genic_selection_recomb(void)
     verify_sweep_genic_selection(100, 1.0);
     verify_sweep_genic_selection(100, -1.0);
 }
-
 
 static void
 test_sweep_genic_selection_time_change(void)
@@ -5087,7 +5069,7 @@ test_sweep_genic_selection_time_change(void)
     for (j = 0; j < 10; j++) {
 
         ret = msp_set_simulation_model_sweep_genic_selection(
-                &msp, 10, num_loci / 2, 0.1, 0.9, 0.1, 0.01);
+            &msp, 10, num_loci / 2, 0.1, 0.9, 0.1, 0.01);
         CU_ASSERT_EQUAL(ret, 0);
 
         CU_ASSERT_EQUAL(ret, 0);
@@ -5111,8 +5093,8 @@ test_interval_map(void)
     int ret;
     size_t j;
     interval_map_t imap;
-    double position[] = {0, 1, 2, 3, 4, 5};
-    double value[] = {0.1, 1.1, 2.1, 3.1, 4.1, 5.1};
+    double position[] = { 0, 1, 2, 3, 4, 5 };
+    double value[] = { 0.1, 1.1, 2.1, 3.1, 4.1, 5.1 };
 
     ret = interval_map_alloc(&imap, 0, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_INSUFFICIENT_INTERVALS);
@@ -5149,9 +5131,9 @@ test_mutation_model_errors(void)
 {
     int ret;
     mutation_model_t model;
-    const char *alleles[] = {"A", "B"};
-    double dist[] = {0.5, 0.5};
-    double matrix[] = {0, 1.0, 1.0, 0};
+    const char *alleles[] = { "A", "B" };
+    double dist[] = { 0.5, 0.5 };
+    double matrix[] = { 0, 1.0, 1.0, 0 };
 
     ret = mutation_model_alloc(&model, 0, NULL, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_INSUFFICIENT_ALLELES);
@@ -5159,79 +5141,68 @@ test_mutation_model_errors(void)
 
     /* Bad probability values */
     dist[0] = -1;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     /* Sums to 1, but bad values */
     dist[0] = -1;
     dist[1] = 2;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     dist[0] = 1.1;
     dist[1] = 0.5;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     /* Must sum to 1 */
     dist[0] = 0.9;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     dist[0] = 0.1;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     /* Make sure dist is still OK . */
     dist[0] = 0.5;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     mutation_model_free(&model);
 
     /* Matrix values must be probablilities */
     matrix[0] = -1;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     /* Sums to 1, but bad values */
     matrix[0] = -1;
     matrix[1] = 2;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     matrix[0] = 1.1;
     matrix[1] = 1.0;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     matrix[0] = 0.6;
     matrix[1] = 0.5;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     matrix[0] = 0.5;
     matrix[1] = 0.5;
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     mutation_model_free(&model);
 }
@@ -5241,13 +5212,12 @@ test_mutation_model_properties(void)
 {
     int ret;
     mutation_model_t model;
-    const char *alleles[] = {"A", "B"};
-    double dist[] = {0.5, 0.5};
-    double matrix[] = {0, 1.0, 1.0, 0};
+    const char *alleles[] = { "A", "B" };
+    double dist[] = { 0.5, 0.5 };
+    double matrix[] = { 0, 1.0, 1.0, 0 };
     int num_alleles;
 
-    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles,
-            dist, matrix);
+    ret = mutation_model_alloc(&model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     num_alleles = mutation_model_get_num_alleles(&model);
     CU_ASSERT_EQUAL_FATAL(num_alleles, 2);
@@ -5272,8 +5242,8 @@ test_strerror(void)
 static void
 test_strerror_tskit(void)
 {
-    int tskit_errors[] = {TSK_ERR_NO_MEMORY,
-        TSK_ERR_NODE_OUT_OF_BOUNDS, TSK_ERR_EDGE_OUT_OF_BOUNDS};
+    int tskit_errors[]
+        = { TSK_ERR_NO_MEMORY, TSK_ERR_NODE_OUT_OF_BOUNDS, TSK_ERR_EDGE_OUT_OF_BOUNDS };
     size_t j;
     int err;
 
@@ -5326,8 +5296,7 @@ msprime_suite_cleanup(void)
 static void
 handle_cunit_error()
 {
-    fprintf(stderr, "CUnit error occured: %d: %s\n",
-            CU_get_error(), CU_get_error_msg());
+    fprintf(stderr, "CUnit error occured: %d: %s\n", CU_get_error(), CU_get_error_msg());
     exit(EXIT_FAILURE);
 }
 
@@ -5338,120 +5307,123 @@ main(int argc, char **argv)
     CU_pTest test;
     CU_pSuite suite;
     CU_TestInfo tests[] = {
-        {"test_fenwick", test_fenwick},
-        {"test_fenwick_expand", test_fenwick_expand},
-        {"test_single_locus_two_populations", test_single_locus_two_populations},
-        {"test_single_locus_many_populations", test_single_locus_many_populations},
-        {"test_single_locus_historical_sample", test_single_locus_historical_sample},
-        {"test_single_locus_multiple_historical_samples",
-            test_single_locus_multiple_historical_samples},
-        {"test_dtwf_simultaneous_historical_samples",
-            test_dtwf_simultaneous_historical_samples},
-        {"test_single_locus_historical_sample_start_time",
-            test_single_locus_historical_sample_start_time},
-        {"test_single_locus_historical_sample_end_time",
-            test_single_locus_historical_sample_end_time},
-        {"test_simulator_getters_setters", test_simulator_getters_setters},
-        {"test_demographic_events", test_demographic_events},
-        {"test_demographic_events_start_time", test_demographic_events_start_time},
-        {"test_census_event", test_census_event},
-        {"test_dtwf_unsupported_bottleneck", test_dtwf_unsupported_bottleneck},
-        {"test_time_travel_error", test_time_travel_error},
-        {"test_single_locus_simulation", test_single_locus_simulation},
-        {"test_single_locus_gene_conversion", test_single_locus_gene_conversion},
-        {"test_multi_locus_bottleneck_arg", test_multi_locus_bottleneck_arg},
-        {"test_mixed_model_simulation", test_mixed_model_simulation},
-        {"test_dtwf_deterministic", test_dtwf_deterministic},
-        {"test_dtwf_zero_pop_size", test_dtwf_zero_pop_size},
-        {"test_dtwf_events_between_generations", test_dtwf_events_between_generations},
-        {"test_dtwf_single_locus_simulation", test_dtwf_single_locus_simulation},
-        {"test_dtwf_low_recombination", test_dtwf_low_recombination},
-        {"test_pedigree_single_locus_simulation", test_pedigree_single_locus_simulation},
-        {"test_pedigree_multi_locus_simulation", test_pedigree_multi_locus_simulation},
-        {"test_pedigree_specification", test_pedigree_specification},
+        { "test_fenwick", test_fenwick },
+        { "test_fenwick_expand", test_fenwick_expand },
+        { "test_single_locus_two_populations", test_single_locus_two_populations },
+        { "test_single_locus_many_populations", test_single_locus_many_populations },
+        { "test_single_locus_historical_sample", test_single_locus_historical_sample },
+        { "test_single_locus_multiple_historical_samples",
+            test_single_locus_multiple_historical_samples },
+        { "test_dtwf_simultaneous_historical_samples",
+            test_dtwf_simultaneous_historical_samples },
+        { "test_single_locus_historical_sample_start_time",
+            test_single_locus_historical_sample_start_time },
+        { "test_single_locus_historical_sample_end_time",
+            test_single_locus_historical_sample_end_time },
+        { "test_simulator_getters_setters", test_simulator_getters_setters },
+        { "test_demographic_events", test_demographic_events },
+        { "test_demographic_events_start_time", test_demographic_events_start_time },
+        { "test_census_event", test_census_event },
+        { "test_dtwf_unsupported_bottleneck", test_dtwf_unsupported_bottleneck },
+        { "test_time_travel_error", test_time_travel_error },
+        { "test_single_locus_simulation", test_single_locus_simulation },
+        { "test_single_locus_gene_conversion", test_single_locus_gene_conversion },
+        { "test_multi_locus_bottleneck_arg", test_multi_locus_bottleneck_arg },
+        { "test_mixed_model_simulation", test_mixed_model_simulation },
+        { "test_dtwf_deterministic", test_dtwf_deterministic },
+        { "test_dtwf_zero_pop_size", test_dtwf_zero_pop_size },
+        { "test_dtwf_events_between_generations", test_dtwf_events_between_generations },
+        { "test_dtwf_single_locus_simulation", test_dtwf_single_locus_simulation },
+        { "test_dtwf_low_recombination", test_dtwf_low_recombination },
+        { "test_pedigree_single_locus_simulation",
+            test_pedigree_single_locus_simulation },
+        { "test_pedigree_multi_locus_simulation", test_pedigree_multi_locus_simulation },
+        { "test_pedigree_specification", test_pedigree_specification },
 
         /* TODO we should move the likelihood tests to their own file */
-        {"test_likelihood_errors", test_likelihood_errors},
-        {"test_likelihood_zero_edges", test_likelihood_zero_edges},
-        {"test_likelihood_three_leaves", test_likelihood_three_leaves},
-        {"test_likelihood_two_mrcas", test_likelihood_two_mrcas},
-        {"test_likelihood_material_overhang", test_likelihood_material_overhang},
-        {"test_likelihood_material_gap", test_likelihood_material_gap},
-        {"test_likelihood_recombination_in_material_gap",
-            test_likelihood_recombination_in_material_gap},
+        { "test_likelihood_errors", test_likelihood_errors },
+        { "test_likelihood_zero_edges", test_likelihood_zero_edges },
+        { "test_likelihood_three_leaves", test_likelihood_three_leaves },
+        { "test_likelihood_two_mrcas", test_likelihood_two_mrcas },
+        { "test_likelihood_material_overhang", test_likelihood_material_overhang },
+        { "test_likelihood_material_gap", test_likelihood_material_gap },
+        { "test_likelihood_recombination_in_material_gap",
+            test_likelihood_recombination_in_material_gap },
 
-        {"test_multi_locus_simulation", test_multi_locus_simulation},
-        {"test_dtwf_multi_locus_simulation", test_dtwf_multi_locus_simulation},
-        {"test_gene_conversion_simulation", test_gene_conversion_simulation},
-        {"test_simulation_replicates", test_simulation_replicates},
-        {"test_bottleneck_simulation", test_bottleneck_simulation},
-        {"test_dirac_coalescent_bad_parameters", test_dirac_coalescent_bad_parameters},
-        {"test_beta_coalescent_bad_parameters", test_beta_coalescent_bad_parameters},
-        {"test_model_time_change_consistency", test_model_time_change_consistency},
-        {"test_multiple_mergers_simulation", test_multiple_mergers_simulation},
-        {"test_large_bottleneck_simulation", test_large_bottleneck_simulation},
-        {"test_simple_recombination_map", test_simple_recomb_map},
-        {"test_recombination_map_copy", test_recomb_map_copy},
-        {"test_recombination_map_errors", test_recomb_map_errors},
-        {"test_recombination_map_examples", test_recomb_map_examples},
+        { "test_multi_locus_simulation", test_multi_locus_simulation },
+        { "test_dtwf_multi_locus_simulation", test_dtwf_multi_locus_simulation },
+        { "test_gene_conversion_simulation", test_gene_conversion_simulation },
+        { "test_simulation_replicates", test_simulation_replicates },
+        { "test_bottleneck_simulation", test_bottleneck_simulation },
+        { "test_dirac_coalescent_bad_parameters", test_dirac_coalescent_bad_parameters },
+        { "test_beta_coalescent_bad_parameters", test_beta_coalescent_bad_parameters },
+        { "test_model_time_change_consistency", test_model_time_change_consistency },
+        { "test_multiple_mergers_simulation", test_multiple_mergers_simulation },
+        { "test_large_bottleneck_simulation", test_large_bottleneck_simulation },
+        { "test_simple_recombination_map", test_simple_recomb_map },
+        { "test_recombination_map_copy", test_recomb_map_copy },
+        { "test_recombination_map_errors", test_recomb_map_errors },
+        { "test_recombination_map_examples", test_recomb_map_examples },
 
-        {"test_translate_position_and_recomb_mass", test_translate_position_and_recomb_mass},
-        {"test_recomb_map_mass_between", test_recomb_map_mass_between},
+        { "test_translate_position_and_recomb_mass",
+            test_translate_position_and_recomb_mass },
+        { "test_recomb_map_mass_between", test_recomb_map_mass_between },
 
-        {"test_binary_search", test_msp_binary_interval_search},
-        {"test_binary_search_repeating", test_msp_binary_interval_search_repeating},
-        {"test_binary_search_edge_cases", test_msp_binary_interval_search_edge_cases},
+        { "test_binary_search", test_msp_binary_interval_search },
+        { "test_binary_search_repeating", test_msp_binary_interval_search_repeating },
+        { "test_binary_search_edge_cases", test_msp_binary_interval_search_edge_cases },
 
-        {"test_simulate_from_single_locus", test_simulate_from_single_locus},
-        {"test_simulate_from_single_locus_replicates",
-            test_simulate_from_single_locus_replicates},
-        {"test_simulate_from_empty", test_simulate_from_empty},
-        {"test_simulate_from_completed", test_simulate_from_completed},
-        {"test_simulate_from_incompatible", test_simulate_from_incompatible},
-        {"test_simulate_init_errors", test_simulate_init_errors},
+        { "test_simulate_from_single_locus", test_simulate_from_single_locus },
+        { "test_simulate_from_single_locus_replicates",
+            test_simulate_from_single_locus_replicates },
+        { "test_simulate_from_empty", test_simulate_from_empty },
+        { "test_simulate_from_completed", test_simulate_from_completed },
+        { "test_simulate_from_incompatible", test_simulate_from_incompatible },
+        { "test_simulate_init_errors", test_simulate_init_errors },
 
-        {"test_mutgen_simple_map", test_mutgen_simple_map},
-        {"test_mutgen_errors", test_mutgen_errors},
-        {"test_mutgen_bad_mutation_order", test_mutgen_bad_mutation_order},
-        {"test_single_tree_mutgen", test_single_tree_mutgen},
-        {"test_single_tree_mutgen_keep_sites", test_single_tree_mutgen_keep_sites},
-        {"test_single_tree_mutgen_discrete_sites", test_single_tree_mutgen_discrete_sites},
-        {"test_single_tree_mutgen_keep_sites_many_mutations",
-            test_single_tree_mutgen_keep_sites_many_mutations},
-        {"test_single_tree_mutgen_interval", test_single_tree_mutgen_interval},
-        {"test_single_tree_mutgen_empty_site", test_single_tree_mutgen_empty_site},
-        {"test_single_tree_mutgen_do_nothing_mutations", test_single_tree_mutgen_do_nothing_mutations},
-        {"test_single_tree_mutgen_many_mutations", test_single_tree_mutgen_many_mutations},
+        { "test_mutgen_simple_map", test_mutgen_simple_map },
+        { "test_mutgen_errors", test_mutgen_errors },
+        { "test_mutgen_bad_mutation_order", test_mutgen_bad_mutation_order },
+        { "test_single_tree_mutgen", test_single_tree_mutgen },
+        { "test_single_tree_mutgen_keep_sites", test_single_tree_mutgen_keep_sites },
+        { "test_single_tree_mutgen_discrete_sites",
+            test_single_tree_mutgen_discrete_sites },
+        { "test_single_tree_mutgen_keep_sites_many_mutations",
+            test_single_tree_mutgen_keep_sites_many_mutations },
+        { "test_single_tree_mutgen_interval", test_single_tree_mutgen_interval },
+        { "test_single_tree_mutgen_empty_site", test_single_tree_mutgen_empty_site },
+        { "test_single_tree_mutgen_do_nothing_mutations",
+            test_single_tree_mutgen_do_nothing_mutations },
+        { "test_single_tree_mutgen_many_mutations",
+            test_single_tree_mutgen_many_mutations },
 
-        {"test_genic_selection_trajectory", test_genic_selection_trajectory},
-        {"test_sweep_genic_selection_bad_parameters",
-            test_sweep_genic_selection_bad_parameters},
-        {"test_sweep_genic_selection_events", test_sweep_genic_selection_events},
-        {"test_sweep_genic_selection_single_locus",
-            test_sweep_genic_selection_single_locus},
-        {"test_sweep_genic_selection_recomb", test_sweep_genic_selection_recomb},
-        {"test_sweep_genic_selection_time_change",
-            test_sweep_genic_selection_time_change},
+        { "test_genic_selection_trajectory", test_genic_selection_trajectory },
+        { "test_sweep_genic_selection_bad_parameters",
+            test_sweep_genic_selection_bad_parameters },
+        { "test_sweep_genic_selection_events", test_sweep_genic_selection_events },
+        { "test_sweep_genic_selection_single_locus",
+            test_sweep_genic_selection_single_locus },
+        { "test_sweep_genic_selection_recomb", test_sweep_genic_selection_recomb },
+        { "test_sweep_genic_selection_time_change",
+            test_sweep_genic_selection_time_change },
 
-        {"test_interval_map", test_interval_map},
+        { "test_interval_map", test_interval_map },
 
-        {"test_mutation_model_errors", test_mutation_model_errors},
-        {"test_mutation_model_properties", test_mutation_model_properties},
+        { "test_mutation_model_errors", test_mutation_model_errors },
+        { "test_mutation_model_properties", test_mutation_model_properties },
 
-        {"test_strerror", test_strerror},
-        {"test_strerror_tskit", test_strerror_tskit},
+        { "test_strerror", test_strerror },
+        { "test_strerror_tskit", test_strerror_tskit },
         CU_TEST_INFO_NULL,
     };
 
     /* We use initialisers here as the struct definitions change between
      * versions of CUnit */
     CU_SuiteInfo suites[] = {
-        {
-            .pName = "msprime",
+        { .pName = "msprime",
             .pInitFunc = msprime_suite_init,
             .pCleanupFunc = msprime_suite_cleanup,
-            .pTests = tests
-        },
+            .pTests = tests },
         CU_SUITE_INFO_NULL,
     };
     if (CUE_SUCCESS != CU_initialize_registry()) {
@@ -5489,4 +5461,3 @@ main(int argc, char **argv)
     CU_cleanup_registry();
     return ret;
 }
-

--- a/lib/util.c
+++ b/lib/util.c
@@ -98,15 +98,15 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_BAD_MODEL:
             ret = "Model error. Either a bad model, or the requested operation "
-                "is not supported for the current model";
+                  "is not supported for the current model";
             break;
         case MSP_ERR_INCOMPATIBLE_FROM_TS:
             ret = "The specified tree sequence is not a compatible starting point "
-                "for the current simulation";
+                  "for the current simulation";
             break;
         case MSP_ERR_BAD_START_TIME_FROM_TS:
             ret = "The specified start_time and from_ts are not compatible. All "
-                "node times in the tree sequence must be <= start_time.";
+                  "node times in the tree sequence must be <= start_time.";
             break;
         case MSP_ERR_BAD_START_TIME:
             ret = "start_time must be >= 0.";
@@ -116,18 +116,19 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_RECOMB_MAP_TOO_COARSE:
             ret = "The specified recombination map is cannot translate the coordinates"
-                "for the specified tree sequence. It is either too coarse (num_loci "
-                "is too small) or contains zero recombination rates. Please either "
-                "increase the number of loci or recombination rate";
+                  "for the specified tree sequence. It is either too coarse (num_loci "
+                  "is too small) or contains zero recombination rates. Please either "
+                  "increase the number of loci or recombination rate";
             break;
         case MSP_ERR_TIME_TRAVEL:
             ret = "The simulation model supplied resulted in a parent node having "
-                "a time value <= to its child. This can occur either as a result "
-                "of multiple bottlenecks happening at the same time or because of "
-                "numerical imprecision with very small population sizes.";
+                  "a time value <= to its child. This can occur either as a result "
+                  "of multiple bottlenecks happening at the same time or because of "
+                  "numerical imprecision with very small population sizes.";
             break;
         case MSP_ERR_INTEGRATION_FAILED:
-            ret = "GSL numerical integration failed. Please check the stderr for details.";
+            ret = "GSL numerical integration failed. Please check the stderr for "
+                  "details.";
             break;
         case MSP_ERR_BAD_SWEEP_POSITION:
             ret = "Sweep position must be between 0 and sequence length.";
@@ -146,7 +147,7 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_EVENTS_DURING_SWEEP:
             ret = "Demographic and sampling events during a sweep "
-                "are not supported";
+                  "are not supported";
             break;
         case MSP_ERR_UNSUPPORTED_OPERATION:
             ret = "Current simulation configuration is not supported.";
@@ -156,11 +157,11 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_DTWF_UNSUPPORTED_BOTTLENECK:
             ret = "Bottleneck events are not supported in the DTWF model. "
-                "They can be implemented as population size changes.";
+                  "They can be implemented as population size changes.";
             break;
         case MSP_ERR_BAD_PEDIGREE_NUM_SAMPLES:
             ret = "The number of haploid lineages denoted by sample_size must "
-                "be divisible by ploidy (default 2)";
+                  "be divisible by ploidy (default 2)";
             break;
         case MSP_ERR_BAD_PEDIGREE_ID:
             ret = "Individual IDs in pedigrees must be strictly > 0.";
@@ -200,8 +201,8 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_MUTATION_GENERATION_OUT_OF_ORDER:
             ret = "Tree sequence contains mutations that would descend from "
-                "existing mutations: finite site mutations must be generated on "
-                "older time periods first.";
+                  "existing mutations: finite site mutations must be generated on "
+                  "older time periods first.";
             break;
         case MSP_ERR_INSUFFICIENT_ALLELES:
             ret = "Must have at least two alleles.";
@@ -210,11 +211,12 @@ msp_strerror_internal(int err)
             ret = "Root probabilities must be nonnegative and sum to one.";
             break;
         case MSP_ERR_BAD_TRANSITION_MATRIX:
-            ret = "Each row of the transition matrix must be nonnegative and sum to one.";
+            ret = "Each row of the transition matrix must be nonnegative and sum to "
+                  "one.";
             break;
         default:
             ret = "Error occurred generating error string. Please file a bug "
-                "report!";
+                  "report!";
             break;
     }
 out:
@@ -246,7 +248,8 @@ msp_strerror(int err)
 }
 
 void
-__msp_safe_free(void **ptr) {
+__msp_safe_free(void **ptr)
+{
     if (ptr != NULL) {
         if (*ptr != NULL) {
             free(*ptr);

--- a/lib/util.h
+++ b/lib/util.h
@@ -23,18 +23,19 @@
 #include <math.h>
 
 #ifdef __GNUC__
-    /*
-     * raise a compiler warning if a potentially error raising function's return
-     * value is not used.
-     */
-	#define MSP_WARN_UNUSED __attribute__ ((warn_unused_result))
-    /* Annotate a function parameter as unused */
-	#define MSP_UNUSED(x) MSP_UNUSED_ ## x __attribute__((__unused__))
+/*
+ * raise a compiler warning if a potentially error raising function's return
+ * value is not used.
+ */
+#define MSP_WARN_UNUSED __attribute__((warn_unused_result))
+/* Annotate a function parameter as unused */
+#define MSP_UNUSED(x) MSP_UNUSED_##x __attribute__((__unused__))
 #else
-	#define MSP_WARN_UNUSED
-	#define MSP_UNUSED(x) MSP_UNUSED_ ## x
+#define MSP_WARN_UNUSED
+#define MSP_UNUSED(x) MSP_UNUSED_##x
 #endif
 
+/* clang-format off */
 /* Error codes */
 #define MSP_ERR_GENERIC                                             -1
 #define MSP_ERR_NO_MEMORY                                           -2
@@ -92,13 +93,13 @@
 #define MSP_ERR_INSUFFICIENT_ALLELES                                -54
 #define MSP_ERR_BAD_ROOT_PROBABILITIES                              -55
 #define MSP_ERR_BAD_TRANSITION_MATRIX                               -56
-
+/* clang-format on */
 /* This bit is 0 for any errors originating from tskit */
 #define MSP_TSK_ERR_BIT 13
 
 int msp_set_tsk_error(int err);
 bool msp_is_tsk_error(int err);
-const char * msp_strerror(int err);
+const char *msp_strerror(int err);
 void __msp_safe_free(void **ptr);
 
 #define msp_safe_free(pointer) __msp_safe_free((void **) &(pointer))


### PR DESCRIPTION
I've used the same configuration as tskit, excluded `avl`.