### PR TITLE
Simulate discrete genomes by default

### DIFF
--- a/docs/examples/segregating_sites.py
+++ b/docs/examples/segregating_sites.py
@@ -6,7 +6,10 @@ import msprime
 def segregating_sites(n, theta, num_replicates):
     S = np.zeros(num_replicates)
     replicates = msprime.simulate(
-        sample_size=n, mutation_rate=theta / 4, num_replicates=num_replicates
+        sample_size=n,
+        mutation_rate=theta / 4,
+        num_replicates=num_replicates,
+        discrete_genome=False,
     )
     for j, tree_sequence in enumerate(replicates):
         S[j] = tree_sequence.get_num_mutations()

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1463,6 +1463,10 @@ API for replication: by providing the ``num_replicates`` argument to the
 in a straightforward manner. Here is an example where we compare the
 analytical results for the number of segregating sites with simulations:
 
+.. warning:: TODO add a helpful warning that older versions of this
+   example will give incorrect answers with msprime 1.0 and link to the
+   docs section where we talk about the discrete genome stuff.
+
 .. literalinclude:: examples/segregating_sites.py
 
 Running this code, we get:

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -40,8 +40,6 @@ from . import provenance
 
 logger = logging.getLogger(__name__)
 
-SHORT_GENOME_THRESHOLD = 1000
-
 
 def model_factory(model):
     """
@@ -713,7 +711,7 @@ def simulate(
         discrete=sim.recombination_map.discrete,
     )
 
-    if discrete_genome is None and sim.sequence_length < SHORT_GENOME_THRESHOLD:
+    if discrete_genome is None and sim.sequence_length < core.SHORT_GENOME_THRESHOLD:
         # discrete_genome and recombination_map are mutually exclusive options,
         # so we only have to worry about the simple examples here. We warn
         # about short recombination maps separately.
@@ -1029,8 +1027,8 @@ class RecombinationMap:
                     "and set discrete=True"
                 )
         if discrete is None:
-            if length < SHORT_GENOME_THRESHOLD:
-                warnings.warn("short genome recomb map")
+            if length < core.SHORT_GENOME_THRESHOLD:
+                warnings.warn("short genome recomb map. TODO: helpful warning.")
             discrete = True
 
         if length < 1 and discrete:

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1033,8 +1033,8 @@ class RecombinationMap:
                 warnings.warn("short genome recomb map")
             discrete = True
 
-        if discrete and np.any(np.floor(positions) != positions):
-            raise ValueError("Cannot create a discrete map with non-integer positions")
+        if length < 1 and discrete:
+            raise ValueError("Cannot have a discrete recombination map with length < 1")
 
         self._ll_recombination_map = _msprime.RecombinationMap(
             positions, rates, discrete
@@ -1122,7 +1122,7 @@ class RecombinationMap:
                 )
         finally:
             f.close()
-        return cls(positions, rates, map_start=map_start)
+        return cls(positions, rates, map_start=map_start, discrete=True)
 
     @property
     def mean_recombination_rate(self):

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -705,6 +705,7 @@ def simulate(
                 "start_time. Please use msprime.mutate on the returned "
                 "tree sequence instead"
             )
+
     mutation_generator = mutations._simple_mutation_generator(
         mutation_rate,
         sim.sequence_length,

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1041,7 +1041,7 @@ class RecombinationMap:
         self.map_start = map_start
 
     @classmethod
-    def uniform_map(cls, length, rate, num_loci=None, discrete=False):
+    def uniform_map(cls, length, rate, num_loci=None, discrete=None):
         """
         Returns a :class:`.RecombinationMap` instance in which the recombination
         rate is constant over a chromosome of the specified length. The optional

--- a/msprime/core.py
+++ b/msprime/core.py
@@ -33,6 +33,11 @@ except ImportError:
     pass
 
 
+# The threshold below which we emit warnings to users, asking them if
+# they're really sure that they want discrete genomes.
+SHORT_GENOME_THRESHOLD = 1000
+
+
 # Make sure the GSL error handler is turned off so that we can be sure that
 # we don't abort on errors. This can be reset by using the function
 # _msprime.restore_gsl_error_handler(), which will set the error handler to

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -21,6 +21,7 @@ Module responsible for generating mutations on a given tree sequence.
 """
 import inspect
 import sys
+import warnings
 
 import numpy as np
 import tskit
@@ -755,10 +756,10 @@ def mutate(
     rate=None,
     random_seed=None,
     model=None,
-    keep=False,
+    keep=None,
     start_time=None,
     end_time=None,
-    discrete=False,
+    discrete=None,
 ):
     """
     Simulates mutations on the specified ancestry and returns the resulting
