### PR TITLE
Multiple merger common ancestor time fix

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -295,7 +295,7 @@ class TestMultipleMergerModels(unittest.TestCase):
         self.verify_non_binary(ts)
 
     def test_dirac_coalescent_lambda_regime_recombination(self):
-        model = msprime.DiracCoalescent(psi=0.9, c=1)
+        model = msprime.DiracCoalescent(psi=0.9, c=100)
         ts = msprime.simulate(
             sample_size=100, recombination_rate=100, model=model, random_seed=3
         )

--- a/verification.py
+++ b/verification.py
@@ -2107,12 +2107,10 @@ class XiTest(SimulationVerifier):
                 f"n=100_alpha={alpha}",
                 sample_size=100,
                 Ne=Ne,
-                r=1e-8,
+                r=1e-7,
                 L=10 ** 6,
                 model=msprime.BetaCoalescent(alpha=alpha),
             )
-            # Add a growth rate with a higher recombination rate so
-            # we still get decent numbers of trees
             self.verify_breakpoint_distribution(
                 basedir_name,
                 f"n=100_alpha={alpha}",
@@ -2126,7 +2124,7 @@ class XiTest(SimulationVerifier):
 
     def run_xi_dirac_breakpoints(self):
         basedir_name = "xi_dirac_breakpoints"
-        Ne = 10 ** 4
+        Ne = 10 ** 2
         for psi in [0.1, 0.3, 0.6, 0.9]:
             for c in [1, 10]:
                 self.verify_breakpoint_distribution(


### PR DESCRIPTION
@jeromekelleher, this is what I think multiple merger coalescents without rescaling should look like. It probably isn't necessary to include a complete `get_common_ancestor_waiting_time_from_rate` function in each model separately, but I thought writing it this way was the most transparent way to see what is going on at first. Let me know if you have any comments.

@TPPSellinger, could you have a look and see if you can break this please? I have run the standard unit tests as well as the expected SFS and break point tests from verification.py, and all of those look good. I seem to recall you had a library of some more extreme cases as well, right? For some reason I couldn't run the `xi_beta_recombinations` and `xi_dirac_recombinations` tests from verification.py - python kept complaining about an invalid key even when I copied and pasted the key directly from the code. If you can get those to run, that would be good too.

@eldonb, would you mind reading through the Dirac coalescent case please? I've taken an edgucated stab at how population growth should work for that model, but to my knowledge the Cannings model leading to a mixture of Kingman and Xi-mergers with population growth has never been written down, so that is where I expect my probability of error to be largest.