### PR TITLE
Add discrete_coordinates argument to simulate.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,11 +22,18 @@
   This can help debug long-running simulations. (:user:`jeromekelleher`,
   :pr:`1080`).
 
+- Add a ``discrete_coordinates`` argument to `simulate`, which ensures that
+  all recombination breakpoints and mutational sites are at integer positions
+  (:user:`jeromekelleher`, :issue:`880`, :pr:`1115`).
+
 **Breaking changes**:
 
 - The class form for specifying models (e.g., ``msprime.StandardCoalescent()``)
   no longer take a ``reference_size`` argument.
   (TODO add paper trail for this)
+
+- The ``simulate`` function only takes one positional argument, and all other
+  arguments are keyword-only.
 
 
 ********************

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -281,7 +281,7 @@ def simulator_factory(
     random_generator=None,
     random_seed=None,
     length=None,
-    discrete_coordinates=None,
+    discrete_genome=None,
     recombination_rate=None,
     recombination_map=None,
     population_configurations=None,
@@ -367,13 +367,13 @@ def simulator_factory(
             raise ValueError("Cannot provide non-positive sequence length")
         if the_rate < 0:
             raise ValueError("Cannot provide negative recombination rate")
-        if discrete_coordinates and length != math.floor(length):
+        if discrete_genome and length != math.floor(length):
             raise ValueError(
-                "Cannot specify non-integer sequence length when discrete_coordinates "
+                "Cannot specify non-integer sequence length when discrete_genome "
                 "is True"
             )
         recombination_map = RecombinationMap.uniform_map(
-            the_length, the_rate, discrete=discrete_coordinates
+            the_length, the_rate, discrete=discrete_genome
         )
     else:
         if not isinstance(recombination_map, RecombinationMap):
@@ -443,7 +443,7 @@ def simulate(
     *,
     Ne=1,
     length=None,
-    discrete_coordinates=None,
+    discrete_genome=None,
     recombination_rate=None,
     recombination_map=None,
     mutation_rate=None,
@@ -487,7 +487,7 @@ def simulate(
     :param float length: The length of the simulated region in bases.
         This parameter cannot be used along with ``recombination_map``.
         Defaults to 1 if not specified.
-    :param bool discrete_coordinates: If True, use discrete coordinates
+    :param bool discrete_genome: If True, use discrete coordinates
         in simulations such that recombination breakpoints and mutational
         sites can only occur at integer positions along the genome.
         Multiple mutations can occur at the same site.
@@ -496,7 +496,7 @@ def simulate(
         All sites in the returned tree sequence will have exactly one mutation.
         Please see the :func:`.mutate` function for a more powerful approach to
         simulating mutations on a tree sequence. It is an error to specify
-        the ``discrete_coordinates`` parameter at the same time as the
+        the ``discrete_genome`` parameter at the same time as the
         ``recombination_map`` argument.
     :param float recombination_rate: The rate of recombination per base
         per generation. This parameter cannot be used along with
@@ -622,15 +622,15 @@ def simulate(
         parameters["random_seed"] = seed
         provenance_dict = provenance.get_provenance_dict(parameters)
 
-    if discrete_coordinates is None:
-        discrete_coordinates = False
+    if discrete_genome is None:
+        discrete_genome = False
     elif recombination_map is not None:
         # TODO this is probably overly strict and we'll want to check if
-        # the recombination_map agrees with the value of discrete_coordinates.
+        # the recombination_map agrees with the value of discrete_genome.
         # Let's figure out the exact default semantcs first before worrying
         # about this, though.
         raise ValueError(
-            "Cannot specify ``discrete_coordinates`` at the same time as the "
+            "Cannot specify ``discrete_genome`` at the same time as the "
             "``recombination_map`` argument."
         )
 
@@ -639,7 +639,7 @@ def simulate(
         random_generator=rng,
         Ne=Ne,
         length=length,
-        discrete_coordinates=discrete_coordinates,
+        discrete_genome=discrete_genome,
         recombination_rate=recombination_rate,
         recombination_map=recombination_map,
         population_configurations=population_configurations,
@@ -691,7 +691,7 @@ def simulate(
         mutation_rate,
         sim.sequence_length,
         sim.random_generator,
-        discrete=discrete_coordinates,
+        discrete=discrete_genome,
     )
     if replicate_index is not None and random_seed is None:
         raise ValueError(

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -736,18 +736,18 @@ class MutationMap:
         return {"position": self.position, "rate": self.rate}
 
 
-def _simple_mutation_generator(rate, sequence_length, rng):
+def _simple_mutation_generator(rate, sequence_length, rng, discrete=False):
     """
     Factory function used to create a low-level mutation generator that
     produces binary infinite sites mutations suitable for use in
     msprime.simulate() and the mspms CLI.
     """
-    # Add a ``discrete`` parameter and pass to the MutationGenerator
-    # constructor.
     if rate is None:
         return None
     rate_map = MutationMap(position=[0, sequence_length], rate=[rate, 0])
-    return _msprime.MutationGenerator(rng, rate_map._ll_map, BinaryMutations())
+    return _msprime.MutationGenerator(
+        rng, rate_map._ll_map, BinaryMutations(), discrete_sites=discrete
+    )
 
 
 def mutate(
@@ -867,12 +867,15 @@ def mutate(
 
     rng = _msprime.RandomGenerator(seed)
     mutation_generator = _msprime.MutationGenerator(
-        random_generator=rng, rate_map=rate_map._ll_map, model=model
+        random_generator=rng,
+        rate_map=rate_map._ll_map,
+        model=model,
+        discrete_sites=discrete,
     )
     lwt = _msprime.LightweightTableCollection()
     lwt.fromdict(tables.asdict())
     mutation_generator.generate(
-        lwt, keep=keep, start_time=start_time, end_time=end_time, discrete=discrete
+        lwt, keep=keep, start_time=start_time, end_time=end_time
     )
 
     tables = tskit.TableCollection.fromdict(lwt.asdict())

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -26,12 +26,28 @@ import os
 import random
 import tempfile
 import unittest
+import warnings
 
 import numpy as np
 import tskit
 
 import _msprime
 import msprime
+
+
+def has_discrete_coordinates(ts):
+    """
+    Returns True if the specified tree sequence has discrete genome coordinates.
+    """
+    tables = ts.tables
+    edges_left = np.all(tables.edges.left == np.floor(tables.edges.left))
+    edges_right = np.all(tables.edges.right == np.floor(tables.edges.right))
+    migrations_left = np.all(tables.migrations.left == np.floor(tables.migrations.left))
+    migrations_right = np.all(
+        tables.migrations.right == np.floor(tables.migrations.right)
+    )
+    sites = np.all(tables.sites.position == np.floor(tables.sites.position))
+    return edges_left and edges_right and migrations_left and migrations_right and sites
 
 
 def get_bottleneck_examples():
@@ -402,6 +418,13 @@ class TestSimulatorFactory(unittest.TestCase):
         sim = msprime.simulator_factory(10)
         self.assertEqual(sim.demography.populations[0].initial_size, 1)
 
+    def test_discrete_coordinates_continuous_length(self):
+        for bad_length in [0.1, 1.1, 1000.1]:
+            with self.assertRaises(ValueError):
+                msprime.simulator_factory(
+                    10, discrete_coordinates=True, length=bad_length
+                )
+
     def test_population_configurations(self):
         def f(configs):
             return msprime.simulator_factory(population_configurations=configs)
@@ -471,10 +494,12 @@ class TestSimulatorFactory(unittest.TestCase):
             # Now check for the structure of the matrix.
             matrix[0][0] = "bad value"
             self.assertRaises(ValueError, f, matrix)
-            matrix[0] = None
-            self.assertRaises(ValueError, f, matrix)
-            matrix[0] = []
-            self.assertRaises(ValueError, f, matrix)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                matrix[0] = None
+                self.assertRaises(ValueError, f, matrix)
+                matrix[0] = []
+                self.assertRaises(ValueError, f, matrix)
             # Simple numpy array.
             matrix = np.ones((N, N))
             np.fill_diagonal(matrix, 0)
@@ -699,6 +724,95 @@ class TestSimulateInterface(unittest.TestCase):
         self.assertEqual(ts.get_num_mutations(), 0)
         self.assertEqual(ts.get_sequence_length(), 1)
         self.assertEqual(len(list(ts.provenances())), 1)
+
+    def test_positional_args_not_allowed(self):
+        with self.assertRaises(TypeError):
+            msprime.simulate(2, 100)
+
+    def test_discrete_coordinates_recombination_map(self):
+        # Cannot specify discrete_coordinates and recombination_map at once
+        recomb_map = msprime.RecombinationMap.uniform_map(10, 0.1)
+        with self.assertRaises(ValueError):
+            msprime.simulate(
+                10, discrete_coordinates=True, recombination_map=recomb_map
+            )
+
+    def test_discrete_coordinates_no_mutations(self):
+        def run_sim(discrete_coordinates=None):
+            return msprime.simulate(
+                10,
+                length=2,
+                recombination_rate=1,
+                discrete_coordinates=discrete_coordinates,
+                random_seed=2134,
+            )
+
+        ts_discrete = run_sim(True)
+        self.assertGreater(ts_discrete.num_trees, 1)
+        self.assertTrue(has_discrete_coordinates(ts_discrete))
+
+        ts_continuous = run_sim(False)
+        self.assertGreater(ts_continuous.num_trees, 1)
+        self.assertFalse(has_discrete_coordinates(ts_continuous))
+
+        ts_default = run_sim()
+        tables_default = ts_default.dump_tables()
+        tables_continuous = ts_continuous.dump_tables()
+        tables_continuous.provenances.clear()
+        tables_default.provenances.clear()
+        self.assertEqual(tables_default, tables_continuous)
+
+    def test_discrete_coordinates_mutations(self):
+        def run_sim(discrete_coordinates=None):
+            return msprime.simulate(
+                10,
+                length=2,
+                recombination_rate=1,
+                mutation_rate=1,
+                discrete_coordinates=discrete_coordinates,
+                random_seed=2134,
+            )
+
+        ts_discrete = run_sim(True)
+        self.assertGreater(ts_discrete.num_trees, 1)
+        self.assertGreater(ts_discrete.num_sites, 1)
+        self.assertTrue(has_discrete_coordinates(ts_discrete))
+
+        ts_continuous = run_sim(False)
+        self.assertGreater(ts_continuous.num_trees, 1)
+        self.assertGreater(ts_discrete.num_sites, 1)
+        self.assertFalse(has_discrete_coordinates(ts_continuous))
+
+        ts_default = run_sim()
+        tables_default = ts_default.dump_tables()
+        tables_continuous = ts_continuous.dump_tables()
+        tables_continuous.provenances.clear()
+        tables_default.provenances.clear()
+        self.assertEqual(tables_default, tables_continuous)
+
+    def test_discrete_coordinates_migrations(self):
+        def run_sim(discrete_coordinates=None):
+            demography = msprime.Demography.stepping_stone_1d(2, 0.1)
+            samples = demography.sample(5, 5)
+            return msprime.simulate(
+                samples=samples,
+                demography=demography,
+                length=5,
+                recombination_rate=1,
+                discrete_coordinates=discrete_coordinates,
+                record_migrations=True,
+                random_seed=2134,
+            )
+
+        ts_discrete = run_sim(True)
+        self.assertGreater(ts_discrete.num_trees, 1)
+        self.assertGreater(ts_discrete.num_migrations, 1)
+        self.assertTrue(has_discrete_coordinates(ts_discrete))
+
+        ts_continuous = run_sim(False)
+        self.assertGreater(ts_continuous.num_trees, 1)
+        self.assertGreater(ts_continuous.num_migrations, 1)
+        self.assertFalse(has_discrete_coordinates(ts_continuous))
 
     def test_numpy_random_seed(self):
         seed = np.array([12345], dtype=np.int64)[0]

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -35,7 +35,7 @@ import _msprime
 import msprime
 
 
-def has_discrete_coordinates(ts):
+def has_discrete_genome(ts):
     """
     Returns True if the specified tree sequence has discrete genome coordinates.
     """
@@ -418,12 +418,10 @@ class TestSimulatorFactory(unittest.TestCase):
         sim = msprime.simulator_factory(10)
         self.assertEqual(sim.demography.populations[0].initial_size, 1)
 
-    def test_discrete_coordinates_continuous_length(self):
+    def test_discrete_genome_continuous_length(self):
         for bad_length in [0.1, 1.1, 1000.1]:
             with self.assertRaises(ValueError):
-                msprime.simulator_factory(
-                    10, discrete_coordinates=True, length=bad_length
-                )
+                msprime.simulator_factory(10, discrete_genome=True, length=bad_length)
 
     def test_population_configurations(self):
         def f(configs):
@@ -729,31 +727,29 @@ class TestSimulateInterface(unittest.TestCase):
         with self.assertRaises(TypeError):
             msprime.simulate(2, 100)
 
-    def test_discrete_coordinates_recombination_map(self):
-        # Cannot specify discrete_coordinates and recombination_map at once
+    def test_discrete_genome_recombination_map(self):
+        # Cannot specify discrete_genome and recombination_map at once
         recomb_map = msprime.RecombinationMap.uniform_map(10, 0.1)
         with self.assertRaises(ValueError):
-            msprime.simulate(
-                10, discrete_coordinates=True, recombination_map=recomb_map
-            )
+            msprime.simulate(10, discrete_genome=True, recombination_map=recomb_map)
 
-    def test_discrete_coordinates_no_mutations(self):
-        def run_sim(discrete_coordinates=None):
+    def test_discrete_genome_no_mutations(self):
+        def run_sim(discrete_genome=None):
             return msprime.simulate(
                 10,
                 length=2,
                 recombination_rate=1,
-                discrete_coordinates=discrete_coordinates,
+                discrete_genome=discrete_genome,
                 random_seed=2134,
             )
 
         ts_discrete = run_sim(True)
         self.assertGreater(ts_discrete.num_trees, 1)
-        self.assertTrue(has_discrete_coordinates(ts_discrete))
+        self.assertTrue(has_discrete_genome(ts_discrete))
 
         ts_continuous = run_sim(False)
         self.assertGreater(ts_continuous.num_trees, 1)
-        self.assertFalse(has_discrete_coordinates(ts_continuous))
+        self.assertFalse(has_discrete_genome(ts_continuous))
 
         ts_default = run_sim()
         tables_default = ts_default.dump_tables()
@@ -762,26 +758,26 @@ class TestSimulateInterface(unittest.TestCase):
         tables_default.provenances.clear()
         self.assertEqual(tables_default, tables_continuous)
 
-    def test_discrete_coordinates_mutations(self):
-        def run_sim(discrete_coordinates=None):
+    def test_discrete_genome_mutations(self):
+        def run_sim(discrete_genome=None):
             return msprime.simulate(
                 10,
                 length=2,
                 recombination_rate=1,
                 mutation_rate=1,
-                discrete_coordinates=discrete_coordinates,
+                discrete_genome=discrete_genome,
                 random_seed=2134,
             )
 
         ts_discrete = run_sim(True)
         self.assertGreater(ts_discrete.num_trees, 1)
         self.assertGreater(ts_discrete.num_sites, 1)
-        self.assertTrue(has_discrete_coordinates(ts_discrete))
+        self.assertTrue(has_discrete_genome(ts_discrete))
 
         ts_continuous = run_sim(False)
         self.assertGreater(ts_continuous.num_trees, 1)
         self.assertGreater(ts_discrete.num_sites, 1)
-        self.assertFalse(has_discrete_coordinates(ts_continuous))
+        self.assertFalse(has_discrete_genome(ts_continuous))
 
         ts_default = run_sim()
         tables_default = ts_default.dump_tables()
@@ -790,8 +786,8 @@ class TestSimulateInterface(unittest.TestCase):
         tables_default.provenances.clear()
         self.assertEqual(tables_default, tables_continuous)
 
-    def test_discrete_coordinates_migrations(self):
-        def run_sim(discrete_coordinates=None):
+    def test_discrete_genome_migrations(self):
+        def run_sim(discrete_genome=None):
             demography = msprime.Demography.stepping_stone_1d(2, 0.1)
             samples = demography.sample(5, 5)
             return msprime.simulate(
@@ -799,7 +795,7 @@ class TestSimulateInterface(unittest.TestCase):
                 demography=demography,
                 length=5,
                 recombination_rate=1,
-                discrete_coordinates=discrete_coordinates,
+                discrete_genome=discrete_genome,
                 record_migrations=True,
                 random_seed=2134,
             )
@@ -807,12 +803,12 @@ class TestSimulateInterface(unittest.TestCase):
         ts_discrete = run_sim(True)
         self.assertGreater(ts_discrete.num_trees, 1)
         self.assertGreater(ts_discrete.num_migrations, 1)
-        self.assertTrue(has_discrete_coordinates(ts_discrete))
+        self.assertTrue(has_discrete_genome(ts_discrete))
 
         ts_continuous = run_sim(False)
         self.assertGreater(ts_continuous.num_trees, 1)
         self.assertGreater(ts_continuous.num_migrations, 1)
-        self.assertFalse(has_discrete_coordinates(ts_continuous))
+        self.assertFalse(has_discrete_genome(ts_continuous))
 
     def test_numpy_random_seed(self):
         seed = np.array([12345], dtype=np.int64)[0]

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2612,6 +2612,12 @@ class TestMutationGenerator(unittest.TestCase):
         self.assertRaises(TypeError, _msprime.MutationGenerator)
         self.assertRaises(TypeError, _msprime.MutationGenerator, imap)
         _msprime.MutationGenerator(_msprime.RandomGenerator(1), imap, model)
+        self.assertRaises(
+            TypeError, _msprime.MutationGenerator, imap, discrete_sites="sdf"
+        )
+        _msprime.MutationGenerator(
+            _msprime.RandomGenerator(1), imap, model, discrete_sites=True
+        )
 
     def test_rng(self):
         imap = _msprime.IntervalMap([0, 1], [0, 0])


### PR DESCRIPTION
WIP.

One notable change this includes is  to make all arguments after the first to simulate keyword only. I doubt this will break anyone's code, and it's a good thing to get formalised for 1.0. Any objections?

Closes #880