### PR TITLE
Initial ploidy variable

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -213,6 +213,7 @@ typedef struct _msp_t {
     double gene_conversion_track_length;
     uint32_t num_populations;
     uint32_t num_labels;
+    uint32_t ploidy;
     sample_t *samples;
     double start_time;
     tsk_treeseq_t *from_ts;
@@ -404,6 +405,7 @@ int msp_set_simulation_model_sweep_genic_selection(msp_t *self, double position,
 
 int msp_set_store_migrations(msp_t *self, bool store_migrations);
 int msp_set_store_full_arg(msp_t *self, bool store_full_arg);
+int msp_set_ploidy(msp_t *self, uint32_t ploidy);
 int msp_set_num_populations(msp_t *self, size_t num_populations);
 int msp_set_dimensions(msp_t *self, size_t num_populations, size_t num_labels);
 int msp_set_gene_conversion_rate(msp_t *self, double rate, double track_length);


### PR DESCRIPTION
Ping @jeromekelleher and @andrewkern.

This is a possible starting point for a ploidy variable. I've put it in as a simulator (`msp_t`) parameter under the assumption that nearly all (or actually all?) conceivable simulations will be exclusively haploid or exclusively diploid. The alternative would be to give each `population_t` its own ploidy variable, which could facilitate simulating populations with different ploidies.

There is also already a ploidy variable in the `pedigree_t` struct. I'm completely unfamiliar with pedigrees and don't know if the variables can clash somewhere, except that current tests don't pick it up if they do.

I've made ploidy default to 2 to match the current implementation. That way everyone's scripts will keep working as they do at present.

There is no checking yet that the variable takes sensible values. We also need to decide what range of permissible values we want. In principle, there is no reason we can't have, say, hexaploid organisms by setting ploidy = 6, at least in the Hudson model, but at least it should be be a positive integer. Do we want to restrict it further to, say, just 1 or 2?

Test coverage and a docstring still need to come, but I thought we should settle on the basic implementation first. Once we have that pinned down, I'll also update the multiple merger coalescents to allow monoecious, haploid reproduction. As usual, variable ploidy is a bit more involved for those models, with both ploidy and the number of parents being important.