@@ -847,8 +848,21 @@ def mutate(
         end_time = float(end_time)
     if start_time > end_time:
         raise ValueError("start_time must be <= end_time")
-    keep = bool(keep)
-    discrete = bool(discrete)
+
+    if keep is None:
+        keep = False
+    else:
+        keep = bool(keep)
+
+    if discrete is None:
+        if tables.sequence_length < core.SHORT_GENOME_THRESHOLD:
+            warnings.warn(
+                "short genome in mutate. Do you really want to be discrete?. "
+                "TODO: helpful warning."
+            )
+        discrete = True
+    else:
+        discrete = bool(discrete)
 
     if model is None:
         model = BinaryMutations()

--- a/msprime/provenance.py
+++ b/msprime/provenance.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2017 University of Oxford
+# Copyright (C) 2016-2020 University of Oxford
 #
 # This file is part of msprime.
 #

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -753,10 +753,10 @@ class TestSimulateInterface(unittest.TestCase):
 
         ts_default = run_sim()
         tables_default = ts_default.dump_tables()
-        tables_continuous = ts_continuous.dump_tables()
-        tables_continuous.provenances.clear()
+        tables_discrete = ts_discrete.dump_tables()
+        tables_discrete.provenances.clear()
         tables_default.provenances.clear()
-        self.assertEqual(tables_default, tables_continuous)
+        self.assertEqual(tables_default, tables_discrete)
 
     def test_discrete_genome_mutations(self):
         def run_sim(discrete_genome=None):
@@ -781,10 +781,10 @@ class TestSimulateInterface(unittest.TestCase):
 
         ts_default = run_sim()
         tables_default = ts_default.dump_tables()
-        tables_continuous = ts_continuous.dump_tables()
-        tables_continuous.provenances.clear()
+        tables_discrete = ts_discrete.dump_tables()
+        tables_discrete.provenances.clear()
         tables_default.provenances.clear()
-        self.assertEqual(tables_default, tables_continuous)
+        self.assertEqual(tables_default, tables_discrete)
 
     def test_discrete_genome_migrations(self):
         def run_sim(discrete_genome=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1500,7 +1500,12 @@ class TestMspConversionOutput(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._tree_sequence = msprime.simulate(
-            10, length=10, recombination_rate=10, mutation_rate=10, random_seed=1
+            10,
+            length=10,
+            recombination_rate=10,
+            mutation_rate=10,
+            random_seed=1,
+            discrete_genome=False,
         )
         fd, cls._tree_sequence_file = tempfile.mkstemp(
             prefix="msp_cli", suffix=".trees"
@@ -1733,7 +1738,7 @@ class TestMspConversionOutput(unittest.TestCase):
         output = stdout.splitlines()
         self.assertTrue(output[0].startswith("COMMAND:"))
         self.assertTrue(output[1].startswith("SEED:"))
-        self.assertEqual(len(output), 2 + self._tree_sequence.get_num_mutations())
+        self.assertEqual(len(output), 2 + self._tree_sequence.num_sites)
         n = self._tree_sequence.get_sample_size()
         m = self._tree_sequence.get_sequence_length()
         sites = list(self._tree_sequence.sites())
@@ -1787,7 +1792,7 @@ class TestUpgrade(TestCli):
             self.assertEqual(ts1.get_num_trees(), ts2.get_num_trees())
 
     def test_duplicate_positions(self):
-        ts = msprime.simulate(10, mutation_rate=10)
+        ts = msprime.simulate(10, mutation_rate=10, discrete_genome=False)
         for version in [2, 3]:
             tskit.dump_legacy(ts, self.legacy_file_name, version=version)
             root = h5py.File(self.legacy_file_name, "r+")

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -2063,6 +2063,7 @@ class MigrationRecordsMixin:
         ts = msprime.simulate(
             model=self.model,
             recombination_rate=1,
+            discrete_genome=False,
             population_configurations=population_configurations,
             migration_matrix=[[0, 0], [1, 0]],
             # Can migrate from 1 to 0 but not vice-versa
@@ -2089,6 +2090,7 @@ class MigrationRecordsMixin:
         ts = msprime.simulate(
             model=self.model,
             recombination_rate=10,
+            discrete_genome=False,
             population_configurations=population_configurations,
             demographic_events=[
                 msprime.MassMigration(time=20, source=1, dest=0, proportion=1)

--- a/tests/test_dict_encoding.py
+++ b/tests/test_dict_encoding.py
@@ -27,6 +27,7 @@ def get_example_tables():
         mutation_rate=1,
         record_migrations=True,
         random_seed=1,
+        discrete_genome=False,
     )
 
     tables = ts.dump_tables()
@@ -119,7 +120,7 @@ class TestRoundTrip(unittest.TestCase):
         self.assertEqual(tables, other_tables)
 
     def test_simple(self):
-        ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=2, discrete_genome=False)
         self.verify(ts.tables)
 
     def test_empty(self):
@@ -128,7 +129,7 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_individuals(self):
         n = 10
-        ts = msprime.simulate(n, mutation_rate=1, random_seed=2)
+        ts = msprime.simulate(n, mutation_rate=1, random_seed=2, discrete_genome=False)
         tables = ts.dump_tables()
         for j in range(n):
             tables.individuals.add_row(flags=j, location=(j, j), metadata=b"x" * j)
@@ -136,7 +137,12 @@ class TestRoundTrip(unittest.TestCase):
 
     def test_sequence_length(self):
         ts = msprime.simulate(
-            10, recombination_rate=0.1, mutation_rate=1, length=0.99, random_seed=2
+            10,
+            recombination_rate=0.1,
+            mutation_rate=1,
+            length=0.99,
+            random_seed=2,
+            discrete_genome=False,
         )
         self.verify(ts.tables)
 
@@ -147,6 +153,7 @@ class TestRoundTrip(unittest.TestCase):
             population_configurations=pop_configs,
             migration_matrix=migration_matrix,
             mutation_rate=1,
+            discrete_genome=False,
             record_migrations=True,
             random_seed=1,
         )

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -518,7 +518,7 @@ class TestSimulatedExamples(unittest.TestCase):
     # TODO Add mutation rate as parameter here.
     def verify(self, ts, recombination_rate, Ne):
         l1 = msprime.log_arg_likelihood(
-            ts, recombination_rate=recombination_rate, Ne=Ne
+            ts, recombination_rate=recombination_rate, Ne=Ne,
         )
         l2 = log_arg_likelihood(ts, recombination_rate, Ne)
         self.assertAlmostEqual(l1, l2)
@@ -533,7 +533,11 @@ class TestSimulatedExamples(unittest.TestCase):
 
     def test_small_arg_no_mutation(self):
         ts = msprime.simulate(
-            5, recombination_rate=1, random_seed=12, record_full_arg=True
+            5,
+            recombination_rate=1,
+            random_seed=12,
+            record_full_arg=True,
+            discrete_genome=False,
         )
         self.assertGreater(ts.num_edges, 10)
         self.verify(ts, recombination_rate=1, Ne=0.5)
@@ -544,7 +548,11 @@ class TestSimulatedExamples(unittest.TestCase):
 
     def test_negative_rec_rate(self):
         ts = msprime.simulate(
-            5, recombination_rate=1, random_seed=12, record_full_arg=True
+            5,
+            recombination_rate=1,
+            random_seed=12,
+            record_full_arg=True,
+            discrete_genome=False,
         )
         with self.assertRaises(ValueError):
             msprime.log_arg_likelihood(ts, recombination_rate=-1)
@@ -554,7 +562,11 @@ class TestSimulatedExamples(unittest.TestCase):
     def test_zero_mut_rate(self):
         # No mutations
         ts = msprime.simulate(
-            5, recombination_rate=1, random_seed=12, record_full_arg=True
+            5,
+            recombination_rate=1,
+            random_seed=12,
+            record_full_arg=True,
+            discrete_genome=False,
         )
         lik = msprime.unnormalised_log_mutation_likelihood(ts, 0)
         self.assertEqual(lik, 0)
@@ -566,6 +578,7 @@ class TestSimulatedExamples(unittest.TestCase):
             mutation_rate=1,
             random_seed=12,
             record_full_arg=True,
+            discrete_genome=False,
         )
         lik = msprime.unnormalised_log_mutation_likelihood(ts, 0)
         self.assertEqual(lik, float("-inf"))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -316,7 +316,6 @@ class TestRejectedCommonAncestorEventCounts(unittest.TestCase):
             model="hudson",
             discrete_genome=False,
             random_seed=2,
-            random_generator=_msprime.RandomGenerator(2),
         )
         sim2.run()
         self.assertEqual(
@@ -359,6 +358,7 @@ class TestEdges(unittest.TestCase):
             sample_size=sample_size,
             recombination_rate=recombination_rate,
             random_seed=random_seed,
+            discrete_genome=False,
         )
         edgesets = sorted(ts.edgesets(), key=lambda e: (e.parent, e.left))
         num_found = 0
@@ -375,6 +375,7 @@ class TestEdges(unittest.TestCase):
                 sample_size=sample_size,
                 recombination_rate=recombination_rate,
                 random_seed=random_seed,
+                discrete_genome=False,
                 model=model,
             )
             edgesets = sorted(ts.edgesets(), key=lambda e: (e.parent, e.left))
@@ -453,7 +454,11 @@ class TestMultipleMergerModels(unittest.TestCase):
     def test_dirac_coalescent_lambda_regime_recombination(self):
         model = msprime.DiracCoalescent(psi=0.9, c=100)
         ts = msprime.simulate(
-            sample_size=100, recombination_rate=100, model=model, random_seed=3
+            sample_size=100,
+            recombination_rate=100,
+            discrete_genome=False,
+            model=model,
+            random_seed=3,
         )
         self.verify_non_binary(ts)
 
@@ -495,13 +500,23 @@ class TestDtwf(unittest.TestCase):
     def test_low_recombination(self):
         # https://github.com/tskit-dev/msprime/issues/831
         ts = msprime.simulate(
-            10, Ne=1e2, model="dtwf", recombination_rate=1e-9, random_seed=2
+            10,
+            Ne=1e2,
+            model="dtwf",
+            recombination_rate=1e-9,
+            random_seed=2,
+            discrete_genome=False,
         )
         self.assertEqual(ts.num_trees, 1)
 
     def test_very_low_recombination(self):
         ts = msprime.simulate(
-            10, Ne=1e2, model="dtwf", recombination_rate=1e-300, random_seed=2
+            10,
+            Ne=1e2,
+            model="dtwf",
+            recombination_rate=1e-300,
+            random_seed=2,
+            discrete_genome=False,
         )
         self.assertEqual(ts.num_trees, 1)
 
@@ -520,7 +535,7 @@ class TestDtwf(unittest.TestCase):
     def test_no_recombination_interval(self):
         positions = [0, 50, 100, 150, 200]
         rates = [0.01, 0.0, 0.1, 0.005, 0.0]
-        recombination_map = msprime.RecombinationMap(positions, rates)
+        recombination_map = msprime.RecombinationMap(positions, rates, discrete=False)
         ts = msprime.simulate(
             10, Ne=10, model="dtwf", random_seed=2, recombination_map=recombination_map
         )
@@ -627,6 +642,7 @@ class TestMixedModels(unittest.TestCase):
             sample_size=4,
             pedigree=ped,
             recombination_rate=0.1,
+            discrete_genome=False,
             model=[model, (1, "dtwf")],
         )
         tree = ts.first()
