### PR TITLE
add a test to test_sweeps.c to reproduce the bug in issue 1111

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4736,6 +4736,8 @@ msp_run_sweep(msp_t *self)
         goto out;
     }
 
+    curr_step = 1;
+
     while (msp_get_num_ancestors(self) > 0 && curr_step < num_steps) {
         events++;
         /* Set pop sizes & rec_rates */
@@ -4746,7 +4748,6 @@ msp_run_sweep(msp_t *self)
             rec_rates[j] = recomb_mass;
         }
 
-        curr_step++;
         event_prob = 1.0;
         event_rand = gsl_rng_uniform(self->rng);
         sweep_over = false;
@@ -4754,24 +4755,34 @@ msp_run_sweep(msp_t *self)
             sweep_dt = time[curr_step] - time[curr_step - 1];
             /* using pop sizes grabbed from get_population_size */
             pop_size = get_population_size(&self->populations[0], time[curr_step]);
-            p_coal_B = ((sweep_pop_sizes[1] * (sweep_pop_sizes[1] - 1)))
-                       / allele_frequency[curr_step] * sweep_dt / pop_size;
-            p_coal_b = ((sweep_pop_sizes[0] * (sweep_pop_sizes[0] - 1)))
-                       / (1.0 - allele_frequency[curr_step]) * sweep_dt / pop_size;
+
+            p_coal_B = 0;
+            if (avl_count(&self->populations[0].ancestors[1]) > 1) {
+                p_coal_B = ((sweep_pop_sizes[1] * (sweep_pop_sizes[1] - 1)))
+                           / allele_frequency[curr_step] * sweep_dt / pop_size;
+            }
+            p_coal_b = 0;
+            if (avl_count(&self->populations[0].ancestors[0]) > 1) {
+                p_coal_b = ((sweep_pop_sizes[0] * (sweep_pop_sizes[0] - 1)))
+                           / (1.0 - allele_frequency[curr_step]) * sweep_dt / pop_size;
+            }
             p_rec_b = rec_rates[0] * sweep_dt;
             p_rec_B = rec_rates[1] * sweep_dt;
             sweep_pop_tot_rate = p_coal_b + p_coal_B + p_rec_b + p_rec_B;
             /* doing this to build in generality if we want >1 pop */
+
             total_rate = sweep_pop_tot_rate;
             event_prob *= 1.0 - total_rate;
             curr_step++;
+
             sweep_over = total_rate == 0;
         }
         if (sweep_over) {
             break;
         }
-        /* passed check, choose event */
+
         tmp_rand = gsl_rng_uniform(self->rng);
+
         e_sum = p_coal_b;
         self->time = time[curr_step - 1];
         if (tmp_rand < e_sum / sweep_pop_tot_rate) {

--- a/verification.py
+++ b/verification.py
@@ -999,7 +999,7 @@ class MsmsSweeps(Test):
     def test_neutral_msms_vs_msp(self):
         self._run_msms_vs_msp("100 300 -t 200 -r 200 500000 -N 10000")
 
-    def _test_selective_msms_vs_msp(self):
+    def test_selective_msms_vs_msp(self):
         """
         NOTE:
             This and the following test methods invoke the seletive sweep
@@ -1031,12 +1031,12 @@ class MsmsSweeps(Test):
             " -SF 0 0.9 -Sp 0.5 -SaA 5000 -SAA 10000 -N 10000"
         )
 
-    def _test_selective_msms_vs_msp_small_s(self):
+    def test_selective_msms_vs_msp_small_s(self):
         self._run_msms_vs_msp(
             "100 300 -t 200 -r 200 500000 -SF 0 0.9 -Sp 0.5 -SaA 1 -SAA 2 -N 10000"
         )
 
-    def _test_selective_msms_vs_msp_multiple_sweeps(self):
+    def test_selective_msms_vs_msp_multiple_sweeps(self):
         self._run_msms_vs_msp(
             "100 300 -t 200 -r 200 500000"
             " -SF 0 0.9 -Sp 0.5"


### PR DESCRIPTION
In the test_sweep,c, I set all the input parameters of msp_t  to match those in verficiation.py script captured by running gdb —args /usr/bin/python3 verification.py -c MsmsSweeps (break at msp_run_sweep function and print *self). Then I put the c code in a loop to mimic the num_repeats. Still, I was not able to reproduce the bug. Suggestions? @jeromekelleher 

I tried to simplify this from a list of 3 models `[None, (t_start, temp_model), (None, None)] ` to a single model object `temp_model` (not in this commit) to better match the test function in test_sweeps.c. And `python3 verification.py -c MsmsSweeps` can reproduce the bug but `test_sweeps` can not.

```
        if params["num_sweeps"] > 0:
            model = [None]
            for i in range(params["num_sweeps"]):
                temp_model = msprime.SweepGenicSelection(
                    position=params["sel_pos"],
                    end_frequency=params["end_frequency_lst"][i],
                    start_frequency=0.5 / params["refsize"],  # should be small
                    alpha=params["alpha"],
                    dt=1.0 / (40 * params["refsize"]),  # should be small enough?
                )
                t_start = params["end_time_lst"][i]
                model.append((t_start, temp_model))
            model.append((None, None))
```