### PR TITLE
C structures refactoring : Rename/elim some tsk_id_t typedefs; rename data members

### DIFF
--- a/lib/dev-tools/dev-cli.c
+++ b/lib/dev-tools/dev-cli.c
@@ -118,7 +118,7 @@ read_samples(config_t *config, size_t *num_samples, sample_t **samples)
         if (t == NULL) {
             fatal_error("population not specified");
         }
-        ret_samples[j].population_id = (population_id_t) config_setting_get_int(t);
+        ret_samples[j].population = (population_id_t) config_setting_get_int(t);
         t = config_setting_get_member(s, "time");
         if (t == NULL) {
             fatal_error("population not specified");

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -63,36 +63,30 @@
 #define MSP_PED_STATE_CLIMBING 1
 #define MSP_PED_STATE_CLIMB_COMPLETE 2
 
-/* FIXME: Using these typedefs to keep the diff size small on the initial
- * tskit transition. Can remove later. */
 typedef tsk_id_t population_id_t;
-typedef tsk_id_t node_id_t;
-typedef tsk_id_t mutation_id_t;
-typedef tsk_id_t site_id_t;
 typedef tsk_id_t label_id_t;
 
 typedef struct segment_t_t {
-    /* TODO change to population */
-    population_id_t population_id;
+    population_id_t population;
     label_id_t label;
     /* During simulation we use genetic coordinates */
     double left;
     double right;
     double left_mass;
     double right_mass;
-    node_id_t value;
+    tsk_id_t value;
     size_t id;
     struct segment_t_t *prev;
     struct segment_t_t *next;
 } segment_t;
 
 typedef struct {
-    double left; /* TODO CHANGE THIS - not a good name! */
+    double position;
     uint32_t value;
 } node_mapping_t;
 
 typedef struct {
-    population_id_t population_id;
+    population_id_t population;
     double time;
 } sample_t;
 
@@ -129,8 +123,8 @@ typedef struct {
 
 typedef struct {
     double time;
-    node_id_t sample;
-    population_id_t population_id;
+    tsk_id_t sample;
+    population_id_t population;
 } sampling_event_t;
 
 /* Simulation models */
@@ -157,8 +151,7 @@ typedef struct {
 } genic_selection_trajectory_t;
 
 typedef struct _sweep_t {
-    /* TODO change the name of this to position */
-    double locus;
+    double position;
     union {
         /* Future trajectory simulation models would go here */
         genic_selection_trajectory_t genic_selection_trajectory;
@@ -262,7 +255,7 @@ typedef struct _msp_t {
 
 /* Demographic events */
 typedef struct {
-    population_id_t population_id;
+    population_id_t population;
     double initial_size;
     double growth_rate;
 } population_parameters_change_t;
@@ -279,12 +272,12 @@ typedef struct {
 } mass_migration_t;
 
 typedef struct {
-    population_id_t population_id;
+    population_id_t population;
     double proportion;
 } simple_bottleneck_t;
 
 typedef struct {
-    population_id_t population_id;
+    population_id_t population;
     double strength;
 } instantaneous_bottleneck_t;
 

--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -949,7 +949,7 @@ out:
 
 static int
 mutgen_add_mutation(
-    mutgen_t *self, site_t *site, node_id_t node, double time, mutation_t **new_mutation)
+    mutgen_t *self, site_t *site, tsk_id_t node, double time, mutation_t **new_mutation)
 {
     int ret = 0;
 
@@ -970,14 +970,14 @@ out:
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_new_mutation(mutgen_t *self, site_t *site, node_id_t node, double time)
+mutgen_add_new_mutation(mutgen_t *self, site_t *site, tsk_id_t node, double time)
 {
     mutation_t *not_used;
     return mutgen_add_mutation(self, site, node, time, &not_used);
 }
 
 static int MSP_WARN_UNUSED
-mutgen_add_existing_mutation(mutgen_t *self, site_t *site, tsk_id_t id, node_id_t node,
+mutgen_add_existing_mutation(mutgen_t *self, site_t *site, tsk_id_t id, tsk_id_t node,
     double time, char *derived_state, tsk_size_t derived_state_length, char *metadata,
     tsk_size_t metadata_length)
 {
@@ -1019,7 +1019,7 @@ mutgen_initialise_sites(mutgen_t *self)
     tsk_size_t j, length, metadata_length;
 
     j = 0;
-    for (site_id = 0; site_id < (site_id_t) sites->num_rows; site_id++) {
+    for (site_id = 0; site_id < (tsk_id_t) sites->num_rows; site_id++) {
         state = sites->ancestral_state + sites->ancestral_state_offset[site_id];
         length = sites->ancestral_state_offset[site_id + 1]
                  - sites->ancestral_state_offset[site_id];
@@ -1127,7 +1127,7 @@ mutgen_place_mutations(mutgen_t *self, bool discrete_sites)
     double left, right, site_left, site_right, edge_right;
     double time, mu, position;
     double branch_start, branch_end, branch_length;
-    node_id_t parent, child;
+    tsk_id_t parent, child;
     avl_node_t *avl_node;
     site_t *site;
     site_t search;
@@ -1137,7 +1137,7 @@ mutgen_place_mutations(mutgen_t *self, bool discrete_sites)
         edge_right = edges.right[j];
         parent = edges.parent[j];
         child = edges.child[j];
-        assert(child >= 0 && child < (node_id_t) nodes.num_rows);
+        assert(child >= 0 && child < (tsk_id_t) nodes.num_rows);
         branch_start = GSL_MAX(start_time, nodes.time[child]);
         branch_end = GSL_MIN(end_time, nodes.time[parent]);
         branch_length = branch_end - branch_start;

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -27,7 +27,7 @@ verify_simulator_tsk_treeseq_equality(msp_t *msp, tsk_treeseq_t *tree_seq, doubl
     uint32_t j;
     tsk_node_t node;
     sample_t *samples;
-    node_id_t *sample_ids;
+    tsk_id_t *sample_ids;
 
     CU_ASSERT_EQUAL_FATAL(
         tsk_treeseq_get_num_samples(tree_seq), msp_get_num_samples(msp));
@@ -43,7 +43,7 @@ verify_simulator_tsk_treeseq_equality(msp_t *msp, tsk_treeseq_t *tree_seq, doubl
     for (j = 0; j < num_samples; j++) {
         ret = tsk_treeseq_get_node(tree_seq, j, &node);
         CU_ASSERT_EQUAL(ret, 0);
-        CU_ASSERT_EQUAL(node.population, samples[j].population_id);
+        CU_ASSERT_EQUAL(node.population, samples[j].population);
         CU_ASSERT_EQUAL(node.time, samples[j].time);
     }
     /* Samples should always be 0..n - 1 here for simulations */
@@ -974,7 +974,7 @@ test_dtwf_events_between_generations(void)
 
     for (j = 0; j < n; j++) {
         samples[j].time = 0;
-        samples[j].population_id = j % 2;
+        samples[j].population = j % 2;
     }
 
     CU_ASSERT_FATAL(samples != NULL);
@@ -1058,7 +1058,7 @@ test_dtwf_unsupported_bottleneck(void)
 
     for (j = 0; j < n; j++) {
         samples[j].time = 0;
-        samples[j].population_id = 0;
+        samples[j].population = 0;
     }
     tables.sequence_length = 1.0;
     ret = msp_alloc(&msp, n, samples, &tables, rng);
@@ -1862,7 +1862,7 @@ test_simulator_getters_setters(void)
     tables.sequence_length = m;
     for (j = 0; j < n; j++) {
         samples[j].time = j;
-        samples[j].population_id = j % 2;
+        samples[j].population = j % 2;
     }
     CU_ASSERT_EQUAL(msp_alloc(&msp, 0, NULL, NULL, rng), MSP_ERR_BAD_PARAM_VALUE);
     msp_free(&msp);
@@ -2003,7 +2003,7 @@ test_demographic_events(void)
     for (model = 0; model < 2; model++) {
         for (j = 0; j < n; j++) {
             samples[j].time = j;
-            samples[j].population_id = j % 2;
+            samples[j].population = j % 2;
         }
 
         tsk_table_collection_clear(&tables);

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -203,7 +203,7 @@ parse_samples(PyObject *py_samples, Py_ssize_t num_populations,
                 (int) tmp_long, (int) j);
             goto out;
         }
-        ret_samples[j].population_id = (population_id_t) tmp_long;
+        ret_samples[j].population = (population_id_t) tmp_long;
         value = PyTuple_GetItem(sample, 1);
         if (!PyNumber_Check(value)) {
             PyErr_Format(PyExc_TypeError, "'time' is not number");
@@ -3569,7 +3569,7 @@ Simulator_get_model(Simulator *self, void *closure)
         Py_DECREF(value);
         value = NULL;
     } else if (model->type == MSP_MODEL_SWEEP) {
-        value = Py_BuildValue("d", model->params.sweep.locus);
+        value = Py_BuildValue("d", model->params.sweep.position);
         if (value == NULL) {
             goto out;
         }
@@ -3967,7 +3967,7 @@ Simulator_individual_to_python(Simulator *self, segment_t *ind)
     j = 0;
     while (u != NULL) {
         t = Py_BuildValue("(d,d,I,I)", u->left, u->right, u->value,
-                u->population_id);
+                u->population);
         if (t == NULL) {
             Py_DECREF(l);
             goto out;
@@ -4182,8 +4182,8 @@ Simulator_get_samples(Simulator *self, void *closure)
         goto out;
     }
     for (j = 0; j < num_samples; j++) {
-        population = samples[j].population_id == TSK_NULL? -1:
-            samples[j].population_id;
+        population = samples[j].population == TSK_NULL? -1:
+            samples[j].population;
         t = Py_BuildValue("id", population, samples[j].time);
         if (t == NULL) {
             goto out;

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -1,6 +1,7 @@
 setuptools_scm
 sphinx-argparse
 sphinx-issues
+sphinx_rtd_theme
 attrs
 tskit>=0.3
 newick


### PR DESCRIPTION
Closes #1121

  - rename/elim typedefs:
    - population_id_t
    - label_id_t
    - node_id_t
    - mutation_id_t
    - site_id_t
  - rename some struct data members:
    - tsk_id_t *.population_id -> *.population
    - node_mapping_t.left -> node_mapping_t.position.
    - sweep_t.locus -> sweep_t.position

Also:
Closes #1145