### PR TITLE
Multiple merger pop growth tests

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -5978,8 +5978,9 @@ beta_compute_timescale(msp_t *self, population_t *pop)
     double truncation_point = self->model.params.beta_coalescent.truncation_point;
     double pop_size = pop->initial_size;
     double m = 2 + exp(alpha * log(2) + (1 - alpha) * log(3) - log(alpha - 1));
-    double timescale = exp(alpha * log(m) + (alpha - 1) * log(pop_size) - log(alpha))
-                       / gsl_sf_beta_inc(2 - alpha, alpha, truncation_point);
+    double timescale = exp(alpha * log(m) + (alpha - 1) * log(pop_size) - log(alpha)
+                           - gsl_sf_lnbeta(2 - alpha, alpha)
+                           - log(gsl_sf_beta_inc(2 - alpha, alpha, truncation_point)));
     return timescale;
 }
 


### PR DESCRIPTION
Ping @jeromekelleher, @TPPSellinger, @eldonb

I've added tests into verification.py to compare the empirical merger time of two non-recombinant haploids, and the mean of the appropriate Gompertz distribution (see Corollary 3 here: https://link.springer.com/article/10.1007/s00285-020-01470-5). Overall, I think the results look very good. The Beta-coalescent case seems to drift a little bit from its expectation (~200 generations in 10 000) when alpha is close to 2, which I think is due to the fact that the Beta(2-alpha, alpha) function is very sensitive to alpha near that region.

I also found a mistake in the Beta-coalescent timescale: I hadn't noticed that `gsl_sf_beta_inc` computes a _normalised_ incomplete beta function. That has now been fixed.