### PR TITLE
Fix DTWF migration bug in #1105

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -67,25 +67,22 @@ However, recombination (with or without recombination maps) and a constant gene 
 rate along the genome can be combined in ``msprime``.
 
 Population structure is modelled by specifying a fixed number of subpopulations
-:math:`d`, and a :math:`d \times d` matrix :math:`M` of per generation migration rates.
-Each element of the matrix :math:`M_{j,k}` defines
-the fraction of population :math:`j` that consists of migrants from
-population :math:`k` in each generation.
-Note that migration rates are specified in a way that makes sense for the
-coalescence process, so that the :math:`(j, k)^{th}` entry of the migration matrix,
-:math:`M_{j, k}`, gives the rate at which an ancestral lineage moves from
-population :math:`j` to population :math:`k` as one follows it back through time.
-In terms of the demographic process of the populations, if a total of
-:math:`n` migrants move from population :math:`k` to
-population :math:`j` per generation, and population :math:`j` has a total of
-:math:`N_{j}` individuals, then the migration matrix has :math:`M_{j,k} = n/N_j`.
-This differs from the migration matrix one usually uses in population
-demography: if :math:`m_{k,j}` is the proportion
-of individuals (in the usual sense; not lineages) in population :math:`k`
-that move to population :math:`j` per generation,
-then translating this proportion of population :math:`k`
-to a proportion of population :math:`j`, we have
-:math:`M_{j,k} = m_{k,j} \times N_k / N_j`.
+:math:`d`, and a :math:`d \times d` matrix :math:`M` of per-generation
+migration rates. The :math:`(j,k)^{th}` entry of :math:`M` is the expected number
+of migrants moving from population :math:`k` to population :math:`j` per
+generation, divided by the size of population :math:`j`. In terms of the
+coalescent process, :math:`M_{j,k}` gives the rate at which an ancestral
+lineage moves from population :math:`j` to population :math:`k`, as one follows
+it back through time. In continuous-time models, when :math:`M_{j,k}` is close
+to zero, this rate is approximately equivalent to the fraction of population :math:`j`
+that is replaced each generation by migrants from population :math:`k`. In
+discrete-time models, the equivalence is exact and each row of :math:`M` has
+the constraint :math:`\sum_{k \neq j} M_{j,k} \leq 1`. This differs from the
+migration matrix one usually uses in population demography: if :math:`m_{k,j}`
+is the proportion of individuals (in the usual sense; not lineages) in
+population :math:`k` that move to population :math:`j` per generation, then
+translating this proportion of population :math:`k` to a proportion of
+population :math:`j`, we have :math:`M_{j,k} = m_{k,j} \times N_k / N_j`.
 
 Each subpopulation has an initial absolute population size :math:`s`
 and a per generation exponential growth rate :math:`\alpha`. The size of a
@@ -269,7 +266,9 @@ To use this option, set the flag ``model="dtwf"`` as in the following example::
     ...     model="dtwf")
 
 
-All other parameters can be set as usual.
+All other parameters can be set as usual. Note that for discrete-time
+Wright-Fisher simulations with population structure, each row of the migration
+matrix must sum to one or less.
 
 .. autoclass:: msprime.DiscreteTimeWrightFisher
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -623,7 +623,8 @@ To fix this, let's add some migration events to the specific demographic history
 Migrations
 **********
 
-With msprime, you can specify continual rates of migrations between populations, as well as one-off mass migrations.
+With msprime, you can specify continual rates of migrations between
+populations, as well as one-off mass migrations.
 
 Constant migration
 ------------------
@@ -632,9 +633,18 @@ Constant migration
    :width: 500px
    :alt: 2 populations with constant migration rate.
 
-Migration rates between the populations can be specified as the elements of an *N* by *N* numpy array, and given to :meth:`msprime.simulate` via the ``migration_matrix`` argument. The diagonal elements of this array must each be 0, and the *(i, j)* th element specifies the fraction of population *i* that consists of new migrants from population *j* in each generation.
+Migration rates between the populations can be specified as the elements of an
+*N* by *N* numpy array, and given to :meth:`msprime.simulate` via the
+``migration_matrix`` argument. The diagonal elements of this array must each be
+0, and the *(i, j)* th element specifies the expected number of migrants moving
+from population *j* to population *i* per generation, divided by the size of
+population *i*.  When this rate is small (close to 0), it is approximately
+equal to the fraction of population *i* that consists of new migrants from
+population *j* in each generation.
 
