### PR TITLE
generalize mutation models

### DIFF
--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -61,6 +61,13 @@ typedef struct {
     interval_map_t *interval_map;
 } IntervalMap;
 
+/* TODO we should refactor some of the code for dealing with the
+ * mutation_model in this base class (which currently does nothing).
+ */
+typedef struct {
+    PyObject_HEAD
+} BaseMutationModel;
+
 typedef struct {
     PyObject_HEAD
     mutation_model_t *mutation_model;
@@ -1831,6 +1838,19 @@ static PyTypeObject IntervalMapType = {
     .tp_new = PyType_GenericNew,
 };
 
+/*===================================================================
+ * Matrix mutation model
+ *===================================================================
+ */
+
+static PyTypeObject BaseMutationModelType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_msprime.BaseMutationModel",
+    .tp_basicsize = sizeof(BaseMutationModel),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "BaseMutationModel objects",
+    .tp_new = PyType_GenericNew,
+};
 
 /*===================================================================
  * Matrix mutation model
@@ -4495,7 +4515,16 @@ PyInit__msprime(void)
     Py_INCREF(&IntervalMapType);
     PyModule_AddObject(module, "IntervalMap", (PyObject *) &IntervalMapType);
 
+    /* BaseMutationModel type */
+    if (PyType_Ready(&BaseMutationModelType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&BaseMutationModelType);
+    PyModule_AddObject(module, "BaseMutationModel",
+            (PyObject *) &BaseMutationModelType);
+
     /* MatrixMutationModel type */
+    MatrixMutationModelType.tp_base = &BaseMutationModelType;
     if (PyType_Ready(&MatrixMutationModelType) < 0) {
         return NULL;
     }
@@ -4504,6 +4533,7 @@ PyInit__msprime(void)
             (PyObject *) &MatrixMutationModelType);
 
     /* SlimMutationModel type */
+    SlimMutationModelType.tp_base = &BaseMutationModelType;
     if (PyType_Ready(&SlimMutationModelType) < 0) {
         return NULL;
     }

