### PR TITLE
Add initial benchmarks

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,160 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "msprime",
+
+    // The project's homepage
+    "project_url": "https://github.com/tskit-dev/msprime/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/tskit-dev/msprime/commit",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["2.7", "3.6"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // "matrix": {
+    //     "numpy": ["1.6", "1.7"],
+    //     "six": ["", null],        // test with and without six installed
+    //     "pip+emcee": [""],   // emcee is only available for install with pip.
+    // },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (c) 2018-2020 Tskit Developers
+# Copyright (c) 2015-2018 University of Oxford
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Benchmarks for msprime - use asv to run
+"""
+import msprime
+
+SAMPLE_SIZES = [2]  # , 1000, 10_000, 50_000, 100_000, 200_000]
+DEFAULTS = {
+    "length": 1e6,
+    "Ne": 1000,
+    "recombination_rate": 1e-8,
+    "mutation_rate": 1e-8,
+    "random_seed": 42,
+}
+
+
+class SimulateLength:
+    version = "1"
+    param_names = ["sample_size", "length"]
+    params = [SAMPLE_SIZES, [10, 1e4, 1e5, 5e5, 1e6]]
+
+    def time_simulate_length(self, sample_size, length):
+        msprime.simulate(sample_size, **{**DEFAULTS, "length": length})
+
+
+class SimulateNe:
+    version = "1"
+    param_names = ["sample_size", "Ne"]
+    params = [SAMPLE_SIZES, [1, 1e3, 2.5e3, 5e3, 1e4]]
+
+    def time_simulate_Ne(self, sample_size, Ne):
+        msprime.simulate(sample_size, **{**DEFAULTS, "Ne": Ne})
+
+
+class SimulateRecombination:
+    version = "1"
+    param_names = ["sample_size", "recombination_rate"]
+    params = [SAMPLE_SIZES, [0, 1e-9, 1e-8, 5e-8, 1e-7]]
+
+    def time_simulate_recombination(self, sample_size, recombination_rate):
+        msprime.simulate(
+            sample_size, **{**DEFAULTS, "recombination_rate": recombination_rate}
+        )
+
+
+class SimulateMutation:
+    version = "1"
+    param_names = ["sample_size", "mutation_rate"]
+    params = [SAMPLE_SIZES, [0, 1e-8, 1e-7, 1e-6, 1e-5]]
+
+    def time_simulate_mutation(self, sample_size, mutation_rate):
+        msprime.simulate(sample_size, **{**DEFAULTS, "mutation_rate": mutation_rate})
+
+
+# class MemSuite:
+#     param_names = ['sample_size', 'length']
+#     params = [
+#                 [2, 1e3, 1e6],
+#                 [10, 1e4, 1e6]
+#     ]
+#
+#     def peakmem_simulate(self, sample_size, length):
+#         msprime.simulate(sample_size, length=length, Ne=1000, recombination_rate=2e-8,
+#                          random_seed=42)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -556,6 +556,25 @@ directory.
 Please the comments at the top of the ``verification.py`` script for details
 on how to write and run these tests.
 
+************
+Benchmarking
+************
+
+Benchmarks to measure performance are in the ``benchmarks`` folder and are run using
+`airspeed velocity <https://asv.readthedocs.io/en/stable/index.html>`_. These
+benchmarks can be run locally to compare your branch with the master branch. Your
+changes must be in a commit to be measured. To run the benchmarks::
+
+    asv run HEAD...master~1
+
+This will run the benchmarks for the latest master commit and all commits on
+your current branch (the syntax for choosing commits is the same as ``git log``).
+The following commands then make a browsable report (link given by output of
+the command)::
+
+    asv publish
+    asv preview
+
 
 ****************
 Containerization

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,3 +1,4 @@
+asv
 attrs
 codecov
 coverage


### PR DESCRIPTION
Add initial benchmarks using airspeed velocity. As well as being used for local dev, these can be run when commits are pushed to master to give a running report like https://pv.github.io/numpy-bench/ although this is not setup yet. I've added some basic `simulate`` benchmarks, certainly there are more that could be written.