-For instance, the following migration matrix specifies that in each generation, 5% of population 0 consists of migrants from population 1, and 2% of population 1 consists of migrants from population 0.
+For instance, the following migration matrix specifies that in each generation,
+approximately 5% of population 0 consists of migrants from population 1, and
+approximately 2% of population 1 consists of migrants from population 0.
 
 
 .. code-block:: python
@@ -650,7 +660,9 @@ For instance, the following migration matrix specifies that in each generation, 
             random_seed = 17,
             recombination_rate = 1e-7)
 
-One consequence of specifying :meth:`msprime.PopulationConfiguration` objects is that each of the simulated nodes will now belong to one of our specified populations:
+One consequence of specifying :meth:`msprime.PopulationConfiguration` objects
+is that each of the simulated nodes will now belong to one of our specified
+populations:
 
 .. code-block:: python
 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4468,6 +4468,13 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
             }
             assert(mig_tmp[j] == 0);
 
+            // Must check that row sums of migration matrix are <=1 in the main
+            // loop, as multiple indices can change in the same generation
+            if (sum > 1) {
+                ret = MSP_ERR_DTWF_MIGRATION_MATRIX_NOT_STOCHASTIC;
+                goto out;
+            }
+
             mig_tmp[j] = 1 - sum;
             N = avl_count(&self->populations[j].ancestors[label]);
             gsl_ran_multinomial(self->rng, self->num_populations, N, mig_tmp, n);

--- a/lib/util.c
+++ b/lib/util.c
@@ -232,6 +232,10 @@ msp_strerror_internal(int err)
         case MSP_ERR_BAD_PLOIDY:
             ret = "Ploidy must be at least 1";
             break;
+        case MSP_ERR_DTWF_MIGRATION_MATRIX_NOT_STOCHASTIC:
+            ret = "The row sums of the migration matrix must not exceed one for "
+                  "the discrete time Wright-Fisher model.";
+            break;
         default:
             ret = "Error occurred generating error string. Please file a bug "
                   "report!";

--- a/lib/util.h
+++ b/lib/util.h
@@ -99,6 +99,7 @@
 #define MSP_ERR_BREAKPOINT_MASS_NON_FINITE                          -59
 #define MSP_ERR_BREAKPOINT_RESAMPLE_OVERFLOW                        -60
 #define MSP_ERR_BAD_PLOIDY                                          -61
+#define MSP_ERR_DTWF_MIGRATION_MATRIX_NOT_STOCHASTIC                -62
 
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -499,15 +499,18 @@ def simulate(
         a single population with a sample of size ``sample_size``
         is assumed.
     :type population_configurations: list or None.
-    :param list migration_matrix: The matrix describing the rates
-        of migration between all pairs of populations. If :math:`N`
-        populations are defined in the ``population_configurations``
-        parameter, then the migration matrix must be an
-        :math:`N \\times N` matrix with 0 on the diagonal, consisting of
-        :math:`N` lists of length :math:`N` or an :math:`N \\times N` numpy
-        array, with the [j, k]th element giving the fraction of
-        population j that consists of migrants from population k in each
-        generation.
+    :param list migration_matrix: The matrix describing the rates of migration
+        between all pairs of populations. If :math:`N` populations are defined
+        in the ``population_configurations`` parameter, then the migration
+        matrix must be an :math:`N \\times N` matrix with 0 on the diagonal,
+        consisting of :math:`N` lists of length :math:`N` or an :math:`N
+        \\times N` numpy array. The :math:`[j, k]^{th}` element of the
+        migration matrix gives the expected number of migrants moving from
+        population :math:`k` to population :math:`j` per generation, divided by
+        the size of population :math:`j`.  When simulating from the
+        discrete-time Wright-Fisher model (``model = "dtwf"``), the row sums of
+        the migration matrix must not exceed 1. There are no sum constraints for
+        migration rates in continuous-time models.
     :param list demographic_events: The list of demographic events to
         simulate. Demographic events describe changes to the populations
         in the past. Events should be supplied in non-decreasing


### PR DESCRIPTION
For #1105:
* Because multiple entries of the migration matrix can change in a single generation, the least intrusive place to check the row sum constraint is in `msprime.c::msp_run_dtwf`. It would be nicer to check for validity immediately after parsing demographic events, but I don't see how to do this without doing a 'dry run' through all the migration rate changes/population mergers. However, I could implement this if it's preferred to checking on the fly.
* Definition of migration rates are updated throughout docs/tutorial as per comments in #988
* Fixed invalid migration matrix (invalid for DTWF) in `tests.c::test_demographic_events`
* Added unit test `tests.c::test_dtwf_migration_matrix_not_stochastic`