### PR TITLE
sweep model clean up

### DIFF
--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1452,7 +1452,6 @@ class DiracCoalescent(ParametricSimulationModel):
 class SweepGenicSelection(ParametricSimulationModel):
     # TODO document and finalise the API
     name = "sweep_genic_selection"
-
     position = attr.ib(default=None)
     start_frequency = attr.ib(default=None)
     end_frequency = attr.ib(default=None)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,7 +134,7 @@ class TestModelFactory(unittest.TestCase):
                 position=0.5,
                 start_frequency=0.1,
                 end_frequency=0.9,
-                alpha=0.1,
+                alpha=1000,
                 dt=0.01,
             ),
             msprime.BetaCoalescent(alpha=2),
@@ -851,7 +851,7 @@ class TestSweepGenicSelection(unittest.TestCase):
 
     def test_incorrect_num_labels(self):
         model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.1, end_frequency=0.9, alpha=0.1, dt=0.01
+            position=0.5, start_frequency=0.1, end_frequency=0.9, alpha=1000, dt=0.01
         )
         for num_labels in [1, 3, 10]:
             with self.assertRaises(_msprime.LibraryError):
@@ -859,29 +859,35 @@ class TestSweepGenicSelection(unittest.TestCase):
                     10, recombination_rate=1, model=model, num_labels=num_labels
                 )
 
-    @unittest.skip("parameters need tuning")
     def test_sweep_coalescence_no_recomb(self):
+        N = 1e6
         model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.1, end_frequency=0.99, alpha=0.01, dt=0.1
+            position=0.5,
+            start_frequency=1.0 / (2 * N),
+            end_frequency=1.0 - (1.0 / (2 * N)),
+            alpha=1000,
+            dt=1e-6,
         )
-        ts = msprime.simulate(10, model=model, random_seed=2)
+        ts = msprime.simulate(10, model=model, recombination_rate=0, random_seed=2)
         self.assertEqual(ts.num_trees, 1)
         for tree in ts.trees():
             self.assertEqual(tree.num_roots, 1)
 
-    @unittest.skip("parameters need tuning")
     def test_sweep_coalescence_recomb(self):
+        N = 1e6
         model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.01, end_frequency=0.999, alpha=1.0, dt=0.01
+            position=0.5,
+            start_frequency=1.0 / (2 * N),
+            end_frequency=1.0 - (1.0 / (2 * N)),
+            alpha=1000,
+            dt=1e-6,
         )
         ts = msprime.simulate(10, model=model, recombination_rate=1, random_seed=2)
         self.assertGreater(ts.num_trees, 1)
-        for tree in ts.trees():
-            self.assertEqual(tree.num_roots, 1)
 
     def test_sweep_coalescence_same_seed(self):
         model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.6, end_frequency=0.7, alpha=0.01, dt=0.1
+            position=0.5, start_frequency=0.6, end_frequency=0.7, alpha=1000, dt=1e4
         )
         ts1 = msprime.simulate(5, model=model, random_seed=2)
         ts2 = msprime.simulate(5, model=model, random_seed=2)
@@ -889,14 +895,18 @@ class TestSweepGenicSelection(unittest.TestCase):
 
     def test_sweep_start_time_complete(self):
         sweep_model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.01, end_frequency=0.99, alpha=0.9, dt=0.001,
+            position=0.5,
+            start_frequency=0.01,
+            end_frequency=0.99,
+            alpha=1000,
+            dt=0.001,
         )
         t_start = 0.1
         ts = msprime.simulate(
             10,
             Ne=0.25,
             recombination_rate=2,
-            model=[None, (t_start, sweep_model)],
+            model=[None, (t_start, sweep_model), (None, None)],
             random_seed=2,
         )
         self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
@@ -904,7 +914,7 @@ class TestSweepGenicSelection(unittest.TestCase):
     def test_sweep_start_time_incomplete(self):
         # Short sweep that doesn't make complete coalescence.
         sweep_model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.69, end_frequency=0.7, alpha=8, dt=0.001,