@@ -681,6 +697,7 @@ class TestMixedModels(unittest.TestCase):
             Ne=Ne,
             model=["dtwf", (t, "hudson")],
             recombination_rate=0.1,
+            discrete_genome=False,
             random_seed=2,
         )
         tree = ts.first()
@@ -697,15 +714,10 @@ class TestMixedModels(unittest.TestCase):
         Ne = 100
         t = 100
         ts1 = msprime.simulate(
-            sample_size=10,
-            Ne=Ne,
-            model=["dtwf", (t, "hudson")],
-            recombination_rate=0.1,
-            random_seed=2,
+            sample_size=10, Ne=Ne, model=["dtwf", (t, "hudson")], random_seed=2,
         )
         ts2 = msprime.simulate(
             sample_size=10,
-            recombination_rate=0.1,
             Ne=Ne,
             model="dtwf",
             demographic_events=[msprime.SimulationModelChange(t, "hudson")],
@@ -713,7 +725,6 @@ class TestMixedModels(unittest.TestCase):
         )
         ts3 = msprime.simulate(
             sample_size=10,
-            recombination_rate=0.1,
             Ne=Ne,
             model="dtwf",
             demographic_events=[msprime.SimulationModelChange(t)],
@@ -737,6 +748,7 @@ class TestMixedModels(unittest.TestCase):
             Ne=Ne,
             model=["dtwf", (t1, "hudson"), (t2, "dtwf")],
             recombination_rate=0.1,
+            discrete_genome=False,
             random_seed=2,
         )
         tree = ts.first()
@@ -755,6 +767,7 @@ class TestMixedModels(unittest.TestCase):
             Ne=Ne,
             sample_size=10,
             recombination_rate=0.1,
+            discrete_genome=False,
             model=[
                 "hudson",
                 msprime.SimulationModelChange(10, msprime.StandardCoalescent()),
@@ -788,6 +801,7 @@ class TestMixedModels(unittest.TestCase):
             Ne=Ne,
             sample_size=10,
             recombination_rate=0.1,
+            discrete_genome=False,
             model=[
                 None,
                 msprime.SimulationModelChange(10, msprime.StandardCoalescent()),
@@ -856,9 +870,7 @@ class TestSweepGenicSelection(unittest.TestCase):
         )
         for num_labels in [1, 3, 10]:
             with self.assertRaises(_msprime.LibraryError):
-                msprime.simulate(
-                    10, recombination_rate=1, model=model, num_labels=num_labels
-                )
+                msprime.simulate(10, model=model, num_labels=num_labels)
 
     def test_sweep_coalescence_no_recomb(self):
         N = 1e6
@@ -909,6 +921,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             10,
             Ne=0.25,
             recombination_rate=2,
+            discrete_genome=False,
             model=[None, (t_start, sweep_model), (None, None)],
             random_seed=2,
         )
@@ -924,6 +937,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             10,
             Ne=0.25,
             recombination_rate=2,
+            discrete_genome=False,
             model=["hudson", (t_start, sweep_model)],
             random_seed=2,
         )
@@ -939,6 +953,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             10,
             Ne=0.25,
             recombination_rate=2,
+            discrete_genome=False,
             model=[sweep_model, (None, None)],
             random_seed=2,
         )
@@ -949,6 +964,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             10,
             Ne=0.25,
             recombination_rate=2,
+            discrete_genome=False,
             model=[
                 sweep_model,
                 msprime.SimulationModelChange(lambda t: None, "hudson"),
@@ -959,7 +975,12 @@ class TestSweepGenicSelection(unittest.TestCase):
 
         # Make sure that the Hudson phase did something.
         ts = msprime.simulate(
-            10, Ne=0.25, recombination_rate=2, model=sweep_model, random_seed=2,
+            10,
+            Ne=0.25,
+            recombination_rate=2,
+            model=sweep_model,
+            random_seed=2,
+            discrete_genome=True,
         )
         self.assertTrue(any(tree.num_roots > 1 for tree in ts.trees()))
 
@@ -975,6 +996,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             Ne=0.25,
             length=10,
             recombination_rate=0.2,
+            discrete_genome=False,
             model=[None, msprime.SimulationModelChange(0.01, sweep_models[0])]
             + [msprime.SimulationModelChange(None, model) for model in sweep_models]
             + [msprime.SimulationModelChange()],
@@ -1006,6 +1028,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             Ne=0.25,
             length=10,
             recombination_rate=0.2,
+            discrete_genome=False,
             demographic_events=events,
             random_seed=2,
         )
@@ -1017,6 +1040,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             model=["hudson"] + events,
             length=10,
             recombination_rate=0.2,
+            discrete_genome=False,
             random_seed=2,
         )
         self.assertTreeSequencesEqual(ts2, ts)
@@ -1044,6 +1068,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             Ne=0.25,
             length=10,
             recombination_rate=0.2,
+            discrete_genome=False,
             demographic_events=events,
             random_seed=2,
         )
@@ -1055,6 +1080,7 @@ class TestSweepGenicSelection(unittest.TestCase):
             Ne=0.25,
             length=10,
             recombination_rate=0.2,
+            discrete_genome=False,
             random_seed=2,
         )
         self.assertTreeSequencesEqual(ts2, ts)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -303,9 +303,7 @@ class TestRejectedCommonAncestorEventCounts(unittest.TestCase):
     def test_hudson(self):
         threshold = 20
         sim = msprime.simulator_factory(
-            sample_size=10,
-            recombination_rate=10,
-            random_generator=_msprime.RandomGenerator(2),
+            sample_size=10, recombination_rate=10, discrete_genome=False, random_seed=2,
         )
         sim.run()
         self.assertGreater(sim.num_common_ancestor_events, threshold)
@@ -316,6 +314,8 @@ class TestRejectedCommonAncestorEventCounts(unittest.TestCase):
             sample_size=10,
             recombination_rate=10,
             model="hudson",
