### PR TITLE
Ploidy for multiple merger models

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -515,6 +515,6 @@ void mutgen_print_state(mutgen_t *self, FILE *out);
 
 /* Functions exposed here for unit testing. Not part of public API. */
 int msp_multi_merger_common_ancestor_event(
-    msp_t *self, avl_tree_t *ancestors, avl_tree_t *Q, uint32_t k);
+    msp_t *self, avl_tree_t *ancestors, avl_tree_t *Q, uint32_t k, uint32_t num_pots);
 
 #endif /*__MSPRIME_H__*/

--- a/verification.py
+++ b/verification.py
@@ -1958,9 +1958,9 @@ class XiVsHudsonTest(Test):
             if model != "hudson":
                 model_str = "Xi"
                 # The Xi Dirac coalescent scales differently than the Hudson model.
-                # (Ne² for Dirac and 4Ne for Hudson).
-                # We need NeDirac= square_root(4NeHudson).
-                simulate_args["Ne"] = 2 * (math.sqrt(int(simulate_args["Ne"])))
+                # (Ne² for Dirac and 2Ne for Hudson).
+                # We need NeDirac= square_root(2NeHudson).
+                simulate_args["Ne"] = math.sqrt(2 * int(simulate_args["Ne"]))
             logging.debug(f"Running: {simulate_args}")
             replicates = msprime.simulate(**simulate_args)
             data = collections.defaultdict(list)
@@ -2393,7 +2393,7 @@ class XiGrowth(Test):
 class BetaGrowth(XiGrowth):
     def _run(self, pop_size, alpha, growth_rate, num_replicates=10000):
         logging.debug(f"running Beta growth for {pop_size} {alpha} {growth_rate}")
-        a = 2 / self.compute_beta_timescale(pop_size, alpha)
+        a = 1 / (4 * self.compute_beta_timescale(pop_size, alpha))
         b = growth_rate * (alpha - 1)
         model = (msprime.BetaCoalescent(alpha=alpha, truncation_point=1),)
         name = f"N={pop_size}_alpha={alpha}_growth_rate={growth_rate}"
@@ -2403,7 +2403,7 @@ class BetaGrowth(XiGrowth):
         m = 2 + np.exp(alpha * np.log(2) + (1 - alpha) * np.log(3) - np.log(alpha - 1))
         ret = np.exp(
             alpha * np.log(m)
-            + (alpha - 1) * np.log(pop_size)
+            + (alpha - 1) * np.log(pop_size / 2)
             - np.log(alpha)
             - scipy.special.betaln(2 - alpha, alpha)
         )
@@ -2422,7 +2422,7 @@ class BetaGrowth(XiGrowth):
 class DiracGrowth(XiGrowth):
     def _run(self, pop_size, c, psi, growth_rate, num_replicates=10000):
         logging.debug(f"running Dirac growth for {pop_size} {c} {psi} {growth_rate}")
-        a = 2 * (1 + c * psi * psi / 4) / (pop_size * pop_size)
+        a = (1 + c * psi * psi / 4) / (pop_size * pop_size)
         b = growth_rate
         model = (msprime.DiracCoalescent(psi=psi, c=c),)
         name = f"N={pop_size}_c={c}_psi={psi}_growth_rate={growth_rate}"


### PR DESCRIPTION
This is a proposed infrastructure for k-ploid individuals in multiple merger models. It's a bit more complicated than in the Hudson case because the family structure also plays a role. I've assumed ploidy = 1 means that each individual only has one parent, while ploidy > 1 means two-parent families. I'm sure that is the best thing to do for ploidy = 1 or 2, but am less sure about higher ploidies. Comments are very welcome.

The statistical tests in verification.py are all hard-coded to the diploid case for now. I'll update them once we have a set way to enter arbitrary ploidies as simulation arguments. As far as I could see, that has not been implemented yet, right?

Ping @jeromekelleher, @eldonb, @TPPSellinger