### PR TITLE
Make Hudson simulate work better for large sparse sets of populations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@
 - Add replicate_index to simulate, allowing output of a single tree sequence
   from a set of replicates. (:user:`benjeffery` :pr:`914`).
 
+- Much better simulation performance for models with large numbers
+  of populations (:user:`jeromekelleher`, :pr:`1069`).
+
 **Breaking changes**:
 
 - The class form for specifying models (e.g., ``msprime.StandardCoalescent()``)

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -107,6 +107,8 @@ typedef struct {
     double growth_rate;
     double start_time;
     avl_tree_t *ancestors;
+    tsk_size_t num_potential_destinations;
+    tsk_id_t *potential_destinations;
 } population_t;
 
 typedef struct individual_t_t {
@@ -243,6 +245,7 @@ typedef struct _msp_t {
     double time;
     double *migration_matrix;
     population_t *populations;
+    avl_tree_t non_empty_populations;
     avl_tree_t breakpoints;
     avl_tree_t overlap_counts;
     /* We keep an independent Fenwick tree for each label */
@@ -416,6 +419,7 @@ size_t msp_get_num_samples(msp_t *self);
 size_t msp_get_num_loci(msp_t *self);
 size_t msp_get_num_populations(msp_t *self);
 size_t msp_get_num_labels(msp_t *self);
+size_t msp_get_num_population_ancestors(msp_t *self, tsk_id_t population);
 size_t msp_get_num_ancestors(msp_t *self);
 size_t msp_get_num_breakpoints(msp_t *self);
 size_t msp_get_num_nodes(msp_t *self);

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -254,6 +254,10 @@ test_single_locus_many_populations(void)
     CU_ASSERT_EQUAL(ret, 0);
 
     msp_print_state(&msp, _devnull);
+    ret = msp_run(&msp, DBL_MAX, 1);
+    CU_ASSERT_EQUAL(ret, MSP_EXIT_MAX_EVENTS);
+    msp_verify(&msp, 0);
+    msp_print_state(&msp, _devnull);
     ret = msp_run(&msp, DBL_MAX, ULONG_MAX);
     CU_ASSERT_EQUAL(ret, 0);
     msp_verify(&msp, 0);

--- a/verification.py
+++ b/verification.py
@@ -460,7 +460,8 @@ def register_ms_tests_1(runner):
         "admixture-2-pop4",
         "1000 1000 -t 2.0 -I 2 500 500 2 -es 0.01 1 0.75 -eg 0.02 1 5.0 -em 0.02 3 1 1",
     )
-    register("gene-conversion-1-r0", "100 10000 -t 5.0 -r 0 2501 -c 10 1")
+    # FIXME disabling this test until GC with recombination rate=0
+    # register("gene-conversion-1-r0", "100 10000 -t 5.0 -r 0 2501 -c 10 1")
     register("gene-conversion-1", "100 10000 -t 5.0 -r 0.01 2501 -c 1000 1")
     register("gene-conversion-2", "100 10000 -t 5.0 -r 10 2501 -c 2 1")
     register("gene-conversion-2-tl-10", "100 10000 -t 5.0 -r 10 2501 -c 2 10")
@@ -536,7 +537,7 @@ class MsTest3(MsTest):
     def run(self, output_dir):
         self._output_dir = output_dir
         logging.info("running", self.group, self.name, self.command)
-        self._run_ms_mshot_stats(self.key, self.command)
+        self._run_ms_mshot_stats(self.name, self.command)
 
 
 def register_ms_tests_3(runner):


### PR DESCRIPTION
Part of the assumptions of using populations more freely in the demographic API update (e.g. #1054 and #1058) is that populations are cheap. There's no reason we should be spinning around a O(N^2) loop when computing migration rates. I'd previously assumed that the number of populations was O(10) so it wasn't worth doing anything fancier, but I think this assumption isn't correct. Anyway, we want to be able to run large spatial models where we're likely to have only local migration, and if we have, say, 1000 demes, then the O(N^2) loop is awful.

This is a simple approach to fixing this. During Hudson simulate we maintain a set of population IDs in which there's at least one lineage, and, for each population, a list of populations where lineages can potentially migrate to (i.e., with nonzero migration rate). Then, instead of iterating over all populations, we just iterate over these subsets. The only tricky thing is maintaining the list, which I think is simple enough so long as we don't try to be too clever.

I'd imagine that for really big models you might want to do something mathematically more clever, but I'm guessing that this will take us a long way. @petrelharp, do you agree with the approach? I've outlined it here in the algoriths.py file (with a few drive-by changes - I originally started doing something much more complex and started refactoring.)