+            discrete_genome=False,
+            random_seed=2,
             random_generator=_msprime.RandomGenerator(2),
         )
         sim2.run()
@@ -332,7 +332,8 @@ class TestRejectedCommonAncestorEventCounts(unittest.TestCase):
                 sample_size=10,
                 recombination_rate=5,
                 model=model,
-                random_generator=_msprime.RandomGenerator(3),
+                discrete_genome=False,
+                random_seed=3,
             )
             sim.run()
             self.assertGreater(sim.num_rejected_common_ancestor_events, 0)
@@ -882,7 +883,9 @@ class TestSweepGenicSelection(unittest.TestCase):
             alpha=1000,
             dt=1e-6,
         )
-        ts = msprime.simulate(10, model=model, recombination_rate=1, random_seed=2)
+        ts = msprime.simulate(
+            10, model=model, recombination_rate=1, random_seed=2, discrete_genome=False
+        )
         self.assertGreater(ts.num_trees, 1)
 
     def test_sweep_coalescence_same_seed(self):

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -294,7 +294,7 @@ class TestMutate(unittest.TestCase, MutateMixin):
         self.assertEqual(t1.mutations, t2.mutations)
 
     def test_mutation_overwrite(self):
-        ts = msprime.simulate(10, mutation_rate=5, random_seed=2)
+        ts = msprime.simulate(10, mutation_rate=5, random_seed=2, discrete_genome=False)
         self.assertGreater(ts.num_sites, 0)
         self.assertGreater(ts.num_mutations, 0)
         mutated = msprime.mutate(ts, 0)
@@ -497,7 +497,9 @@ class TestFiniteSites(TestMutate):
 
     def test_zero_mutation_rate(self):
         for keep in (True, False):
-            ts = msprime.simulate(10, random_seed=1, mutation_rate=2.0)
+            ts = msprime.simulate(
+                10, random_seed=1, mutation_rate=2.0, discrete_genome=False
+            )
             mutated = self.mutate_binary(ts, 0, keep=keep)
             t1 = ts.dump_tables()
             t2 = mutated.dump_tables()
@@ -510,7 +512,9 @@ class TestFiniteSites(TestMutate):
                 self.assertEqual(t2.sites.num_rows, 0)
 
     def test_bad_mutate_order(self):
-        ts = msprime.simulate(10, random_seed=1, recombination_rate=1, length=10)
+        ts = msprime.simulate(
+            10, random_seed=1, recombination_rate=1, length=10, discrete_genome=True
+        )
         mutated = msprime.mutate(
             ts, 3, random_seed=5, start_time=0.0, end_time=0.5, discrete=True
         )
@@ -527,7 +531,13 @@ class TestFiniteSites(TestMutate):
 
     def test_one_way_mutation(self):
         for discrete in (True, False):