+            position=0.5, start_frequency=0.69, end_frequency=0.7, alpha=800, dt=0.001,
         )
         t_start = 0.1
         ts = msprime.simulate(
@@ -920,7 +930,7 @@ class TestSweepGenicSelection(unittest.TestCase):
         # Short sweep that doesn't coalesce followed
         # by Hudson phase to finish up coalescent
         sweep_model = msprime.SweepGenicSelection(
-            position=0.5, start_frequency=0.69, end_frequency=0.7, alpha=1e-5, dt=1,
+            position=0.5, start_frequency=0.69, end_frequency=0.7, alpha=1e5, dt=1,
         )
         ts = msprime.simulate(
             10,
@@ -953,7 +963,7 @@ class TestSweepGenicSelection(unittest.TestCase):
     def test_many_sweeps(self):
         sweep_models = [
             msprime.SweepGenicSelection(
-                position=j, start_frequency=0.69, end_frequency=0.7, alpha=1e-5, dt=0.1,
+                position=j, start_frequency=0.69, end_frequency=0.7, alpha=1e5, dt=0.1,
             )
             for j in range(10)
         ]

--- a/verification.py
+++ b/verification.py
@@ -247,7 +247,7 @@ class Test:
         with tempfile.TemporaryFile() as f:
             f.write(output)
             f.seek(0)
-            df = pd.read_table(f)
+            df = pd.read_csv(f, sep="\t")
         return df
 
     def _build_filename(self, *args):
@@ -706,8 +706,8 @@ class DiscoalSweeps(DiscoalTest):
     def _run(self, args):
         # This is broken currently: https://github.com/tskit-dev/msprime/issues/942
         # Skip noisily
-        logging.error("Skipping sweep comparison due to known bug.")
-        return
+        # logging.error("Skipping sweep comparison due to known bug.")
+        # return
 
         # TODO We should be parsing the args string here to derive these values
         # from the input. There's no point in having it as a parameter otherwise.
@@ -727,13 +727,11 @@ class DiscoalSweeps(DiscoalTest):
         data = collections.defaultdict(list)
         replicates = msprime.simulate(
             10,
-            model=mod,
+            model=[mod, (None, None)],
             length=seqlen,
             recombination_rate=rho,
             mutation_rate=mu,
             num_replicates=nreps,
-            # Change to Hudson after sweep finishes
-            demographic_events=[msprime.SimulationModelChange()],
         )
         for ts in replicates:
             data["pi"].append(ts.diversity(span_normalise=False))
@@ -753,7 +751,7 @@ class DiscoalSweeps(DiscoalTest):
         logging.debug(f"msp D mean: {df['D'].mean()}")
         logging.debug(f"discoal D mean: {df_df['D'].mean()}")
         logging.debug(f"sample sizes msp: {len(df['pi'])} discoal: {len(df_df['pi'])}")
-        self._plot_stats(f"mutation{df}, {df_df}")
+        self._plot_stats("mutation", df, df_df, "msp", "discoal")
 
     def test_sweep_ex1(self):
         cmd = "10 1000 10000 -t 10.0 -r 10.0 -ws 0 -a 500 -x 0.5 -N 10000"


### PR DESCRIPTION
this is a tiny PR to clean up some nagging issues on the sweep implementation. I'd like to merge these changes in while I work on the next layer of debugging.

as it stands the scaling _seems_ to be okay, but i'm now picking up an occasional `MSP_ERR_TIME_TRAVEL` bug where parent and child nodes are getting the same times. e.g., this seed with these parameters

```
refsize = 1e4
nreps = 1
seqlen = 1e4
mu = 2.5e-8
rho = 0
alpha = 2000
s = alpha / 2.0 / refsize
mod = msprime.SweepGenicSelection(
    reference_size=refsize,
    start_frequency=1.0 / (2 * refsize),
    end_frequency = 1.0 - (1.0 / (2 * refsize)),
    alpha = alpha,
    dt = 1.0/(2* refsize),
    position = np.floor(seqlen/2)
)

replicates = msprime.simulate(
    100,
    model=mod,
    length=seqlen,
    num_labels=2,
    recombination_rate=rho,
    mutation_rate=mu,
    num_replicates=nreps,
    random_seed=666
)
```
this is annoying to debug so far so open to suggestions as to how best to go about it...