### PR TITLE
fixup of verification for ddb.mean_coaltime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ ENV/
 
 # Vim swp files.
 *.swp
+tmp__NOBACKUP__

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -942,10 +942,7 @@ class TestDemographyTrajectories(unittest.TestCase):
         ddb = self.one_pop_example()
         steps = np.linspace(0, 400, 101)
         rates, P = ddb.coalescence_rate_trajectory(steps=steps, num_samples=[2])
-        for time_step in range(len(steps)):
-            time = steps[time_step]
-            rA = rates[time_step]
-            pA = P[time_step]
+        for time, rA, pA in zip(steps, rates, P):
             if time >= 0 and time < 100:
                 self.assertAlmostEqual(rA, 1 / (2 * 100))
                 self.assertAlmostEqual(pA, np.exp(-time / 200))
@@ -960,6 +957,18 @@ class TestDemographyTrajectories(unittest.TestCase):
                 self.assertAlmostEqual(
                     pA, np.exp(-100 / 200 - (300 - 100) / 400 - (time - 300) / 200)
                 )
+
+    def test_nan_coalrate(self):
+        # The returned rate will be nan at times where the probability
+        # of not having coalesced is floating-point-zero
+        ddb = self.one_pop_example()
+        steps = np.array([1000000 * k for k in range(1, 4)])
+        rates, P = ddb.coalescence_rate_trajectory(steps=steps, num_samples=[2])
+        print(rates)
+        print(P)
+        for rA, pA in zip(rates, P):
+            self.assertTrue(np.isnan(rA))
+            self.assertEqual(pA, 0)
 
     def test_mean_one_pop(self):
         # As above. The mean time to coalescence should be


### PR DESCRIPTION
I've fixed up a few things: the divisions by zero we were legitimately accounting for, so we now ignore these. And, some of the other numerical errors were coming from populations going to infinity looking back in time, so I've put a stop to that in the verification script. (Also, the z-score was incorrectly calculated.)  But, things are still not looking good. I'm currently unclear if it has to do with numerical issues or a legitimate bug somewhere? Changing the `rtol` and `max_steps` parameters of `mean_coalescence_time` seems to only have the effect of making it take a *lot* longer to run.  Might you be able to take a look, @apragsdale and see if you spot any errors?

Running
```
python3 verification.py test_ddb_mean_coaltime --debug
```
produces
```
2020-07-06 10:16:48,041 [12160] DEBUG    root: coaltime: theory  mean  sd   z
2020-07-06 10:16:48,698 [12160] DEBUG    root:         168.09 115.43 9.12 31.63
2020-07-06 10:16:49,156 [12160] DEBUG    root:         110.09 97.14 9.12 7.78
2020-07-06 10:16:50,665 [12160] DEBUG    root:         198.67 192.89 22.82 1.39
2020-07-06 10:16:51,407 [12160] DEBUG    root:         148.62 148.04 16.85 0.19
2020-07-06 10:16:52,099 [12160] DEBUG    root:         127.14 127.87 11.04 -0.36
2020-07-06 10:16:53,362 [12160] DEBUG    root:         170.10 173.66 20.77 -0.94
2020-07-06 10:16:53,934 [12160] DEBUG    root:         147.53 151.70 17.18 -1.33
2020-07-06 10:16:54,237 [12160] DEBUG    root:         104.49 97.86 14.43 2.52
```
The z-scores for the first two simulations are not good, and the plot in `tmp__NOBACKUP__/DemographyDebugger/test_ddb_mean_coaltime/mean_coaltimes.png` backs this up.