--- a/_msprimemodule.c
+++ b/_msprimemodule.c
@@ -64,14 +64,19 @@ typedef struct {
 typedef struct {
     PyObject_HEAD
     mutation_model_t *mutation_model;
-} MutationModel;
+} MatrixMutationModel;
+
+typedef struct {
+    PyObject_HEAD
+    mutation_model_t *mutation_model;
+} SlimMutationModel;
 
 typedef struct {
     PyObject_HEAD
     mutgen_t *mutgen;
     RandomGenerator *random_generator;
     IntervalMap *rate_map;
-    MutationModel *model;
+    PyObject *model;
 } MutationGenerator;
 
 typedef struct {
@@ -1828,23 +1833,23 @@ static PyTypeObject IntervalMapType = {
 
 
 /*===================================================================
- * Mutation model
+ * Matrix mutation model
  *===================================================================
  */
 
 static int
-MutationModel_check_state(MutationModel *self)
+MatrixMutationModel_check_state(MatrixMutationModel *self)
 {
     int ret = 0;
     if (self->mutation_model == NULL) {
-        PyErr_SetString(PyExc_SystemError, "MutationModel not initialised");
+        PyErr_SetString(PyExc_SystemError, "MatrixMutationModel not initialised");
         ret = -1;
     }
     return ret;
 }
 
 static void
-MutationModel_dealloc(MutationModel* self)
+MatrixMutationModel_dealloc(MatrixMutationModel* self)
 {
     if (self->mutation_model != NULL) {
         mutation_model_free(self->mutation_model);
@@ -1855,7 +1860,7 @@ MutationModel_dealloc(MutationModel* self)
 }
 
 static int
-MutationModel_init(MutationModel *self, PyObject *args, PyObject *kwds)
+MatrixMutationModel_init(MatrixMutationModel *self, PyObject *args, PyObject *kwds)
 {
     int ret = -1;
     int err;
@@ -1923,7 +1928,7 @@ MutationModel_init(MutationModel *self, PyObject *args, PyObject *kwds)
             goto out;
         }
     }
-    err = mutation_matrix_model_alloc(self->mutation_model,
+    err = matrix_mutation_model_alloc(self->mutation_model,
             num_alleles, alleles,
             PyArray_DATA(root_distribution_array),
             PyArray_DATA(transition_matrix_array));
@@ -1940,7 +1945,7 @@ out:
 }
 
 static PyObject *
-MutationModel_get_alleles(MutationModel *self, void *closure)
+MatrixMutationModel_get_alleles(MatrixMutationModel *self, void *closure)
 {
     PyObject *ret = NULL;
     size_t j;
@@ -1967,7 +1972,7 @@ out:
 }
 
 static PyObject *
-MutationModel_get_root_distribution(MutationModel *self, void *closure)
+MatrixMutationModel_get_root_distribution(MatrixMutationModel *self, void *closure)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
@@ -1987,7 +1992,7 @@ out:
 }
 
 static PyObject *
-MutationModel_get_transition_matrix(MutationModel *self, void *closure)
+MatrixMutationModel_get_transition_matrix(MatrixMutationModel *self, void *closure)
 {
     PyObject *ret = NULL;
     PyArrayObject *array;
@@ -2006,35 +2011,140 @@ out:
     return ret;
 }
 
-static PyGetSetDef MutationModel_getsetters[] = {
-    {"alleles", (getter) MutationModel_get_alleles, NULL,
+static PyGetSetDef MatrixMutationModel_getsetters[] = {
+    {"alleles", (getter) MatrixMutationModel_get_alleles, NULL,
         "A copy of the alleles list"},
-    {"root_distribution", (getter) MutationModel_get_root_distribution, NULL,
+    {"root_distribution", (getter) MatrixMutationModel_get_root_distribution, NULL,
         "A copy of the root_distribution array"},
-    {"transition_matrix", (getter) MutationModel_get_transition_matrix, NULL,
+    {"transition_matrix", (getter) MatrixMutationModel_get_transition_matrix, NULL,
         "A copy of the transition_matrix array"},
     {NULL}  /* Sentinel */
 };
 
-static PyMemberDef MutationModel_members[] = {
+static PyMemberDef MatrixMutationModel_members[] = {
     {NULL}  /* Sentinel */
 };
 
-static PyMethodDef MutationModel_methods[] = {
+static PyMethodDef MatrixMutationModel_methods[] = {
     {NULL}  /* Sentinel */
 };
 
-static PyTypeObject MutationModelType = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "_msprime.MutationModel",
-    .tp_basicsize = sizeof(MutationModel),
-    .tp_dealloc = (destructor)MutationModel_dealloc,
+static PyTypeObject MatrixMutationModelType = {
+    .tp_name = "_msprime.MatrixMutationModel",
+    .tp_basicsize = sizeof(MatrixMutationModel),
+    .tp_dealloc = (destructor)MatrixMutationModel_dealloc,
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
-    .tp_doc = "MutationModel objects",
-    .tp_methods = MutationModel_methods,
-    .tp_members = MutationModel_members,
-    .tp_getset = MutationModel_getsetters,
-    .tp_init = (initproc)MutationModel_init,
+    .tp_doc = "MatrixMutationModel objects",
+    .tp_methods = MatrixMutationModel_methods,
+    .tp_members = MatrixMutationModel_members,
+    .tp_getset = MatrixMutationModel_getsetters,
+    .tp_init = (initproc)MatrixMutationModel_init,
+    .tp_new = PyType_GenericNew,
+}
+;
+
+/*===================================================================
+ * Slim mutation model
+ *===================================================================
+ */
+
+static int
+SlimMutationModel_check_state(SlimMutationModel *self)
+{
+    int ret = 0;
+    if (self->mutation_model == NULL) {
+        PyErr_SetString(PyExc_SystemError, "SlimMutationModel not initialised");
+        ret = -1;
+    }
+    return ret;
+}
+
+static void
+SlimMutationModel_dealloc(SlimMutationModel* self)
+{
+    if (self->mutation_model != NULL) {
+        mutation_model_free(self->mutation_model);
+        PyMem_Free(self->mutation_model);
+        self->mutation_model = NULL;
+    }
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static int
+SlimMutationModel_init(SlimMutationModel *self, PyObject *args, PyObject *kwds)
+{
+    int ret = -1;
+    int err;
+    static char *kwlist[] = {"type", "next_id", "block_size", NULL};
+    long type;
+    long long next_id = 0;
+    Py_ssize_t block_size = 0;
+
+    self->mutation_model = NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "l|Ln", kwlist,
+            &type, &next_id, &block_size)) {
+        goto out;
+    }
+
+    /* Note: it's important we zero out mutation_model here because
+     * we can error before we can mutation_model_alloc, leaving the
+     * object in an uninitialised state */
+    self->mutation_model = PyMem_Calloc(1, sizeof(*self->mutation_model));
+    if (self->mutation_model == NULL) {
+        PyErr_NoMemory();
+        goto out;
+    }
+    err = slim_mutation_model_alloc(self->mutation_model,
+        (int32_t) type, (int64_t) next_id, (size_t) block_size);
+    if (err != 0) {
+        handle_library_error(err);
+        goto out;
+    }
+    ret = 0;
+out:
+    return ret;
+}
+
+static PyObject *
+SlimMutationModel_get_type(SlimMutationModel *self, void *closure)
+{
+    slim_mutator_t *params = &self->mutation_model->params.slim_mutator;
+    return Py_BuildValue("l", (long) params->mutation_type_id);
+}
+
+static PyObject *
+SlimMutationModel_get_next_id(SlimMutationModel *self, void *closure)
+{
+    slim_mutator_t *params = &self->mutation_model->params.slim_mutator;
+    return Py_BuildValue("L", params->next_mutation_id);
+}
+
+static PyGetSetDef SlimMutationModel_getsetters[] = {
+    {"type", (getter) SlimMutationModel_get_type, NULL,
+        "Return the mutation type"},
+    {"next_id", (getter) SlimMutationModel_get_next_id, NULL,
+        "Return the next mutation id"},
+    {NULL}  /* Sentinel */
+};
+
+static PyMemberDef SlimMutationModel_members[] = {
+    {NULL}  /* Sentinel */
+};
+
+static PyMethodDef SlimMutationModel_methods[] = {
+    {NULL}  /* Sentinel */
+};
+
+static PyTypeObject SlimMutationModelType = {
+    .tp_name = "_msprime.SlimMutationModel",
+    .tp_basicsize = sizeof(SlimMutationModel),
+    .tp_dealloc = (destructor)SlimMutationModel_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    .tp_doc = "SlimMutationModel objects",
+    .tp_methods = SlimMutationModel_methods,
+    .tp_members = SlimMutationModel_members,
+    .tp_getset = SlimMutationModel_getsetters,
+    .tp_init = (initproc)SlimMutationModel_init,
     .tp_new = PyType_GenericNew,
 };
 
@@ -2079,16 +2189,19 @@ MutationGenerator_init(MutationGenerator *self, PyObject *args, PyObject *kwds)
     static char *kwlist[] = {"random_generator", "rate_map", "model", NULL};
     RandomGenerator *random_generator = NULL;
     IntervalMap *rate_map = NULL;
-    MutationModel *model = NULL;
+    PyObject *py_model = NULL;
+    MatrixMutationModel *matrix_mutation_model = NULL;
+    SlimMutationModel *slim_mutation_model = NULL;
+    mutation_model_t *model = NULL;
 
     self->mutgen = NULL;
     self->random_generator = NULL;
     self->rate_map = NULL;
     self->model = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O", kwlist,
             &RandomGeneratorType, &random_generator,
             &IntervalMapType, &rate_map,
-            &MutationModelType, &model)) {
+            &py_model)) {
         goto out;
     }
     self->random_generator = random_generator;
@@ -2101,18 +2214,34 @@ MutationGenerator_init(MutationGenerator *self, PyObject *args, PyObject *kwds)
     if (IntervalMap_check_state(self->rate_map) != 0) {
         goto out;
     }
-    self->model = model;
-    Py_INCREF(self->model);
-    if (MutationModel_check_state(self->model) != 0) {
+    if (PyObject_TypeCheck(py_model, &MatrixMutationModelType)) {
+        matrix_mutation_model = (MatrixMutationModel *) py_model;
+        if (MatrixMutationModel_check_state(matrix_mutation_model) != 0) {
+            goto out;
+        }
+        model = matrix_mutation_model->mutation_model;
+    } else if (PyObject_TypeCheck(py_model, &SlimMutationModelType)) {
+        slim_mutation_model = (SlimMutationModel *) py_model;
+        if (SlimMutationModel_check_state(slim_mutation_model) != 0) {
+            goto out;
+        }
+        model = slim_mutation_model->mutation_model;
+    } else {
+        PyErr_SetString(PyExc_TypeError,
+            "model must be an instance of MatrixMutationModel "
+            "or SlimMutationModel");
         goto out;
     }
+    self->model = py_model;
+    Py_INCREF(self->model);
+
     self->mutgen = PyMem_Malloc(sizeof(mutgen_t));
     if (self->mutgen == NULL) {
         PyErr_NoMemory();
         goto out;
     }
     err = mutgen_alloc(self->mutgen, random_generator->rng,
-            rate_map->interval_map, model->mutation_model, 0);
+            rate_map->interval_map, model, 0);
     if (err != 0) {
         handle_library_error(err);
         goto out;
@@ -4366,12 +4495,21 @@ PyInit__msprime(void)
     Py_INCREF(&IntervalMapType);
     PyModule_AddObject(module, "IntervalMap", (PyObject *) &IntervalMapType);
 
-    /* MutationModel type */
-    if (PyType_Ready(&MutationModelType) < 0) {
+    /* MatrixMutationModel type */
+    if (PyType_Ready(&MatrixMutationModelType) < 0) {
         return NULL;
     }
-    Py_INCREF(&MutationModelType);
-    PyModule_AddObject(module, "MutationModel", (PyObject *) &MutationModelType);
+    Py_INCREF(&MatrixMutationModelType);
+    PyModule_AddObject(module, "MatrixMutationModel",
+            (PyObject *) &MatrixMutationModelType);
+
+    /* SlimMutationModel type */
+    if (PyType_Ready(&SlimMutationModelType) < 0) {
+        return NULL;
+    }
+    Py_INCREF(&SlimMutationModelType);
+    PyModule_AddObject(module, "SlimMutationModel",
+            (PyObject *) &SlimMutationModelType);
 
     /* Errors and constants */
     MsprimeInputError = PyErr_NewException("_msprime.InputError", NULL, NULL);

--- a/lib/dev-tools/dev-cli.c
+++ b/lib/dev-tools/dev-cli.c
@@ -786,7 +786,7 @@ run_simulate(const char *conf_file, const char *output_file, int verbose, int nu
     if (ret != 0) {
         fatal_msprime_error(ret, __LINE__);
     }
-    ret = mutation_model_factory(&mut_model, mutation_params.alphabet);
+    ret = matrix_mutation_model_factory(&mut_model, mutation_params.alphabet);
     if (ret != 0) {
         fatal_msprime_error(ret, __LINE__);
     }

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -312,18 +312,62 @@ typedef struct demographic_event_t_t {
     struct demographic_event_t_t *next;
 } demographic_event_t;
 
+/* The site_t and mutation_t are similar the equivalent tsk_ types,
+ * with some extra fields that we need for mutation generation. */
+typedef struct mutation_t {
+    tsk_id_t id;
+    tsk_id_t site;
+    tsk_id_t node;
+    char *derived_state;
+    tsk_size_t derived_state_length;
+    char *metadata;
+    tsk_size_t metadata_length;
+    double time;
+    struct mutation_t *parent;
+    struct mutation_t *next;
+    bool new;
+    bool keep;
+} mutation_t;
+
 typedef struct {
     double position;
-    node_id_t node;
-    const char *ancestral_state;
-    const char *derived_state;
-} infinite_sites_mutation_t;
+    char *ancestral_state;
+    tsk_size_t ancestral_state_length;
+    char *metadata;
+    tsk_size_t metadata_length;
+    mutation_t *mutations;
+    size_t mutations_length;
+    bool new;
+} site_t;
 
 typedef struct {
     size_t num_alleles;
     char **alleles;
+    tsk_size_t *allele_length;
     double *root_distribution;
     double *transition_matrix;
+} mutation_matrix_t;
+
+typedef struct {
+    int32_t mutation_type_id; // following SLiM's MutationMetadataRec
+    int64_t next_mutation_id; // following SLiM's slim_mutationid_t
+    tsk_blkalloc_t allocator;
+} slim_mutator_t;
+
+typedef struct _mutation_model_t {
+    union {
+        mutation_matrix_t mutation_matrix;
+        slim_mutator_t slim_mutator;
+        /* Other known mutation models */
+    } params;
+    void (*print_state)(struct _mutation_model_t *model, FILE *out);
+    int (*free)(struct _mutation_model_t *model);
+    int (*choose_root_state)(
+        struct _mutation_model_t *model, gsl_rng *rng, site_t *site);
+    int (*transition)(struct _mutation_model_t *model, gsl_rng *rng,
+        const char *parent_allele, tsk_size_t parent_allele_length,
+        const char *parent_metadata, tsk_size_t parent_metadata_length,
+        mutation_t *mutation);
 } mutation_model_t;
 
 typedef struct {
@@ -470,12 +514,18 @@ double recomb_map_position_to_mass(recomb_map_t *self, double position);
 double recomb_map_shift_by_mass(recomb_map_t *self, double pos, double mass);
 double recomb_map_sample_poisson(recomb_map_t *self, gsl_rng *rng, double start);
 
-int mutation_model_alloc(mutation_model_t *self, size_t num_alleles, char **alleles,
-    double *root_distribution, double *transition_matrix);
-int mutation_model_free(mutation_model_t *self);
-size_t mutation_model_get_num_alleles(mutation_model_t *self);
-void mutation_model_print_state(mutation_model_t *self, FILE *out);
 int mutation_model_factory(mutation_model_t *self, int model);
+int mutation_matrix_model_alloc(mutation_model_t *self, size_t num_alleles,
+    char **alleles, double *root_distribution, double *transition_matrix);
+int slim_mutator_alloc(mutation_model_t *self, int32_t mutation_type_id,
+    int64_t next_mutation_id, size_t block_size);
+int mutation_model_free(mutation_model_t *self);
+int mutation_model_choose_root_state(mutation_model_t *self, gsl_rng *rng, site_t *site);
+int mutation_model_transition(mutation_model_t *model, gsl_rng *rng,
+    const char *parent_allele, tsk_size_t parent_allele_length,
+    const char *parent_metadata, tsk_size_t parent_metadata_length,
+    mutation_t *mutation);
+void mutation_model_print_state(mutation_model_t *self, FILE *out);
 
 int mutgen_alloc(mutgen_t *self, gsl_rng *rng, interval_map_t *rate_map,
     mutation_model_t *model, size_t mutation_block_size);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -354,10 +354,17 @@ typedef struct {
     tsk_blkalloc_t allocator;
 } slim_mutator_t;
 
+typedef struct {
+    uint64_t start_allele;
+    uint64_t next_allele;
+    tsk_blkalloc_t allocator;
+} infinite_alleles_t;
+
 typedef struct _mutation_model_t {
     union {
         mutation_matrix_t mutation_matrix;
         slim_mutator_t slim_mutator;
+        infinite_alleles_t infinite_alleles;
         /* Other known mutation models */
     } params;
     void (*print_state)(struct _mutation_model_t *model, FILE *out);
@@ -519,12 +526,9 @@ int matrix_mutation_model_alloc(mutation_model_t *self, size_t num_alleles,
     char **alleles, double *root_distribution, double *transition_matrix);
 int slim_mutation_model_alloc(mutation_model_t *self, int32_t mutation_type_id,
     int64_t next_mutation_id, size_t block_size);
+int infinite_alleles_mutation_model_alloc(
+    mutation_model_t *self, uint64_t start_allele, tsk_flags_t options);
 int mutation_model_free(mutation_model_t *self);
-int mutation_model_choose_root_state(mutation_model_t *self, gsl_rng *rng, site_t *site);
-int mutation_model_transition(mutation_model_t *model, gsl_rng *rng,
-    const char *parent_allele, tsk_size_t parent_allele_length,
-    const char *parent_metadata, tsk_size_t parent_metadata_length,
-    mutation_t *mutation);
 void mutation_model_print_state(mutation_model_t *self, FILE *out);
 
 int mutgen_alloc(mutgen_t *self, gsl_rng *rng, interval_map_t *rate_map,

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -514,10 +514,10 @@ double recomb_map_position_to_mass(recomb_map_t *self, double position);
 double recomb_map_shift_by_mass(recomb_map_t *self, double pos, double mass);
 double recomb_map_sample_poisson(recomb_map_t *self, gsl_rng *rng, double start);
 
-int mutation_model_factory(mutation_model_t *self, int model);
-int mutation_matrix_model_alloc(mutation_model_t *self, size_t num_alleles,
+int matrix_mutation_model_factory(mutation_model_t *self, int model);
+int matrix_mutation_model_alloc(mutation_model_t *self, size_t num_alleles,
     char **alleles, double *root_distribution, double *transition_matrix);
-int slim_mutator_alloc(mutation_model_t *self, int32_t mutation_type_id,
+int slim_mutation_model_alloc(mutation_model_t *self, int32_t mutation_type_id,
     int64_t next_mutation_id, size_t block_size);
 int mutation_model_free(mutation_model_t *self);
 int mutation_model_choose_root_state(mutation_model_t *self, gsl_rng *rng, site_t *site);

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -26,34 +26,6 @@
 
 #include "msprime.h"
 
-typedef struct mutation_t {
-    tsk_id_t id;
-    tsk_id_t site;
-    tsk_id_t node;
-    char *derived_state;
-    tsk_size_t derived_state_length;
-    char *metadata;
-    tsk_size_t metadata_length;
-    // additions to tsk_mutation_t:
-    double time;
-    struct mutation_t *parent;
-    struct mutation_t *next;
-    bool new;
-    bool keep;
-} mutation_t;
-
-typedef struct {
-    double position;
-    char *ancestral_state;
-    tsk_size_t ancestral_state_length;
-    char *metadata;
-    tsk_size_t metadata_length;
-    // modifications to tsk_site_t:
-    mutation_t *mutations;
-    size_t mutations_length;
-    bool new;
-} site_t;
-
 static int
 cmp_site(const void *a, const void *b)
 {
@@ -123,25 +95,50 @@ out:
     return ret;
 }
 
-/*******************
- * Mutation model */
+static int MSP_WARN_UNUSED
+copy_string(tsk_blkalloc_t *allocator, char *source, tsk_size_t length, char **destp,
+    tsk_size_t *dest_length)
+{
+    int ret = 0;
+    char *buff;
+    *dest_length = length;
+    *destp = NULL;
 
-void
-mutation_model_print_state(mutation_model_t *self, FILE *out)
+    if (length > 0) {
+        buff = tsk_blkalloc_get(allocator, length);
+        if (buff == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
+        memcpy(buff, source, length);
+        *destp = buff;
+    }
+out:
+    return ret;
+}
+
+/**************************
+ * Mutation matrix model */
+
+static void
+mutation_matrix_print_state(mutation_model_t *self, FILE *out)
 {
     size_t j, k;
     double *mutation_row;
+    mutation_matrix_t params = self->params.mutation_matrix;
 
-    fprintf(out, "mutation_model (%p):: (%d)", (void *) self, (int) self->num_alleles);
+    fprintf(out, "mutation_matrix :: num_alleles = %d\n", (int) params.num_alleles);
     fprintf(out, "\nroot_distribution =");
-    for (j = 0; j < self->num_alleles; j++) {
-        fprintf(out, " %s (%0.4f),", self->alleles[j], self->root_distribution[j]);
+    for (j = 0; j < params.num_alleles; j++) {
+        fprintf(out, " '%.*s'(len=%d p=%0.4f),", (int) params.allele_length[j],
+            params.alleles[j], (int) params.allele_length[j],
+            params.root_distribution[j]);
     }
     fprintf(out, "\n\t------------------------------\n");
-    for (j = 0; j < self->num_alleles; j++) {
-        mutation_row = self->transition_matrix + j * self->num_alleles;
+    for (j = 0; j < params.num_alleles; j++) {
+        mutation_row = params.transition_matrix + j * params.num_alleles;
         fprintf(out, "\t");
-        for (k = 0; k < self->num_alleles; k++) {
+        for (k = 0; k < params.num_alleles; k++) {
             fprintf(out, " %0.4f", mutation_row[k]);
         }
         fprintf(out, "\n");
@@ -150,7 +147,7 @@ mutation_model_print_state(mutation_model_t *self, FILE *out)
 }
 
 static int MSP_WARN_UNUSED
-mutation_model_check_validity(mutation_model_t *self)
+mutation_matrix_check_validity(mutation_matrix_t *self)
 {
     int ret = 0;
     size_t j, k;
@@ -187,53 +184,343 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutation_model_copy_alleles(mutation_model_t *self, char **alleles)
+mutation_matrix_copy_alleles(mutation_matrix_t *self, char **alleles)
 {
     int ret = 0;
     size_t j, len;
 
     for (j = 0; j < self->num_alleles; j++) {
         len = strlen(alleles[j]);
-        self->alleles[j] = malloc(len + 1);
+        self->allele_length[j] = (tsk_size_t) len;
+        self->alleles[j] = malloc(len);
         if (self->alleles[j] == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
             goto out;
         }
-        strcpy(self->alleles[j], alleles[j]);
+        memcpy(self->alleles[j], alleles[j], len);
     }
 out:
     return ret;
 }
 
+static tsk_id_t
+mutation_matrix_allele_index(mutation_matrix_t *self, const char *allele, size_t length)
+{
+    tsk_id_t ret = -1;
+    tsk_size_t j;
+
+    for (j = 0; j < self->num_alleles; j++) {
+        if (length == self->allele_length[j]
+            && memcmp(allele, self->alleles[j], length) == 0) {
+            ret = (tsk_id_t) j;
+            break;
+        }
+    }
+    return ret;
+}
+
+static int
+mutation_matrix_choose_root_state(mutation_model_t *self, gsl_rng *rng, site_t *site)
+{
+    int ret = 0;
+    mutation_matrix_t params = self->params.mutation_matrix;
+    double u = gsl_ran_flat(rng, 0.0, 1.0);
+    tsk_size_t j = 0;
+
+    while (u > params.root_distribution[j]) {
+        u -= params.root_distribution[j];
+        j++;
+        assert(j < params.num_alleles);
+    }
+    site->ancestral_state = params.alleles[j];
+    site->ancestral_state_length = params.allele_length[j];
+    return ret;
+}
+
+/* Return 1 if the new derived allele matches parent allele
+ * and therefore no transition occurs
+ */
+static int
+mutation_matrix_transition(mutation_model_t *self, gsl_rng *rng,
+    const char *parent_allele, tsk_size_t parent_allele_length,
+    const char *MSP_UNUSED(parent_metadata),
+    tsk_size_t MSP_UNUSED(parent_metadata_length), mutation_t *mutation)
+{
+    int ret = 0;
+    mutation_matrix_t params = self->params.mutation_matrix;
+    double u = gsl_ran_flat(rng, 0.0, 1.0);
+    double *probs;
+    tsk_id_t j, pi;
+
+    pi = mutation_matrix_allele_index(&params, parent_allele, parent_allele_length);
+    if (pi < 0) {
+        /* only error if we are actually trying to mutate an unknown allele */
+        ret = MSP_ERR_UNKNOWN_ALLELE;
+        goto out;
+    }
+    probs = params.transition_matrix + (tsk_size_t) pi * params.num_alleles;
+    j = 0;
+    while (u > probs[j]) {
+        u -= probs[j];
+        j++;
+        assert(j < (tsk_id_t) params.num_alleles);
+    }
+    ret = 1;
+    if (j != pi) {
+        /* Only return 0 in the case where we perform an actual transition */
+        ret = 0;
+        mutation->derived_state = params.alleles[j];
+        mutation->derived_state_length = params.allele_length[j];
+    }
+out:
+    return ret;
+}
+
+static int
+mutation_matrix_free(mutation_model_t *self)
+{
+    mutation_matrix_t params = self->params.mutation_matrix;
+    tsk_size_t j;
+
+    if (params.alleles != NULL) {
+        for (j = 0; j < params.num_alleles; j++) {
+            msp_safe_free(params.alleles[j]);
+        }
+    }
+    msp_safe_free(params.alleles);
+    msp_safe_free(params.allele_length);
+    msp_safe_free(params.root_distribution);
+    msp_safe_free(params.transition_matrix);
+    return 0;
+}
+
+/***********************
+ * SLiM mutation model */
+
+/* From slim_globals.h:
+ * line 131 in v3.4, git hash b2c2b634199f35e53c4e7e513bd26c91c6d99fd9 */
+typedef int64_t slim_mutationid_t; // identifiers for mutations, which require 64 bits
+                                   // since there can be so many
+
+/* Typedefs from MutationMetadataRec in slim_sim.h:
+ * line 125 in v3.4, git hash b2c2b634199f35e53c4e7e513bd26c91c6d99fd9
+ *  int32_t mutation_type_id_; // 4 bytes (int32_t): the id of the mutation type the
+ *                             // mutation belongs to
+ *  float selection_coeff_;    // 4 bytes (float): the selection coefficient
+ *  int32_t subpop_index_; // 4 bytes (int32_t): the id of the subpopulation in which the
+ *                         // mutation arose
+ *  int32_t origin_generation_; // 4 bytes (int32_t): the generation in which the
+ *                              // mutation arose
+ *  int8_t nucleotide_; // 1 byte (int8_t): the nucleotide for the mutation (0='A',
+ *                      // 1='C', 2='G', 3='T'), or -1
+ *
+ * Note that these are defined there as a __packed__ struct, like
+ * typedef struct __attribute__((__packed__))  but this is not available
+ * in Windows compilers, so we're just copying the info in directly */
+
+#define SLIM_MUTATION_METADATA_SIZE 17 // = 4 + 4 + 4 + 4 + 1
+
+static void
+copy_slim_mutation_metadata(slim_mutator_t *params, char *dest)
+{
+    size_t n;
+    int32_t *mutation_type_id_;
+    float *selection_coeff_;
+    int32_t *subpop_index_;
+    int32_t *origin_generation_;
+    int8_t *nucleotide_;
+
+    n = 0;
+    mutation_type_id_ = (int32_t *) (dest + n);
+    *mutation_type_id_ = params->mutation_type_id;
+    n += sizeof(int32_t);
+    selection_coeff_ = (float *) (dest + n);
+    *selection_coeff_ = 0.0;
+    n += sizeof(float);
+    subpop_index_ = (int32_t *) (dest + n);
+    *subpop_index_ = TSK_NULL;
+    n += sizeof(int32_t);
+    // TODO: remove this when switch to mutation time
+    origin_generation_ = (int32_t *) (dest + n);
+    *origin_generation_ = 0.0;
+    n += sizeof(int32_t);
+    nucleotide_ = (int8_t *) (dest + n);
+    *nucleotide_ = -1;
+}
+
+static void
+slim_mutator_print_state(mutation_model_t *self, FILE *out)
+{
+    slim_mutator_t params = self->params.slim_mutator;
+    fprintf(out, "SLiM mutation model :: mutation type ID = %d\n",
+        (int) params.mutation_type_id);
+    fprintf(out, "                       next mutation ID = %d\n",
+        (int) params.next_mutation_id);
+}
+
+static int MSP_WARN_UNUSED
+slim_mutator_check_validity(slim_mutator_t *self)
+{
+    int ret = 0;
+
+    if (self->next_mutation_id < 0) {
+        ret = MSP_ERR_BAD_SLIM_PARAMETERS;
+        goto out;
+    }
+
+    if (self->mutation_type_id < 0) {
+        ret = MSP_ERR_BAD_SLIM_PARAMETERS;
+        goto out;
+    }
+
+out:
+    return ret;
+}
+
+static int
+slim_mutator_choose_root_state(
+    mutation_model_t *MSP_UNUSED(self), gsl_rng *MSP_UNUSED(rng), site_t *site)
+{
+    site->ancestral_state = NULL;
+    site->ancestral_state_length = 0;
+    return 0;
+}
+
+static int
+slim_mutator_transition(mutation_model_t *self, gsl_rng *MSP_UNUSED(rng),
+    const char *parent_allele, tsk_size_t parent_allele_length,
+    const char *parent_metadata, tsk_size_t parent_metadata_length, mutation_t *mutation)
+{
+    int ret = 0;
+    slim_mutator_t *params = &self->params.slim_mutator;
+    char *buff = NULL;
+
+    // append to derived state
+    buff = tsk_blkalloc_get(
+        &params->allocator, parent_allele_length + sizeof(slim_mutationid_t));
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, parent_allele, parent_allele_length);
+    memcpy(buff + parent_allele_length, &params->next_mutation_id,
+        sizeof(slim_mutationid_t));
+    params->next_mutation_id++;
+    mutation->derived_state = buff;
+    mutation->derived_state_length
+        = (tsk_size_t)(parent_allele_length + sizeof(slim_mutationid_t));
+
+    // append to metadata
+    buff = tsk_blkalloc_get(
+        &params->allocator, parent_metadata_length + SLIM_MUTATION_METADATA_SIZE);
+    if (buff == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+    memcpy(buff, parent_metadata, parent_metadata_length);
+    copy_slim_mutation_metadata(params, buff + parent_metadata_length);
+
+    mutation->metadata = buff;
+    mutation->metadata_length
+        = (tsk_size_t)(parent_metadata_length + SLIM_MUTATION_METADATA_SIZE);
+
+out:
+    return ret;
+}
+
+static int
+slim_mutator_free(mutation_model_t *self)
+{
+    slim_mutator_t params = self->params.slim_mutator;
+    tsk_blkalloc_free(&params.allocator);
+    return 0;
+}
+
+/*****************************************
+ * Mutation model public API
+ *
+ * This consists of a factory function for each type of model supported
+ * (e.g., mutation_matrix_model_alloc), mutation_matrix_free,
+ * mutation_model_choose_root_state and mutation_model_transition.
+ * These delegate the actual implementations to function pointers that
+ * are implemented by the actual models.
+ */
+
 int MSP_WARN_UNUSED
-mutation_model_alloc(mutation_model_t *self, size_t num_alleles, char **alleles,
+mutation_matrix_model_alloc(mutation_model_t *self, size_t num_alleles, char **alleles,
     double *root_distribution, double *transition_matrix)
 {
     int ret = 0;
+    mutation_matrix_t *params = &self->params.mutation_matrix;
 
     memset(self, 0, sizeof(mutation_model_t));
     if (num_alleles < 2) {
         ret = MSP_ERR_INSUFFICIENT_ALLELES;
         goto out;
     }
-    self->alleles = calloc(num_alleles, sizeof(*self->alleles));
-    self->root_distribution = malloc(num_alleles * sizeof(*self->root_distribution));
-    self->transition_matrix
-        = malloc(num_alleles * num_alleles * sizeof(*self->transition_matrix));
-    if (self->alleles == NULL || self->root_distribution == NULL
-        || self->transition_matrix == NULL) {
+    params->num_alleles = num_alleles;
+    params->alleles = calloc(num_alleles, sizeof(*params->alleles));
+    params->allele_length = calloc(num_alleles, sizeof(*params->allele_length));
+    params->root_distribution = malloc(num_alleles * sizeof(*params->root_distribution));
+    params->transition_matrix
+        = malloc(num_alleles * num_alleles * sizeof(*params->transition_matrix));
+    if (params->alleles == NULL || params->allele_length == NULL
+        || params->root_distribution == NULL || params->transition_matrix == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
-    self->num_alleles = num_alleles;
-    memcpy(self->root_distribution, root_distribution,
+    memcpy(params->root_distribution, root_distribution,
         num_alleles * sizeof(*root_distribution));
-    memcpy(self->transition_matrix, transition_matrix,
+    memcpy(params->transition_matrix, transition_matrix,
         num_alleles * num_alleles * sizeof(*transition_matrix));
-    ret = mutation_model_copy_alleles(self, alleles);
+    ret = mutation_matrix_copy_alleles(params, alleles);
     if (ret != 0) {
         goto out;
     }
-    ret = mutation_model_check_validity(self);
+    self->choose_root_state = &mutation_matrix_choose_root_state;
+    self->transition = &mutation_matrix_transition;
+    self->print_state = &mutation_matrix_print_state;
+    self->free = &mutation_matrix_free;
+
+    ret = mutation_matrix_check_validity(params);
+    if (ret != 0) {
+        goto out;
+    }
+out:
+    return ret;
+}
+
+int MSP_WARN_UNUSED
+slim_mutator_alloc(mutation_model_t *self, int32_t mutation_type_id,
+    int64_t next_mutation_id, size_t block_size)
+{
+    int ret = 0;
+    slim_mutator_t *params = &self->params.slim_mutator;
+
+    memset(self, 0, sizeof(mutation_model_t));
+
+    if (block_size == 0) {
+        block_size = 8192;
+    }
+    ret = tsk_blkalloc_init(&params->allocator, block_size);
+    if (ret != 0) {
+        ret = msp_set_tsk_error(ret);
+        goto out;
+    }
+
+    params->mutation_type_id = mutation_type_id;
+    params->next_mutation_id = next_mutation_id;
+
+    self->choose_root_state = &slim_mutator_choose_root_state;
+    self->transition = &slim_mutator_transition;
+    self->print_state = &slim_mutator_print_state;
+    self->free = &slim_mutator_free;
+
+    ret = slim_mutator_check_validity(params);
+    if (ret != 0) {
+        goto out;
+    }
+
 out:
     return ret;
 }
@@ -241,39 +528,31 @@ out:
 int
 mutation_model_free(mutation_model_t *self)
 {
-    size_t j;
-
-    if (self->alleles != NULL) {
-        for (j = 0; j < self->num_alleles; j++) {
-            msp_safe_free(self->alleles[j]);
-        }
+    if (self->free != NULL) {
+        self->free(self);
     }
-    msp_safe_free(self->alleles);
-    msp_safe_free(self->root_distribution);
-    msp_safe_free(self->transition_matrix);
     return 0;
 }
 
-size_t
-mutation_model_get_num_alleles(mutation_model_t *self)
+int MSP_WARN_UNUSED
+mutation_model_choose_root_state(mutation_model_t *self, gsl_rng *rng, site_t *site)
 {
-    return self->num_alleles;
+    return self->choose_root_state(self, rng, site);
 }
 
-static tsk_id_t
-mutation_model_allele_index(mutation_model_t *self, const char *allele, size_t length)
+int MSP_WARN_UNUSED
+mutation_model_transition(mutation_model_t *self, gsl_rng *rng,
+    const char *parent_allele, tsk_size_t parent_allele_length,
+    const char *parent_metadata, tsk_size_t parent_metadata_length, mutation_t *mutation)
 {
-    tsk_id_t ret = -1;
-    tsk_size_t j;
+    return self->transition(self, rng, parent_allele, parent_allele_length,
+        parent_metadata, parent_metadata_length, mutation);
+}
 
-    for (j = 0; j < self->num_alleles; j++) {
-        if (length == strlen(self->alleles[j])
-            && memcmp(allele, self->alleles[j], length) == 0) {
-            ret = (tsk_id_t) j;
-            break;
-        }
-    }
-    return ret;
+void
+mutation_model_print_state(mutation_model_t *self, FILE *out)
+{
+    self->print_state(self, out);
 }
 
 static const char *binary_alleles[] = { "0", "1" };
@@ -303,10 +582,11 @@ mutation_model_factory(mutation_model_t *self, int model)
     /* We need to cast to uintptr_t * first to work around the annoying pedantry
      * about discarding const qualifiers. */
     if (model == 0) {
-        ret = mutation_model_alloc(self, 2, (char **) (uintptr_t *) binary_alleles,
-            binary_model_root_distribution, binary_model_transition_matrix);
+        ret = mutation_matrix_model_alloc(self, 2,
+            (char **) (uintptr_t *) binary_alleles, binary_model_root_distribution,
+            binary_model_transition_matrix);
     } else if (model == 1) {
-        ret = mutation_model_alloc(self, 4, (char **) (uintptr_t *) acgt_alleles,
+        ret = mutation_matrix_model_alloc(self, 4, (char **) (uintptr_t *) acgt_alleles,
             jukes_cantor_model_root_distribution, jukes_cantor_model_transition_matrix);
     }
     return ret;
@@ -353,19 +633,20 @@ mutgen_print_state(mutgen_t *self, FILE *out)
     fprintf(out, "\tstart_time = %f\n", self->start_time);
     fprintf(out, "\tend_time = %f\n", self->end_time);
     fprintf(out, "\tmodel:\n");
-    mutation_model_print_state(self->model, out);
+    self->model->print_state(self->model, out);
     tsk_blkalloc_print_state(&self->allocator, out);
 
     for (a = self->sites.head; a != NULL; a = a->next) {
         s = (site_t *) a->item;
-        fprintf(out, "%f\t%.*s\t%.*s\t(%d)\t%d\n", s->position,
+        fprintf(out, "site:\t%f\t'%.*s'\t'%.*s'\t(%d)\t%d\n", s->position,
             (int) s->ancestral_state_length, s->ancestral_state,
             (int) s->metadata_length, s->metadata, s->new, (int) s->mutations_length);
         for (m = s->mutations; m != NULL; m = m->next) {
             parent_id = m->parent == NULL ? TSK_NULL : m->parent->id;
-            fprintf(out, "\t(%d)\t%f\t%d\t%d\t%.*s\t%.*s\t(%d)\t%d\n", m->id, m->time,
-                m->node, parent_id, (int) m->derived_state_length, m->derived_state,
-                (int) m->metadata_length, m->metadata, m->new, m->keep);
+            fprintf(out, "\tmut:\t(%d)\t%f\t%d\t%d\t'%.*s'\t'%.*s'\t(%d)\t%d\n", m->id,
+                m->time, m->node, parent_id, (int) m->derived_state_length,
+                m->derived_state, (int) m->metadata_length, m->metadata, m->new,
+                m->keep);
         }
     }
     mutgen_check_state(self);
@@ -455,7 +736,7 @@ mutgen_init_allocator(mutgen_t *self, tsk_table_collection_t *tables)
         = GSL_MAX(self->block_size, 1 + tables->mutations.derived_state_length);
     self->block_size = GSL_MAX(self->block_size, 1 + tables->mutations.metadata_length);
     self->block_size = GSL_MAX(
-        self->block_size, (1 + tables->mutations.num_rows) * sizeof(tsk_mutation_t));
+        self->block_size, (1 + tables->mutations.num_rows) * sizeof(mutation_t));
     ret = tsk_blkalloc_init(&self->allocator, self->block_size);
     if (ret != 0) {
         ret = msp_set_tsk_error(ret);
@@ -466,12 +747,9 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_site(mutgen_t *self, double position, bool new, const char *ancestral_state,
-    tsk_size_t ancestral_state_length, const char *metadata, tsk_size_t metadata_length,
-    avl_node_t **avl_nodep)
+mutgen_add_new_site(mutgen_t *self, double position, site_t **new_site)
 {
     int ret = 0;
-    char *buff;
     avl_node_t *avl_node;
     site_t *site;
 
@@ -483,27 +761,7 @@ mutgen_add_site(mutgen_t *self, double position, bool new, const char *ancestral
     }
     memset(site, 0, sizeof(*site));
     site->position = position;
-    site->new = new;
-
-    /* ancestral state */
-    buff = tsk_blkalloc_get(&self->allocator, ancestral_state_length);
-    if (buff == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    memcpy(buff, ancestral_state, ancestral_state_length);
-    site->ancestral_state = buff;
-    site->ancestral_state_length = ancestral_state_length;
-
-    /* metadata */
-    buff = tsk_blkalloc_get(&self->allocator, metadata_length);
-    if (buff == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    memcpy(buff, metadata, metadata_length);
-    site->metadata = buff;
-    site->metadata_length = metadata_length;
+    site->new = true;
 
     avl_init_node(avl_node, site);
     avl_node = avl_insert_node(&self->sites, avl_node);
@@ -511,19 +769,46 @@ mutgen_add_site(mutgen_t *self, double position, bool new, const char *ancestral
         ret = MSP_ERR_DUPLICATE_SITE_POSITION;
         goto out;
     }
-    *avl_nodep = avl_node;
-
+    *new_site = site;
 out:
     return ret;
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_mutation(mutgen_t *self, site_t *site, tsk_id_t id, node_id_t node,
-    double time, bool new, const char *derived_state, tsk_size_t derived_state_length,
-    const char *metadata, tsk_size_t metadata_length)
+mutgen_add_existing_site(mutgen_t *self, double position, char *ancestral_state,
+    tsk_size_t ancestral_state_length, char *metadata, tsk_size_t metadata_length,
+    site_t **new_site)
 {
     int ret = 0;
-    char *buff;
+    site_t *site;
+
+    ret = mutgen_add_new_site(self, position, &site);
+    if (ret != 0) {
+        goto out;
+    }
+    site->new = false;
+
+    /* We need to copy the ancestral state and metadata  */
+    ret = copy_string(&self->allocator, ancestral_state, ancestral_state_length,
+        &site->ancestral_state, &site->ancestral_state_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = copy_string(&self->allocator, metadata, metadata_length, &site->metadata,
+        &site->metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
+    *new_site = site;
+out:
+    return ret;
+}
+
+static int
+mutgen_add_mutation(
+    mutgen_t *self, site_t *site, node_id_t node, double time, mutation_t **new_mutation)
+{
+    int ret = 0;
 
     mutation_t *mutation = tsk_blkalloc_get(&self->allocator, sizeof(*mutation));
     if (mutation == NULL) {
@@ -531,33 +816,49 @@ mutgen_add_mutation(mutgen_t *self, site_t *site, tsk_id_t id, node_id_t node,
         goto out;
     }
     memset(mutation, 0, sizeof(*mutation));
-    mutation->id = id, mutation->node = node;
-    mutation->parent = NULL;
+    mutation->node = node;
     mutation->time = time;
-    mutation->new = new;
-    mutation->keep = true;
-
-    /* derived state */
-    buff = tsk_blkalloc_get(&self->allocator, derived_state_length);
-    if (buff == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    memcpy(buff, derived_state, derived_state_length);
-    mutation->derived_state = buff;
-    mutation->derived_state_length = derived_state_length;
-
-    /* metadata */
-    buff = tsk_blkalloc_get(&self->allocator, metadata_length);
-    if (buff == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    memcpy(buff, metadata, metadata_length);
-    mutation->metadata = buff;
-    mutation->metadata_length = metadata_length;
-
+    mutation->parent = NULL;
+    mutation->new = true;
     insert_mutation(site, mutation);
+    *new_mutation = mutation;
+out:
+    return ret;
+}
+
+static int MSP_WARN_UNUSED
+mutgen_add_new_mutation(mutgen_t *self, site_t *site, node_id_t node, double time)
+{
+    mutation_t *placeholder;
+    return mutgen_add_mutation(self, site, node, time, &placeholder);
+}
+
+static int MSP_WARN_UNUSED
+mutgen_add_existing_mutation(mutgen_t *self, site_t *site, tsk_id_t id, node_id_t node,
+    double time, char *derived_state, tsk_size_t derived_state_length, char *metadata,
+    tsk_size_t metadata_length)
+{
+    int ret = 0;
+    mutation_t *mutation;
+
+    ret = mutgen_add_mutation(self, site, node, time, &mutation);
+    if (ret != 0) {
+        goto out;
+    }
+    mutation->id = id;
+    mutation->new = false;
+
+    /* Need to copy the derived state and metadata */
+    ret = copy_string(&self->allocator, derived_state, derived_state_length,
+        &mutation->derived_state, &mutation->derived_state_length);
+    if (ret != 0) {
+        goto out;
+    }
+    ret = copy_string(&self->allocator, metadata, metadata_length, &mutation->metadata,
+        &mutation->metadata_length);
+    if (ret != 0) {
+        goto out;
+    }
 out:
     return ret;
 }
@@ -569,26 +870,22 @@ mutgen_initialise_sites(mutgen_t *self, tsk_table_collection_t *tables)
     tsk_site_table_t *sites = &tables->sites;
     tsk_mutation_table_t *mutations = &tables->mutations;
     tsk_node_table_t *nodes = &tables->nodes;
-    site_id_t site_id;
-    avl_node_t *avl_node;
-    const char *state, *metadata;
+    tsk_id_t site_id;
+    site_t *site;
+    char *state, *metadata;
     tsk_size_t j, length, metadata_length;
 
     j = 0;
     for (site_id = 0; site_id < (site_id_t) sites->num_rows; site_id++) {
-        avl_node = tsk_blkalloc_get(&self->allocator, sizeof(*avl_node));
-        if (avl_node == NULL) {
-            ret = MSP_ERR_NO_MEMORY;
-            goto out;
-        }
         state = sites->ancestral_state + sites->ancestral_state_offset[site_id];
         length = sites->ancestral_state_offset[site_id + 1]
                  - sites->ancestral_state_offset[site_id];
         metadata = sites->metadata + sites->metadata_offset[site_id];
         metadata_length
             = sites->metadata_offset[site_id + 1] - sites->metadata_offset[site_id];
-        ret = mutgen_add_site(self, sites->position[site_id], false, state, length,
-            metadata, metadata_length, &avl_node);
+
+        ret = mutgen_add_existing_site(self, sites->position[site_id], state, length,
+            metadata, metadata_length, &site);
         if (ret != 0) {
             goto out;
         }
@@ -601,9 +898,9 @@ mutgen_initialise_sites(mutgen_t *self, tsk_table_collection_t *tables)
             metadata = mutations->metadata + mutations->metadata_offset[j];
             metadata_length
                 = mutations->metadata_offset[j + 1] - mutations->metadata_offset[j];
-            ret = mutgen_add_mutation(self, (site_t *) avl_node->item, (int) j,
-                mutations->node[j], nodes->time[mutations->node[j]], false, state,
-                length, metadata, metadata_length);
+            ret = mutgen_add_existing_mutation(self, site, (int) j, mutations->node[j],
+                nodes->time[mutations->node[j]], state, length, metadata,
+                metadata_length);
             if (ret != 0) {
                 goto out;
             }
@@ -686,6 +983,7 @@ mutgen_place_mutations(
     double branch_start, branch_end, branch_length;
     node_id_t parent, child;
     avl_node_t *avl_node;
+    site_t *site;
     double start_time = self->start_time;
     double end_time = self->end_time;
     site_t search;
@@ -726,15 +1024,15 @@ mutgen_place_mutations(
                 time = gsl_ran_flat(self->rng, branch_start, branch_end);
                 assert(site_left <= position && position < site_right);
                 assert(branch_start <= time && time < branch_end);
-                if (avl_node == NULL) {
-                    ret = mutgen_add_site(
-                        self, position, true, NULL, 0, NULL, 0, &avl_node);
+                if (avl_node != NULL) {
+                    site = (site_t *) avl_node->item;
+                } else {
+                    ret = mutgen_add_new_site(self, position, &site);
                     if (ret != 0) {
                         goto out;
                     }
                 }
-                ret = mutgen_add_mutation(self, (site_t *) avl_node->item, TSK_NULL,
-                    child, time, true, NULL, 0, NULL, 0);
+                ret = mutgen_add_new_mutation(self, site, child, time);
                 if (ret != 0) {
                     goto out;
                 }
@@ -746,76 +1044,13 @@ out:
     return ret;
 }
 
-static int
-mutation_model_pick_allele(mutation_model_t *self, gsl_rng *rng)
-{
-    double u = gsl_ran_flat(rng, 0.0, 1.0);
-    int j = 0;
-    while (u > self->root_distribution[j]) {
-        u -= self->root_distribution[j];
-        j++;
-        assert(j < (int) self->num_alleles);
-    }
-    return j;
-}
-
-static int
-mutation_model_transition_allele(mutation_model_t *self, int parent_allele, gsl_rng *rng)
-{
-    double *probs = self->transition_matrix + parent_allele * (int) self->num_alleles;
-    double u = gsl_ran_flat(rng, 0.0, 1.0);
-    int j = 0;
-
-    while (u > probs[j]) {
-        u -= probs[j];
-        j++;
-        assert(j < (int) self->num_alleles);
-    }
-    return j;
-}
-
-static int
-mutgen_set_ancestral_state(mutgen_t *self, site_t *site, int allele)
-{
-    int ret = 0;
-    size_t len = strlen(self->model->alleles[allele]);
-    char *buff = tsk_blkalloc_get(&self->allocator, len);
-
-    if (buff == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    memcpy(buff, self->model->alleles[allele], len);
-    site->ancestral_state = buff;
-    site->ancestral_state_length = (tsk_size_t) len;
-out:
-    return ret;
-}
-
-static int
-mutgen_set_derived_state(mutgen_t *self, mutation_t *mut, int allele)
-{
-    int ret = 0;
-    size_t len = strlen(self->model->alleles[allele]);
-    char *buff = tsk_blkalloc_get(&self->allocator, len);
-
-    if (buff == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
-        goto out;
-    }
-    memcpy(buff, self->model->alleles[allele], len);
-    mut->derived_state = buff;
-    mut->derived_state_length = (tsk_size_t) len;
-out:
-    return ret;
-}
-
 static int MSP_WARN_UNUSED
 mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_mutation,
     tsk_size_t num_nodes, site_t *site)
 {
     int ret = 0;
-    int ai, pa, da;
+    const char *pa, *pm;
+    tsk_size_t palen, pmlen;
     mutation_t *mut, *parent_mut;
     tsk_id_t u;
 
@@ -823,20 +1058,12 @@ mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_muta
     if (ret != 0) {
         goto out;
     }
-
     if (site->new) {
-        ai = mutation_model_pick_allele(self->model, self->rng);
-        ret = mutgen_set_ancestral_state(self, site, ai);
+        assert(site->ancestral_state == NULL);
+        ret = mutation_model_choose_root_state(self->model, self->rng, site);
         if (ret != 0) {
             goto out;
         }
-    } else {
-        /* we don't error here if the allele is not found (and so ai < 0)
-         * because it's ok if we don't try to add a mutation to the site,
-         * e.g., if it is kept and we're doing infinite sites, or if we're
-         * mutating a different part of the genome  */
-        ai = mutation_model_allele_index(
-            self->model, site->ancestral_state, site->ancestral_state_length);
     }
 
     /* Create a mapping from mutations to nodes in bottom_mutation. If we see
@@ -849,7 +1076,10 @@ mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_muta
             u = parent[u];
         }
         if (u == TSK_NULL) {
-            pa = ai;
+            pa = site->ancestral_state;
+            palen = site->ancestral_state_length;
+            pm = site->metadata;
+            pmlen = site->metadata_length;
             assert(mut->parent == NULL);
         } else {
             parent_mut = bottom_mutation[u];
@@ -859,28 +1089,26 @@ mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_muta
                 goto out;
             }
             if (mut->new) {
-                pa = mutation_model_allele_index(self->model, parent_mut->derived_state,
-                    parent_mut->derived_state_length);
+                pa = parent_mut->derived_state;
+                palen = parent_mut->derived_state_length;
+                pm = parent_mut->metadata;
+                pmlen = parent_mut->metadata_length;
             }
         }
+        mut->keep = true;
         if (mut->new) {
-            if (pa < 0) {
-                /* only error if we are actually trying to mutate an unknown allele */
-                ret = MSP_ERR_UNKNOWN_ALLELE;
+            assert(mut->derived_state == NULL);
+            ret = mutation_model_transition(
+                self->model, self->rng, pa, palen, pm, pmlen, mut);
+            if (ret < 0) {
                 goto out;
             }
-            da = mutation_model_transition_allele(self->model, pa, self->rng);
-            if (da == pa) {
-                // mark mut for removal
+            /* A non-zero return value here indicates that we transitioned to the
+             * same allele, and so the discard the mutation. */
+            if (ret != 0) {
                 mut->keep = false;
-            } else {
-                ret = mutgen_set_derived_state(self, mut, da);
-                if (ret != 0) {
-                    goto out;
-                }
             }
         }
-        /* mut->keep defaults to true */
         if (mut->keep) {
             bottom_mutation[mut->node] = mut;
         }
@@ -889,7 +1117,7 @@ mutgen_choose_alleles(mutgen_t *self, tsk_id_t *parent, mutation_t **bottom_muta
     for (mut = site->mutations; mut != NULL; mut = mut->next) {
         bottom_mutation[mut->node] = NULL;
     }
-
+    ret = 0;
 out:
     return ret;
 }

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -2912,7 +2912,7 @@ test_simulation_replicates(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = interval_map_alloc_single(&mut_map, m / 2, mutation_rate);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_model_factory(&mut_model, ALPHABET_BINARY);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_BINARY);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = tsk_table_collection_init(&tables, 0);
@@ -4166,7 +4166,7 @@ test_mutgen_simple_map(void)
 
     ret = interval_map_alloc(&rate_map, 6, pos, rate);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = mutgen_alloc(&mutgen, rng, &rate_map, &mut_model, 0);
@@ -4214,9 +4214,9 @@ test_mutgen_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     insert_single_tree(&tables, ALPHABET_NUCLEOTIDE);
 
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_model_factory(&mut_model_binary, ALPHABET_BINARY);
+    ret = matrix_mutation_model_factory(&mut_model_binary, ALPHABET_BINARY);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = interval_map_alloc_single(&rate_map, 1, -1);
@@ -4283,7 +4283,7 @@ test_mutgen_bad_mutation_order(void)
     insert_single_tree(&tables, ALPHABET_NUCLEOTIDE);
     ret = interval_map_alloc_single(&rate_map, 1, 20);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* bad mutation generation order */
@@ -4323,7 +4323,7 @@ test_single_tree_mutgen(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     insert_single_tree(&tables1, ALPHABET_BINARY);
     insert_single_tree(&tables2, ALPHABET_BINARY);
-    ret = mutation_model_factory(&mut_model, ALPHABET_BINARY);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_BINARY);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = interval_map_alloc_single(&rate_map, 1, 0);
@@ -4398,7 +4398,7 @@ test_single_tree_mutgen_keep_sites(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     insert_single_tree(&copy2, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_TRUE(tsk_table_collection_equals(&tables, &copy2));
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* With a mutation rate of 0, we should keep exactly the same set
@@ -4485,7 +4485,7 @@ test_single_tree_mutgen_discrete_sites(void)
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     insert_single_tree(&tables, ALPHABET_NUCLEOTIDE);
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* in the single tree, node 4, at time 1, is ancestral to node 0
@@ -4555,7 +4555,7 @@ test_single_tree_mutgen_keep_sites_many_mutations(void)
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     insert_single_tree(&tables, ALPHABET_NUCLEOTIDE);
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     for (j = 0; j < 8192; j++) {
@@ -4600,7 +4600,7 @@ test_single_tree_mutgen_interval(void)
     ret = tsk_table_collection_init(&tables, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     insert_single_tree(&tables, ALPHABET_NUCLEOTIDE);
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = interval_map_alloc_single(&rate_map, 1, 10);
@@ -4664,7 +4664,7 @@ test_single_tree_mutgen_empty_site(void)
     mutation_model_t mut_model;
 
     CU_ASSERT_FATAL(rng != NULL);
-    ret = mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = interval_map_alloc_single(&rate_map, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4701,7 +4701,7 @@ test_single_tree_mutgen_do_nothing_mutations(void)
     static double transition_matrix[] = { 1.0, 0.0, 0.0, 1.0 };
 
     CU_ASSERT_FATAL(rng != NULL);
-    ret = mutation_matrix_model_alloc(&mut_model, 2,
+    ret = matrix_mutation_model_alloc(&mut_model, 2,
         (char **) (uintptr_t *) binary_alleles, root_distribution, transition_matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = interval_map_alloc_single(&rate_map, 1, 1);
@@ -4748,7 +4748,7 @@ test_single_tree_mutgen_many_mutations(void)
     mutation_model_t mut_model;
 
     CU_ASSERT_FATAL(rng != NULL);
-    ret = mutation_model_factory(&mut_model, ALPHABET_BINARY);
+    ret = matrix_mutation_model_factory(&mut_model, ALPHABET_BINARY);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = interval_map_alloc_single(&rate_map, 1, 100);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4839,7 +4839,7 @@ test_mutgen_slim_mutations(void)
     int64_t next_mutation_id = 23;
 
     CU_ASSERT_FATAL(rng != NULL);
-    ret = slim_mutator_alloc(&mut_model, mutation_type_id, next_mutation_id, 0);
+    ret = slim_mutation_model_alloc(&mut_model, mutation_type_id, next_mutation_id, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = interval_map_alloc_single(&rate_map, 1, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -4907,6 +4907,8 @@ test_mutgen_slim_mutations(void)
             tables.mutations.metadata_offset[j + 1] - tables.mutations.metadata_offset[j]
                 - parent_len);
     }
+
+    mutgen_print_state(&mutgen, _devnull);
 
     mutgen_free(&mutgen);
 
@@ -5259,7 +5261,7 @@ test_interval_map(void)
 }
 
 static void
-test_mutation_matrix_model_errors(void)
+test_matrix_mutation_model_errors(void)
 {
     int ret;
     mutation_model_t model;
@@ -5267,13 +5269,13 @@ test_mutation_matrix_model_errors(void)
     double dist[] = { 0.5, 0.5 };
     double matrix[] = { 0, 1.0, 1.0, 0 };
 
-    ret = mutation_matrix_model_alloc(&model, 0, NULL, NULL, NULL);
+    ret = matrix_mutation_model_alloc(&model, 0, NULL, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_INSUFFICIENT_ALLELES);
     mutation_model_free(&model);
 
     /* Bad probability values */
     dist[0] = -1;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
@@ -5281,41 +5283,41 @@ test_mutation_matrix_model_errors(void)
     /* Sums to 1, but bad values */
     dist[0] = -1;
     dist[1] = 2;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     dist[0] = 1.1;
     dist[1] = 0.5;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     /* Must sum to 1 */
     dist[0] = 0.9;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     dist[0] = 0.1;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ROOT_PROBABILITIES);
     mutation_model_free(&model);
 
     /* Make sure dist is still OK . */
     dist[0] = 0.5;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     mutation_model_free(&model);
 
     /* Matrix values must be probablilities */
     matrix[0] = -1;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
@@ -5323,35 +5325,35 @@ test_mutation_matrix_model_errors(void)
     /* Sums to 1, but bad values */
     matrix[0] = -1;
     matrix[1] = 2;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     matrix[0] = 1.1;
     matrix[1] = 1.0;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     matrix[0] = 0.6;
     matrix[1] = 0.5;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_TRANSITION_MATRIX);
     mutation_model_free(&model);
 
     matrix[0] = 0.5;
     matrix[1] = 0.5;
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     mutation_model_free(&model);
 }
 
 static void
-test_mutation_matrix_model_properties(void)
+test_matrix_mutation_model_properties(void)
 {
     int ret;
     mutation_model_t model;
@@ -5359,7 +5361,7 @@ test_mutation_matrix_model_properties(void)
     double dist[] = { 0.5, 0.5 };
     double matrix[] = { 0, 1.0, 1.0, 0 };
 
-    ret = mutation_matrix_model_alloc(
+    ret = matrix_mutation_model_alloc(
         &model, 2, (char **) (uintptr_t) alleles, dist, matrix);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(model.params.mutation_matrix.num_alleles, 2);
@@ -5368,7 +5370,7 @@ test_mutation_matrix_model_properties(void)
 }
 
 static void
-test_slim_mutator_errors(void)
+test_slim_mutation_model_errors(void)
 {
     int ret;
     mutation_model_t model;
@@ -5376,29 +5378,29 @@ test_slim_mutator_errors(void)
     int64_t next_mutation_id = 0;
 
     next_mutation_id--;
-    ret = slim_mutator_alloc(&model, mutation_type_id, next_mutation_id, 100);
+    ret = slim_mutation_model_alloc(&model, mutation_type_id, next_mutation_id, 0);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SLIM_PARAMETERS);
+    mutation_model_free(&model);
 
     mutation_type_id--;
     next_mutation_id++;
-    ret = slim_mutator_alloc(&model, mutation_type_id, next_mutation_id, 100);
+    ret = slim_mutation_model_alloc(&model, mutation_type_id, next_mutation_id, 0);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_SLIM_PARAMETERS);
-
     mutation_model_free(&model);
 }
 
 static void
-test_slim_mutator_properties(void)
+test_slim_mutation_model_properties(void)
 {
     int ret;
     mutation_model_t model;
-    int32_t mutation_type_id = 0;
+    int32_t mutation_type_id = 1;
     int64_t next_mutation_id = 2;
 
-    ret = slim_mutator_alloc(&model, mutation_type_id, next_mutation_id, 100);
+    ret = slim_mutation_model_alloc(&model, mutation_type_id, next_mutation_id, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(model.params.slim_mutator.next_mutation_id, 2);
-    CU_ASSERT_EQUAL_FATAL(model.params.slim_mutator.mutation_type_id, 0);
+    CU_ASSERT_EQUAL_FATAL(model.params.slim_mutator.mutation_type_id, 1);
 
     mutation_model_free(&model);
 }
@@ -5588,11 +5590,11 @@ main(int argc, char **argv)
 
         { "test_interval_map", test_interval_map },
 
-        { "test_mutation_matrix_model_errors", test_mutation_matrix_model_errors },
-        { "test_mutation_matrix_model_properties",
-            test_mutation_matrix_model_properties },
-        { "test_slim_mutator_errors", test_slim_mutator_errors },
-        { "test_slim_mutator_properties", test_slim_mutator_properties },
+        { "test_matrix_mutation_model_errors", test_matrix_mutation_model_errors },
+        { "test_matrix_mutation_model_properties",
+            test_matrix_mutation_model_properties },
+        { "test_slim_mutation_model_errors", test_slim_mutation_model_errors },
+        { "test_slim_mutation_model_properties", test_slim_mutation_model_properties },
 
         { "test_strerror", test_strerror },
         { "test_strerror_tskit", test_strerror_tskit },

--- a/lib/util.c
+++ b/lib/util.c
@@ -211,6 +211,9 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_SLIM_PARAMETERS:
             ret = "SLiM mutation IDs and mutation type IDs must be nonnegative.";
             break;
+        case MSP_ERR_MUTATION_ID_OVERFLOW:
+            ret = "Mutation ID overflow.";
+            break;
         default:
             ret = "Error occurred generating error string. Please file a bug "
                   "report!";

--- a/lib/util.c
+++ b/lib/util.c
@@ -208,6 +208,9 @@ msp_strerror_internal(int err)
             ret = "Each row of the transition matrix must be nonnegative and sum to "
                   "one.";
             break;
+        case MSP_ERR_BAD_SLIM_PARAMETERS:
+            ret = "SLiM mutation IDs and mutation type IDs must be nonnegative.";
+            break;
         default:
             ret = "Error occurred generating error string. Please file a bug "
                   "report!";

--- a/lib/util.h
+++ b/lib/util.h
@@ -92,6 +92,7 @@
 #define MSP_ERR_INSUFFICIENT_ALLELES                                -53
 #define MSP_ERR_BAD_ROOT_PROBABILITIES                              -54
 #define MSP_ERR_BAD_TRANSITION_MATRIX                               -55
+#define MSP_ERR_BAD_SLIM_PARAMETERS                                 -57
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */
 #define MSP_TSK_ERR_BIT 13

--- a/lib/util.h
+++ b/lib/util.h
@@ -93,6 +93,8 @@
 #define MSP_ERR_BAD_ROOT_PROBABILITIES                              -54
 #define MSP_ERR_BAD_TRANSITION_MATRIX                               -55
 #define MSP_ERR_BAD_SLIM_PARAMETERS                                 -57
+#define MSP_ERR_MUTATION_ID_OVERFLOW                                -58
+
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */
 #define MSP_TSK_ERR_BIT 13

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -54,13 +54,7 @@ _AMINO_ACIDS = [
 ]
 
 
-class MutationModel(_msprime.MutationModel):
-    """
-    Superclass of mutation models. Allows you to build your own mutation model.
-
-    TODO document properly.
-    """
-
+class BaseMutationModel:
     def asdict(self):
         # This version of asdict makes sure that we have sufficient parameters
         # to call the contructor and recreate the class. However, this means
@@ -71,6 +65,19 @@ class MutationModel(_msprime.MutationModel):
             for key in inspect.signature(self.__init__).parameters.keys()
             if hasattr(self, key)
         }
+
+
+class SlimMutationModel(_msprime.SlimMutationModel, BaseMutationModel):
+    pass
+
+
+# TODO Change this to MatrixMutationModel
+class MutationModel(_msprime.MatrixMutationModel, BaseMutationModel):
+    """
+    Superclass of mutation models. Allows you to build your own mutation model.
+
+    TODO document properly.
+    """
 
     def __str__(self):
         alleles = " ".join([x.decode() for x in self.alleles])
@@ -839,7 +846,7 @@ def mutate(
 
     if model is None:
         model = BinaryMutations()
-    if not isinstance(model, MutationModel):
+    if not isinstance(model, BaseMutationModel):
         raise TypeError("model must be a MutationModel")
 
     argspec = inspect.getargvalues(inspect.currentframe())

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -28,6 +28,7 @@ import tskit
 import _msprime
 from . import core
 from . import provenance
+from _msprime import BaseMutationModel
 
 _ACGT_ALLELES = [b"A", b"C", b"G", b"T"]
 _AMINO_ACIDS = [
@@ -54,25 +55,14 @@ _AMINO_ACIDS = [
 ]
 
 
-class BaseMutationModel:
-    def asdict(self):
-        # This version of asdict makes sure that we have sufficient parameters
-        # to call the contructor and recreate the class. However, this means
-        # that subclasses *must* have an instance variable of the same name.
-        # This is essential for Provenance round-tripping to work.
-        return {
-            key: getattr(self, key)
-            for key in inspect.signature(self.__init__).parameters.keys()
-            if hasattr(self, key)
-        }
-
-
-class SlimMutationModel(_msprime.SlimMutationModel, BaseMutationModel):
-    pass
+# NOTE we're currently repeating the definition of asdict here
+# because we can't have multiple inheritance because of a
+# bug in sphinx. We can at least factor the definition out, though
+# and note that's why we're doing it.
 
 
 # TODO Change this to MatrixMutationModel
-class MutationModel(_msprime.MatrixMutationModel, BaseMutationModel):
+class MutationModel(_msprime.MatrixMutationModel):
     """
     Superclass of mutation models. Allows you to build your own mutation model.
 
@@ -89,6 +79,30 @@ class MutationModel(_msprime.MatrixMutationModel, BaseMutationModel):
         for row in self.transition_matrix:
             s += "     {}\n".format(" ".join(map(str, row)))
         return s
+
+    def asdict(self):
+        # This version of asdict makes sure that we have sufficient parameters
+        # to call the contructor and recreate the class. However, this means
+        # that subclasses *must* have an instance variable of the same name.
+        # This is essential for Provenance round-tripping to work.
+        return {
+            key: getattr(self, key)
+            for key in inspect.signature(self.__init__).parameters.keys()
+            if hasattr(self, key)
+        }
+
+
+class SlimMutationModel(_msprime.SlimMutationModel):
+    def asdict(self):
+        # This version of asdict makes sure that we have sufficient parameters
+        # to call the contructor and recreate the class. However, this means
+        # that subclasses *must* have an instance variable of the same name.
+        # This is essential for Provenance round-tripping to work.
+        return {
+            key: getattr(self, key)
+            for key in inspect.signature(self.__init__).parameters.keys()
+            if hasattr(self, key)
+        }
 
 
 class BinaryMutations(MutationModel):

--- a/stress_lowlevel.py
+++ b/stress_lowlevel.py
@@ -11,9 +11,9 @@ import sys
 import time
 import unittest
 
+import tests.test_ancestry as test_ancestry
 import tests.test_demography as test_demography
 import tests.test_dict_encoding as test_dict_encoding
-import tests.test_highlevel as test_highlevel
 import tests.test_lowlevel as test_lowlevel
 import tests.test_recombination_map as test_recombination_map
 
@@ -21,7 +21,7 @@ import tests.test_recombination_map as test_recombination_map
 def main():
     modules = {
         "demography": test_demography,
-        "highlevel": test_highlevel,
+        "ancestry": test_ancestry,
         "lowlevel": test_lowlevel,
         "dict_encoding": test_dict_encoding,
         "recombination_map": test_recombination_map,

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2396,7 +2396,6 @@ class TestMutationModel(unittest.TestCase):
             matrix = np.zeros((n, n))
             matrix[:, 0] = 1
             mm = _msprime.MutationModel(alleles, dist, matrix)
-            self.assertEqual(mm.get_num_alleles(), len(alleles))
             self.assertEqual(mm.alleles, alleles)
             self.assertTrue(np.array_equal(mm.root_distribution, dist))
             self.assertTrue(np.array_equal(mm.transition_matrix, matrix))

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1110,7 +1110,7 @@ class TestMutationStatistics(unittest.TestCase, StatisticalTestMixin):
         self.verify_mutation_rates(model)
 
 
-class TestSlimMutationGenerator(unittest.TestCase):
+class TestSlimMutationModel(unittest.TestCase):
     """
     Tests for the SLiM mutation generator.
     """
@@ -1143,6 +1143,13 @@ class TestSlimMutationGenerator(unittest.TestCase):
         model = PythonSlimMutationModel(0)
         mts = py_mutate(ts, rate=1, random_seed=23, model=model, discrete=True)
         self.validate_slim_mutations(mts)
+        # TODO do this properly
+        model = msprime.SlimMutationModel(0)
+        mts2 = msprime.mutate(ts, rate=1, random_seed=23, model=model, discrete=True)
+        self.assertGreater(model.next_id, 0)
+        self.assertEqual(mts2.num_mutations, model.next_id)
+        # breaks because of text decoding issues:
+        # print(mts2.tables)
 
     def test_add_slim_mutation(self):
         ts = msprime.simulate(10, length=100, random_seed=5)


### PR DESCRIPTION
Here's how I'd like to make mutation models more flexible, as outlined in #1006. Mutation models would only need to have the 'pick root allele' and 'transition allele' methods; what we've done so far is the special case of MutationMatrixModels. I've coded the (small) changes up in python, with the SLiM mutation model.

I've also made the check that we aren't sticking a mutation above an existing one optional (in python only, again).

How's this look?

Note: with this in place, it'll be easy to do models of microsats, etcetera.