-            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            ts = msprime.simulate(
+                10,
+                random_seed=1,
+                recombination_rate=1.0,
+                length=10,
+                discrete_genome=False,
+            )
             mut_matrix = [[0.0, 1.0], [0.0, 1.0]]
             mutated = self.mutate_binary(
                 ts,
@@ -548,7 +558,13 @@ class TestFiniteSites(TestMutate):
     def test_flip_flop_mutation(self):
         nucleotides = "ACGT"
         for discrete in (True, False):
-            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            ts = msprime.simulate(
+                10,
+                random_seed=1,
+                recombination_rate=1.0,
+                length=10,
+                discrete_genome=True,
+            )
             mut_matrix = [
                 [0.0, 0.0, 0.5, 0.5],
                 [0.0, 0.0, 0.5, 0.5],
@@ -595,7 +611,13 @@ class TestFiniteSites(TestMutate):
     def test_uniform_mutations(self):
         nucleotides = "ACGT"
         for discrete in (True, False):
-            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            ts = msprime.simulate(
+                10,
+                random_seed=1,
+                recombination_rate=1.0,
+                length=10,
+                discrete_genome=True,
+            )
             mut_matrix = [
                 [0.1, 0.3, 0.3, 0.3],
                 [0.0, 0.0, 0.5, 0.5],
@@ -625,7 +647,13 @@ class TestFiniteSites(TestMutate):
     def test_circular_mutations(self):
         nucleotides = "ACGT"
         for discrete in (True, False):
-            ts = msprime.simulate(10, random_seed=1, recombination_rate=1.0, length=10)
+            ts = msprime.simulate(
+                10,
+                random_seed=1,
+                recombination_rate=1.0,
+                length=10,
+                discrete_genome=True,
+            )
             mut_matrix = [
                 [0.0, 1.0, 0.0, 0.0],
                 [0.0, 0.0, 1.0, 0.0],
@@ -656,7 +684,9 @@ class TestFiniteSites(TestMutate):
                     )
 
     def test_integer_sites(self):
-        ts = msprime.simulate(10, random_seed=5, length=10, recombination_rate=10.0)
+        ts = msprime.simulate(
+            10, random_seed=5, length=10, recombination_rate=10.0, discrete_genome=True
+        )
         mutated = self.mutate_binary(ts, rate=5.0, discrete=True)
         self.assertEqual(mutated.site(0).position, 0.0)
         for site in mutated.sites():
@@ -748,7 +778,9 @@ class TestInterval(unittest.TestCase):
         self.verify(ts)
 
     def test_coalescent_trees(self):
-        ts = msprime.simulate(20, recombination_rate=1, random_seed=2)
+        ts = msprime.simulate(
+            20, recombination_rate=1, random_seed=2, discrete_genome=False
+        )
         self.verify(ts)
 
     def test_wright_fisher_trees(self):
@@ -760,7 +792,9 @@ class TestInterval(unittest.TestCase):
         self.verify(ts, rate=10)
 
     def test_negative_time(self):
-        ts = msprime.simulate(10, recombination_rate=1, random_seed=2)
+        ts = msprime.simulate(
+            10, recombination_rate=1, random_seed=2, discrete_genome=False
+        )
         tables = ts.dump_tables()
         time = tables.nodes.time
         max_time = np.max(time)
@@ -817,7 +851,7 @@ class TestKeep(unittest.TestCase):
         self.assertEqual(found, original.num_sites)
 
     def test_simple_binary(self):
-        ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=2, discrete_genome=False)
         self.assertGreater(ts.num_sites, 0)
         self.verify(ts, 1, random_seed=2)
 
@@ -833,21 +867,25 @@ class TestKeep(unittest.TestCase):
 
     def test_branch_mutations(self):
         ts = tsutil.insert_branch_mutations(
-            msprime.simulate(10, recombination_rate=1, random_seed=2)
+            msprime.simulate(
+                10, recombination_rate=1, random_seed=2, discrete_genome=False
+            )
         )
         self.assertGreater(ts.num_sites, 1)
         self.verify(ts, 3, random_seed=7)
 
     def test_multichar_mutations(self):
         ts = tsutil.insert_multichar_mutations(
-            msprime.simulate(12, recombination_rate=4, random_seed=3)
+            msprime.simulate(
+                12, recombination_rate=4, random_seed=3, discrete_genome=False
+            )
         )
         self.assertGreater(ts.num_sites, 5)
         self.verify(ts, 3, random_seed=7)
 
     def test_random_metadata(self):
         ts = tsutil.add_random_metadata(
-            msprime.simulate(12, random_seed=3, mutation_rate=1)
+            msprime.simulate(12, random_seed=3, mutation_rate=1, discrete_genome=False)
         )
         self.assertGreater(ts.num_sites, 5)
         self.verify(ts, 3, random_seed=7)
@@ -904,7 +942,9 @@ class TestKeep(unittest.TestCase):
         self.verify_sites(ts, other)
 
     def test_keep_mutation_parent(self):
-        ts = msprime.simulate(12, recombination_rate=3, random_seed=3)
+        ts = msprime.simulate(
+            12, recombination_rate=3, random_seed=3, discrete_genome=False
+        )
         ts = tsutil.insert_branch_mutations(ts)
         self.assertGreater(ts.num_sites, 2)
         other = msprime.mutate(ts, rate=1, random_seed=1, keep=True)
@@ -912,7 +952,9 @@ class TestKeep(unittest.TestCase):
         self.verify_sites(ts, other)
 
     def test_keep_mutation_parent_zero_rate(self):
-        ts = msprime.simulate(12, recombination_rate=3, random_seed=3)
+        ts = msprime.simulate(
+            12, recombination_rate=3, random_seed=3, discrete_genome=False
+        )
         ts = tsutil.insert_branch_mutations(ts)
         self.assertGreater(ts.num_sites, 2)
         other = msprime.mutate(ts, rate=0, random_seed=1, keep=True)
@@ -952,7 +994,9 @@ class StatisticalTestMixin:
 
 class TestMutationStatistics(unittest.TestCase, StatisticalTestMixin):
     def verify_model(self, model, verify_roots=True):
-        ots = msprime.simulate(10, random_seed=5, recombination_rate=0.05, length=20)
+        ots = msprime.simulate(
+            10, random_seed=5, recombination_rate=0.05, length=20, discrete_genome=False
+        )
         # "large enough sample"-condition for the chisquare test
         if len(model.alleles) > 4:
             rates = (15, 20)
@@ -1049,7 +1093,9 @@ class TestMutationStatistics(unittest.TestCase, StatisticalTestMixin):
         # doesn't depend on the previous state
         assert len(set(np.diag(model.transition_matrix))) == 1
         np.random.seed(23)
-        ots = msprime.simulate(10, random_seed=5, recombination_rate=0.05, length=20)
+        ots = msprime.simulate(
+            10, random_seed=5, recombination_rate=0.05, length=20, discrete_genome=True
+        )
         for discrete in (False, True):
             for rate in (1, 10):
                 ts = msprime.mutate(
@@ -1254,7 +1300,9 @@ class TestSlimMutationModel(unittest.TestCase):
         self.validate_slim_mutations(mts)
 
     def test_binary_many_trees(self):
-        ts = msprime.simulate(8, length=5, recombination_rate=5, random_seed=50)
+        ts = msprime.simulate(
+            8, length=5, recombination_rate=5, random_seed=50, discrete_genome=False
+        )
         self.assertGreater(ts.num_trees, 20)
         mts = self.run_mutate(ts, rate=2.0, random_seed=23)
         self.assertGreater(mts.num_mutations, 10)
@@ -1324,7 +1372,9 @@ class TestInfiniteAllelesMutationModel(unittest.TestCase):
         self.validate(mts)
 
     def test_binary_many_trees(self):
-        ts = msprime.simulate(8, length=5, recombination_rate=5, random_seed=50)
+        ts = msprime.simulate(
+            8, length=5, recombination_rate=5, random_seed=50, discrete_genome=False
+        )
         self.assertGreater(ts.num_trees, 20)
         mts = self.run_mutate(ts, rate=2.0, random_seed=23)
         self.assertGreater(mts.num_mutations, 10)
@@ -1380,18 +1430,31 @@ class TestPythonMutationGenerator(unittest.TestCase):
         self.verify(ts, random_seed=234)
 
     def test_single_tree_mutations(self):
-        ts = msprime.simulate(10, length=100, mutation_rate=0.1, random_seed=1234)
-        self.assertGreater(ts.num_sites, 0)
+        ts = msprime.simulate(
+            10, length=100, mutation_rate=0.1, random_seed=1234, discrete_genome=False
+        )
+        self.assertGreater(ts.num_sites, 1)
         self.verify(ts, random_seed=34)
 
     def test_many_trees_no_mutations(self):
-        ts = msprime.simulate(10, length=100, recombination_rate=0.1, random_seed=123)
+        ts = msprime.simulate(
+            10,
+            length=100,
+            recombination_rate=0.1,
+            random_seed=123,
+            discrete_genome=True,
+        )
         self.assertGreater(ts.num_trees, 1)
         self.verify(ts, random_seed=789)
 
     def test_many_trees_mutations(self):
         ts = msprime.simulate(
-            10, length=100, mutation_rate=0.1, recombination_rate=2, random_seed=123
+            10,
+            length=100,
+            mutation_rate=0.1,
+            recombination_rate=2,
+            random_seed=123,
+            discrete_genome=False,
         )
         self.assertGreater(ts.num_trees, 1)
         self.assertGreater(ts.num_sites, 1)

--- a/tests/test_pedigree.py
+++ b/tests/test_pedigree.py
@@ -30,7 +30,12 @@ class TestPedigree(unittest.TestCase):
         model = msprime.WrightFisherPedigree()
         ped = msprime.Pedigree(individual, parents, time, is_sample, sex=None, ploidy=2)
         replicates = msprime.simulate(
-            2, pedigree=ped, model=model, recombination_rate=1, num_replicates=100
+            2,
+            pedigree=ped,
+            model=model,
+            recombination_rate=1,
+            num_replicates=100,
+            discrete_genome=False,
         )
         for ts in replicates:
             self.assertTrue(ts is not None)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -60,7 +60,7 @@ class ValidateSchemas(unittest.TestCase):
 
     def test_mutate(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.mutate(ts, rate=1, random_seed=1)
+        ts = msprime.mutate(ts, rate=1, random_seed=1, discrete=False)
         prov = json.loads(ts.provenance(1).record)
         tskit.validate_provenance(prov)
         self.assertEqual(prov["parameters"]["command"], "mutate")
@@ -276,7 +276,13 @@ class TestBuildObjects(unittest.TestCase):
     def test_mutate(self):
         ts = msprime.simulate(5, random_seed=1)
         ts = msprime.mutate(
-            ts, rate=2, random_seed=1, start_time=0, end_time=100, keep=False
+            ts,
+            rate=2,
+            random_seed=1,
+            start_time=0,
+            end_time=100,
+            keep=False,
+            discrete=False,
         )
         decoded = self.decode(ts.provenance(1).record)
         self.assertEqual(decoded.schema_version, "1.0.0")
@@ -286,13 +292,14 @@ class TestBuildObjects(unittest.TestCase):
         self.assertEqual(decoded.parameters.start_time, 0)
         self.assertEqual(decoded.parameters.end_time, 100)
         self.assertEqual(decoded.parameters.keep, False)
+        self.assertEqual(decoded.parameters.discrete, False)
         self.assertEqual(
             decoded.parameters.model["__class__"], "msprime.mutations.BinaryMutations"
         )
 
     def test_mutate_model(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.mutate(ts, model=msprime.JukesCantor())
+        ts = msprime.mutate(ts, model=msprime.JukesCantor(), discrete=True)
         decoded = self.decode(ts.provenance(1).record)
         self.assertEqual(decoded.schema_version, "1.0.0")
         self.assertEqual(decoded.parameters.command, "mutate")
@@ -303,7 +310,7 @@ class TestBuildObjects(unittest.TestCase):
     def test_mutate_map(self):
         ts = msprime.simulate(5, random_seed=1)
         rate_map = msprime.MutationMap(position=[0, 0.5, 1], rate=[0, 1, 0])
-        ts = msprime.mutate(ts, rate=rate_map)
+        ts = msprime.mutate(ts, rate=rate_map, discrete=False)
         decoded = self.decode(ts.provenance(1).record)
         self.assertEqual(decoded.schema_version, "1.0.0")
         self.assertEqual(decoded.parameters.command, "mutate")
@@ -322,6 +329,7 @@ class TestBuildObjects(unittest.TestCase):
             start_time=np.array([0])[0],
             end_time=np.array([100][0]),
             keep=np.array([False][0]),
+            discrete=np.array([False][0]),
         )
         decoded = self.decode(ts.provenance(1).record)
         self.assertEqual(decoded.schema_version, "1.0.0")
@@ -331,6 +339,7 @@ class TestBuildObjects(unittest.TestCase):
         self.assertEqual(decoded.parameters.start_time, 0)
         self.assertEqual(decoded.parameters.end_time, 100)
         self.assertEqual(decoded.parameters.keep, False)
+        self.assertEqual(decoded.parameters.discrete, False)
 
 
 class TestParseProvenance(unittest.TestCase):
@@ -348,7 +357,7 @@ class TestParseProvenance(unittest.TestCase):
             )
 
     def test_current_ts(self):
-        ts1 = msprime.simulate(5, random_seed=1)
+        ts1 = msprime.simulate(5, length=1000, random_seed=1)
         ts2 = msprime.mutate(ts1)
         command, prov = msprime.provenance.parse_provenance(ts2.provenance(1), ts1)
         self.assertEquals(command, "mutate")
@@ -445,7 +454,13 @@ class TestMutateRoundTrip(TestRoundTrip):
     def test_mutate_round_trip(self):
         ts = msprime.simulate(5, random_seed=1)
         ts = msprime.mutate(
-            ts, rate=2, random_seed=1, start_time=0, end_time=100, keep=False
+            ts,
+            rate=2,
+            random_seed=1,
+            start_time=0,
+            end_time=100,
+            keep=False,
+            discrete=False,
         )
         self.verify(ts)
 

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -905,7 +905,9 @@ class TestErrors(unittest.TestCase):
         for bad_length in [1, 4.99, 5.01, 100]:
             with self.assertRaises(ValueError):
                 msprime.simulate(from_ts=base_ts, start_time=100, length=bad_length)
-            recomb_map = msprime.RecombinationMap.uniform_map(bad_length, 1)
+            recomb_map = msprime.RecombinationMap.uniform_map(
+                bad_length, 1, discrete=False
+            )
             with self.assertRaises(ValueError):
                 msprime.simulate(
                     from_ts=base_ts, start_time=100, recombination_map=recomb_map

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -679,6 +679,11 @@ class TestBaseEquivalanceHudson(BaseEquivalanceMixin, unittest.TestCase):
 class TestBaseEquivalanceWrightFisher(BaseEquivalanceMixin, unittest.TestCase):
     model = msprime.DiscreteTimeWrightFisher()
 
+    @unittest.skip("assertion trip in DTWF")
+    # lib/msprime.c:1729: msp_dtwf_generate_breakpoint: Assertion `k > start' failed.
+    def test_random_recombination_map(self):
+        pass
+
 
 class TestDemography(unittest.TestCase):
     """

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -72,34 +72,64 @@ class TestUncoalescedTreeSequenceProperties(unittest.TestCase):
                     self.assertEqual(ts.node(root).time, root_time)
 
     def test_bug_instance1(self):
-        ts = msprime.simulate(10, recombination_rate=10, end_time=0.5, random_seed=103)
+        ts = msprime.simulate(
+            10,
+            recombination_rate=10,
+            end_time=0.5,
+            random_seed=103,
+            discrete_genome=False,
+        )
         self.verify(ts)
 
     def test_bug_instance2(self):
-        ts = msprime.simulate(10, recombination_rate=10, end_time=1.0, random_seed=61)
+        ts = msprime.simulate(
+            10,
+            recombination_rate=10,
+            end_time=1.0,
+            random_seed=61,
+            discrete_genome=False,
+        )
         self.verify(ts)
 
     def test_large_recombination(self):
-        ts = msprime.simulate(15, recombination_rate=1.0, random_seed=2, end_time=0.25)
+        ts = msprime.simulate(
+            15,
+            recombination_rate=1.0,
+            random_seed=2,
+            end_time=0.25,
+            discrete_genome=False,
+        )
         self.verify(ts)
 
     def test_simple_recombination(self):
-        ts = msprime.simulate(10, recombination_rate=0.1, random_seed=1, end_time=0.5)
+        ts = msprime.simulate(
+            10,
+            recombination_rate=0.1,
+            random_seed=1,
+            end_time=0.5,
+            discrete_genome=False,
+        )
         self.verify(ts)
 
     def test_discrete_loci(self):
         ts = msprime.simulate(
             10,
-            recombination_map=msprime.RecombinationMap.uniform_map(
-                10, 1, discrete=True
-            ),
+            length=10,
+            recombination_rate=1,
+            discrete_genome=True,
             random_seed=1,
             end_time=0.5,
         )
         self.verify(ts)
 
     def test_simple_recombination_time_zero(self):
-        ts = msprime.simulate(10, recombination_rate=0.1, random_seed=4, end_time=0.0)
+        ts = msprime.simulate(
+            10,
+            recombination_rate=0.1,
+            random_seed=4,
+            end_time=0.0,
+            discrete_genome=False,
+        )
         self.verify(ts)
 
     def test_no_recombination(self):
@@ -112,7 +142,13 @@ class TestUncoalescedTreeSequenceProperties(unittest.TestCase):
 
     def test_dtwf_recombination(self):
         ts = msprime.simulate(
-            10, Ne=100, model="dtwf", random_seed=2, end_time=100, recombination_rate=10
+            10,
+            Ne=100,
+            model="dtwf",
+            random_seed=2,
+            end_time=100,
+            recombination_rate=10,
+            discrete_genome=False,
         )
         self.assertGreater(ts.num_trees, 1)
         self.verify(ts)
@@ -195,9 +231,7 @@ class TestBasicFunctionality(unittest.TestCase):
         m = 100
         from_ts = get_wf_base(6, 4, num_loci=m)
         final_ts = msprime.simulate(
-            from_ts=from_ts,
-            random_seed=2,
-            recombination_map=msprime.RecombinationMap.uniform_map(m, 1, discrete=True),
+            from_ts=from_ts, random_seed=2, recombination_rate=1, discrete_genome=True,
         )
         self.verify_from_tables(from_ts, final_ts)
         self.verify_simulation_completed(final_ts)
@@ -206,9 +240,7 @@ class TestBasicFunctionality(unittest.TestCase):
         m = 100
         from_ts = get_wf_base(6, 14, survival=0.25, num_loci=m)
         final_ts = msprime.simulate(
-            from_ts=from_ts,
-            random_seed=2,
-            recombination_map=msprime.RecombinationMap.uniform_map(m, 1, discrete=True),
+            from_ts=from_ts, random_seed=2, recombination_rate=1, discrete_genome=1,
         )
         self.verify_from_tables(from_ts, final_ts)
         self.verify_simulation_completed(final_ts)
@@ -238,35 +270,51 @@ class TestBasicFunctionality(unittest.TestCase):
         self.assertGreater(max(tree.num_roots for tree in from_ts.trees()), 1)
         start_time = from_ts.tables.nodes.time.max()
         final_ts = msprime.simulate(
-            from_ts=from_ts, start_time=start_time, random_seed=2, recombination_rate=2
+            from_ts=from_ts,
+            start_time=start_time,
+            random_seed=2,
+            recombination_rate=2,
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
 
     def test_single_locus_mutations(self):
-        from_ts = msprime.simulate(20, end_time=1, random_seed=5, mutation_rate=5)
+        from_ts = msprime.simulate(
+            20, end_time=1, random_seed=5, mutation_rate=5, discrete_genome=False
+        )
         self.assertGreater(max(tree.num_roots for tree in from_ts.trees()), 1)
         self.assertGreater(from_ts.num_sites, 0)
         start_time = from_ts.tables.nodes.time.max()
         final_ts = msprime.simulate(
-            from_ts=from_ts, start_time=start_time, random_seed=2
+            from_ts=from_ts,
+            start_time=start_time,
+            random_seed=2,
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
 
     def test_decapitated_mutations(self):
-        ts = msprime.simulate(10, random_seed=5, mutation_rate=10)
+        ts = msprime.simulate(
+            10, random_seed=5, mutation_rate=10, discrete_genome=False
+        )
         from_ts = tsutil.decapitate(ts, ts.num_edges // 2)
         self.assertGreater(from_ts.num_mutations, 0)
         start_time = from_ts.tables.nodes.time.max()
         final_ts = msprime.simulate(
-            from_ts=from_ts, start_time=start_time, random_seed=2
+            from_ts=from_ts,
+            start_time=start_time,
+            random_seed=2,
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
 
     def test_from_multi_locus_decapitated(self):
-        ts = msprime.simulate(10, recombination_rate=2, random_seed=5)
+        ts = msprime.simulate(
+            10, recombination_rate=2, discrete_genome=False, random_seed=5
+        )
         self.assertGreater(ts.num_trees, 1)
         from_ts = tsutil.decapitate(ts, ts.num_edges // 2)
         start_time = from_ts.tables.nodes.time.max()
@@ -275,29 +323,37 @@ class TestBasicFunctionality(unittest.TestCase):
             start_time=start_time,
             random_seed=2,
             recombination_rate=0.0001,
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
 
     def test_from_multi_locus_old_recombination(self):
-        ts = msprime.simulate(10, recombination_rate=2, random_seed=5)
+        ts = msprime.simulate(
+            10, recombination_rate=2, random_seed=5, discrete_genome=False
+        )
         self.assertGreater(ts.num_trees, 1)
         from_ts = tsutil.decapitate(ts, ts.num_edges // 2)
         start_time = from_ts.tables.nodes.time.max()
         final_ts = msprime.simulate(
-            from_ts=from_ts, start_time=start_time, random_seed=2, recombination_rate=2
+            from_ts=from_ts,
+            start_time=start_time,
+            random_seed=2,
+            recombination_rate=2,
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
 
     def test_small_num_loci(self):
-        for m in [1, 10, 16, 100]:
-            recombination_map = msprime.RecombinationMap.uniform_map(m, 10 / m)
+        for L in [1, 10, 16, 100]:
             from_ts = msprime.simulate(
                 sample_size=4,
                 end_time=1,
                 random_seed=5,
-                recombination_map=recombination_map,
+                recombination_rate=10 / L,
+                length=L,
+                discrete_genome=True,
             )
             self.assertGreater(max(tree.num_roots for tree in from_ts.trees()), 1)
             start_time = from_ts.tables.nodes.time.max()
@@ -305,7 +361,9 @@ class TestBasicFunctionality(unittest.TestCase):
                 from_ts=from_ts,
                 start_time=start_time,
                 random_seed=2,
-                recombination_map=recombination_map,
+                recombination_rate=10 / L,
+                length=L,
+                discrete_genome=True,
             )
             self.verify_from_tables(from_ts, final_ts, start_time)
             self.verify_simulation_completed(final_ts)
@@ -319,6 +377,7 @@ class TestBasicFunctionality(unittest.TestCase):
                 msprime.PopulationConfiguration(5),
                 msprime.PopulationConfiguration(5),
             ],
+            discrete_genome=False,
             migration_matrix=[[0, 1], [1, 0]],
         )
         self.assertTrue(any(tree.num_roots > 1 for tree in from_ts.trees()))
@@ -334,6 +393,7 @@ class TestBasicFunctionality(unittest.TestCase):
                 msprime.PopulationConfiguration(),
             ],
             migration_matrix=[[0, 1], [1, 0]],
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
@@ -346,6 +406,7 @@ class TestBasicFunctionality(unittest.TestCase):
                 msprime.PopulationConfiguration(5),
                 msprime.PopulationConfiguration(5),
             ],
+            discrete_genome=False,
             migration_matrix=[[0, 1], [1, 0]],
         )
         from_ts = tsutil.decapitate(from_ts, from_ts.num_edges // 3)
@@ -357,6 +418,7 @@ class TestBasicFunctionality(unittest.TestCase):
             start_time=start_time,
             random_seed=2,
             recombination_rate=2,
+            discrete_genome=False,
             population_configurations=[
                 msprime.PopulationConfiguration(),
                 msprime.PopulationConfiguration(),
@@ -377,6 +439,7 @@ class TestBasicFunctionality(unittest.TestCase):
                 samples=[msprime.Sample(0, 0) for _ in range(10)],
                 recombination_rate=2,
                 random_seed=15,
+                discrete_genome=False,
                 population_configurations=population_configurations,
                 migration_matrix=migration_matrix,
             )
@@ -389,6 +452,7 @@ class TestBasicFunctionality(unittest.TestCase):
                 start_time=start_time,
                 random_seed=8,
                 recombination_rate=2,
+                discrete_genome=False,
                 population_configurations=population_configurations,
                 migration_matrix=migration_matrix,
             )
@@ -396,7 +460,9 @@ class TestBasicFunctionality(unittest.TestCase):
             self.verify_simulation_completed(final_ts)
 
     def test_random_seeds_equal_outcome(self):
-        from_ts = msprime.simulate(8, recombination_rate=2, random_seed=5, end_time=1)
+        from_ts = msprime.simulate(
+            8, recombination_rate=2, random_seed=5, end_time=1, discrete_genome=False,
+        )
         self.assertGreater(from_ts.num_trees, 1)
         self.assertTrue(any(tree.num_roots > 1 for tree in from_ts.trees()))
         start_time = from_ts.tables.nodes.time.max()
@@ -407,6 +473,7 @@ class TestBasicFunctionality(unittest.TestCase):
             start_time=start_time,
             random_seed=seed,
             recombination_rate=recombination_rate,
+            discrete_genome=False,
         )
         self.verify_from_tables(from_ts, final_ts, start_time)
         self.verify_simulation_completed(final_ts)
@@ -418,6 +485,7 @@ class TestBasicFunctionality(unittest.TestCase):
                 start_time=start_time,
                 random_seed=seed,
                 recombination_rate=recombination_rate,
+                discrete_genome=False,
             )
             other_tables = other_ts.dump_tables()
             other_tables.provenances.clear()
@@ -435,7 +503,9 @@ class TestBasicFunctionality(unittest.TestCase):
         self.verify_simulation_completed(final_ts)
 
     def test_replicates(self):
-        from_ts = msprime.simulate(15, recombination_rate=2, random_seed=5, end_time=2)
+        from_ts = msprime.simulate(
+            15, recombination_rate=2, random_seed=5, end_time=2, discrete_genome=False
+        )
         self.assertTrue(any(tree.num_roots > 1 for tree in from_ts.trees()))
         self.assertGreater(from_ts.num_trees, 1)
         start_time = from_ts.tables.nodes.time.max()
@@ -445,6 +515,7 @@ class TestBasicFunctionality(unittest.TestCase):
             random_seed=2,
             num_replicates=10,
             recombination_rate=1,
+            discrete_genome=False,
         )
         tables = []
         for final_ts in replicates:
@@ -488,24 +559,31 @@ class TestBasicFunctionality(unittest.TestCase):
         self.verify_simulation_completed(final_ts)
 
     def test_sequence_length_recombination(self):
-        from_ts = msprime.simulate(
-            5, end_time=0.1, random_seed=5, length=5, recombination_rate=5
-        )
-        start_time = from_ts.tables.nodes.time.max()
-        final_ts = msprime.simulate(
-            from_ts=from_ts,
-            start_time=start_time,
-            random_seed=2,
-            length=5,
-            recombination_rate=5,
-        )
-        self.verify_from_tables(from_ts, final_ts, start_time)
-        self.verify_simulation_completed(final_ts)
+        for discrete in [True, False]:
+            from_ts = msprime.simulate(
+                5,
+                end_time=0.1,
+                random_seed=5,
+                length=5,
+                recombination_rate=5,
+                discrete_genome=discrete,
+            )
+            start_time = from_ts.tables.nodes.time.max()
+            final_ts = msprime.simulate(
+                from_ts=from_ts,
+                start_time=start_time,
+                random_seed=2,
+                length=5,
+                recombination_rate=5,
+                discrete_genome=discrete,
+            )
+            self.verify_from_tables(from_ts, final_ts, start_time)
+            self.verify_simulation_completed(final_ts)
 
     def test_nonuniform_recombination_map(self):
         positions = [0, 0.25, 0.5, 0.75, 1]
         rates = [1, 2, 1, 3, 0]
-        recomb_map = msprime.RecombinationMap(positions, rates)
+        recomb_map = msprime.RecombinationMap(positions, rates, discrete=False)
         from_ts = msprime.simulate(
             5, end_time=0.1, random_seed=5, recombination_map=recomb_map
         )
@@ -527,7 +605,9 @@ class TestBasicFunctionality(unittest.TestCase):
         position.sort()
         rate = np.random.random(k)
         rate[-1] = 0
-        recomb_map = msprime.RecombinationMap(list(position), list(rate))
+        recomb_map = msprime.RecombinationMap(
+            list(position), list(rate), discrete=False
+        )
         from_ts = msprime.simulate(
             10, end_time=0.1, random_seed=50, recombination_map=recomb_map
         )
@@ -576,15 +656,14 @@ class BaseEquivalanceMixin:
     """
 
     def verify_simple_model(
-        self, n, seed=1, recombination_rate=None, length=None, recombination_map=None
+        self, n, seed=1, recombination_rate=0, length=1, recombination_map=None
     ):
+        if recombination_map is None:
+            recombination_map = msprime.RecombinationMap.uniform_map(
+                length=length, rate=recombination_rate, discrete=False
+            )
         ts1 = msprime.simulate(
-            n,
-            random_seed=seed,
-            recombination_rate=recombination_rate,
-            length=length,
-            recombination_map=recombination_map,
-            model=self.model,
+            n, random_seed=seed, recombination_map=recombination_map, model=self.model,
         )
         tables = tskit.TableCollection(ts1.sequence_length)
         tables.populations.add_row()
@@ -594,7 +673,6 @@ class BaseEquivalanceMixin:
             from_ts=tables.tree_sequence(),
             start_time=0,
             random_seed=seed,
-            recombination_rate=recombination_rate,
             recombination_map=recombination_map,
             model=self.model,
         )
@@ -636,7 +714,7 @@ class BaseEquivalanceMixin:
         position.sort()
         rate = np.random.random(k)
         rate[-1] = 0
-        recomb_map = msprime.RecombinationMap(list(position), list(rate))
+        recomb_map = msprime.RecombinationMap(position, rate, discrete=False)
         self.verify_simple_model(10, 23, recombination_map=recomb_map)
 
     def test_two_populations_migration(self):
@@ -679,10 +757,11 @@ class TestBaseEquivalanceHudson(BaseEquivalanceMixin, unittest.TestCase):
 class TestBaseEquivalanceWrightFisher(BaseEquivalanceMixin, unittest.TestCase):
     model = msprime.DiscreteTimeWrightFisher()
 
-    @unittest.skip("assertion trip in DTWF")
-    # lib/msprime.c:1729: msp_dtwf_generate_breakpoint: Assertion `k > start' failed.
-    def test_random_recombination_map(self):
-        pass
+
+#     @unittest.skip("assertion trip in DTWF")
+#     # lib/msprime.c:1729: msp_dtwf_generate_breakpoint: Assertion `k > start' failed.
+#     def test_random_recombination_map(self):
+#         pass
 
 
 class TestDemography(unittest.TestCase):
@@ -733,6 +812,7 @@ class TestDemography(unittest.TestCase):
             ],
             migration_matrix=np.zeros((3, 3)),
             recombination_rate=0.5,
+            discrete_genome=False,
             end_time=0.1,
             random_seed=seed,
         )
@@ -745,6 +825,7 @@ class TestDemography(unittest.TestCase):
             migration_matrix=np.zeros((3, 3)),
             from_ts=ts1,
             recombination_rate=0.5,
+            discrete_genome=False,
             demographic_events=[
                 msprime.SimpleBottleneck(time=0.5, population=0, proportion=1.0),
                 msprime.SimpleBottleneck(time=0.5, population=1, proportion=1.0),


### PR DESCRIPTION
See #1116

This is an initial proposal to simulate genomes on discrete coordinates by default. This is a major change from the pre-1.0 semantics, but hopefully it won't break too much. Basically we warn if we think the simulation might be affected significantly. Currently this is just L<1000 and mutation/recombination rate > 0. But, I guess this should really be some function of L * rate > some threshold that makes multiple hits on a single base reasonably likely (we could do the maths on this for the basic coalescent model, but maybe this would be badly wrong in some cases and so worse than a simple rule of thumb).

Basically seems to work. Some stuff is broken, but the warning mostly works. 

Some thoughts:

1.  If we're making discrete the default, then perhaps we should make the parameter ``continuous_genome``? It seems more natural to specify the option this way. We'd also have to update the ``RecombinationMap`` class.
2. It's a bit weird being able to specify discrete/continuous in both simulate and the recombination map. Really, we'd only want to specify ``discrete_genome`` when the recombination_map argument is not provided, since it should be canonical. 

I haven't touched ``mutate`` yet, but presumably we'd do something similar there.