### PR TITLE
Add newick as install_requires dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
     },
     include_package_data=True,
     # NOTE: make sure this is the 'attrs' package, not 'attr'!
-    install_requires=[numpy_ver, "attrs>=19.1.0", "tskit"],
+    install_requires=[numpy_ver, "attrs>=19.1.0", "newick", "tskit"],
     ext_modules=[_msprime_module],
     keywords=["Coalescent simulation", "ms"],
     license="GNU GPLv3+",


### PR DESCRIPTION
Fixes #1029

Incidentally, the wheel-build-and-test action i'm working on in kastore would have caught this.