### PR TITLE
Fix header for C unit tests

### DIFF
--- a/lib/tests/testlib.c
+++ b/lib/tests/testlib.c
@@ -19,6 +19,10 @@
 
 #include "testlib.h"
 
+/* Global variables used for test in state in the test suite */
+char *_tmp_file_name;
+FILE *_devnull;
+
 static int
 msprime_suite_init(void)
 {

--- a/lib/tests/testlib.h
+++ b/lib/tests/testlib.h
@@ -37,8 +37,8 @@
 #define ALPHABET_NUCLEOTIDE 1
 
 /* Global variables used for test in state in the test suite */
-char *_tmp_file_name;
-FILE *_devnull;
+extern char *_tmp_file_name;
+extern FILE *_devnull;
 
 int test_main(CU_TestInfo *tests, int argc, char **argv);
 


### PR DESCRIPTION
Small fix on top of #1139, as per [comment](https://github.com/tskit-dev/msprime/pull/1139#discussion_r475098638) by @gbinux.