### PR TITLE
Multiple merger docs + timescale

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1960,23 +1960,23 @@ Multiple merger coalescents
 ***************************
 
 ``msprime`` can simulate several multiple merger coalescent models,
-in which any number of lineages can coalesce in up to four simultaneous
-mergers. These can often be appropriate models when the distribution of
+in which any number of lineages can coalesce in a number of simultaneous
+mergers. These models are often appropriate when the distribution of
 offspring numbers among individuals in the population is highly skewed.
-Provided are the classes of Beta-Xi-coalescents and Dirac-Xi-coalescents.
+The two provided models are the Beta-coalescent and the Dirac-coalescent.
 
-The Beta-Xi-coalescent can be simulated as follows:
+The diploid Beta-Xi-coalescent can be simulated as follows:
 
 .. code-block:: python
 
     def beta_multiple_merger_example():
-        ts = msprime.simulate(
-            sample_size=10, random_seed=1,
+        ts = msprime.sim_ancestry(
+            sample_size=5, ploidy=2, random_seed=1,
             model=msprime.BetaCoalescent(alpha=1.001, truncation_point=1))
         tree = ts.first()
         print(tree.draw(format="unicode"))
 
-Running this code we get::
+Running this code, we get::
 
          16
      ┏━━━━┻━━━┓
@@ -2000,13 +2000,13 @@ no multiple mergers for small sample sizes:
 .. code-block:: python
 
     def beta_few_multiple_mergers_example():
-        ts = msprime.simulate(
-            sample_size=10, random_seed=1,
+        ts = msprime.sim_ancestry(
+            sample_size=5, ploidy=2, random_seed=1,
             model=msprime.BetaCoalescent(alpha=1.8, truncation_point=1))
         tree = ts.first()
         print(tree.draw(format="unicode"))
 
-Running this code we get::
+Running this code, we get::
 
          18
       ┏━━━┻━━━┓
@@ -2028,15 +2028,44 @@ Running this code we get::
     ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┏┻┓
     5 2 3 7 8 0 6 9 1 4
 
-The timescale of the Beta-Xi-coalescent depends nonlinearly on both :math:`\alpha`
+Multiple mergers still take place in a haploid simulaton, but only one merger
+can take place at a given time:
+
+.. code-block:: python
+
+    def beta_haploid_multiple_merger_example():
+        ts = msprime.sim_ancestry(
+            sample_size=10, ploidy=1, random_seed=1,
+            model=msprime.BetaCoalescent(alpha=1.001, truncation_point=1))
+        tree = ts.first()
+        print(tree.draw(format="unicode"))
+
+Running this code, we get::
+
+       14
+    ┏━┳━┻━━━┓
+    ┃ ┃    13
+    ┃ ┃ ┏━━━┻━━━┓
+    ┃ ┃ ┃      12
+    ┃ ┃ ┃ ┏━┳━━━╋━━━━┓
+    ┃ ┃ ┃ ┃ ┃   ┃   11
+    ┃ ┃ ┃ ┃ ┃   ┃   ┏┻┓
+    ┃ ┃ ┃ ┃ ┃  10   ┃ ┃
+    ┃ ┃ ┃ ┃ ┃ ┏━╋━┓ ┃ ┃
+    1 2 0 5 7 3 4 9 6 8
+
+A haploid simulation results in larger individual mergers than a polyploid simulation
+because large mergers typically get broken up into multiple simultaneous mergers
+in the polyploid model.
+
+The timescale of the Beta-coalescent depends nonlinearly on both :math:`\alpha`
 and the effective population size :math:`N_e` as detailed in
 :ref:`sec_api_simulation_models_multiple_mergers`. For a fixed :math:`\alpha`,
-a unit of coalescent time is proportional to :math:`N_e^{\alpha - 1}` generations,
-albeit with a complicated constant of proportionality that depends on :math:`\alpha`.
-The dependence on :math:`\alpha` for fixed :math:`N_e` is not monotone.
-Since two lineages merge in 0.5 units of coalescent time on average regadless of
-:math:`N_e` and :math:`\alpha`, the time to their most recent common ancestor depends
-on both of these parameters when measured in generations.
+the number of generations between common ancestor events is proportional to
+:math:`N_e^{\alpha - 1}`, albeit with a complicated constant of proportionality
+that depends on :math:`\alpha`. The dependence on :math:`\alpha` for fixed :math:`N_e`
+is not monotone. Thus, both branch lengths and the number of generations until a
+most recent common ancestor depend on both of these parameters.
 
 To illustrate, for :math:`\alpha` close to 2 the relationship between effective
 population size and number of generations is almost linear:
@@ -2044,74 +2073,98 @@ population size and number of generations is almost linear:
 .. code-block:: python
 
     def beta_high_scaling_example():
-        ts = msprime.simulate(
-            sample_size=2, random_seed=1, Ne=10,
+        ts = msprime.sim_ancestry(
+            sample_size=1, ploidy=2, random_seed=1, population_size=10,
             model=msprime.BetaCoalescent(alpha=1.99, truncation_point=1))
         tree = ts.first()
         print(tree.tmrca(0,1))
-        ts = msprime.simulate(
-            sample_size=2, random_seed=1, Ne=1000,
+        ts = msprime.sim_ancestry(
+            sample_size=1, ploidy=2, random_seed=1, population_size=1000,
             model=msprime.BetaCoalescent(alpha=1.99, truncation_point=1))
         tree = ts.first()
         print(tree.tmrca(0,1))
 
 which results in::
 
-    0.03714089444719166
-    3.546927883527276
+    0.14959691919068155
+    14.286394871874865
 
 For :math:`\alpha` close to 1 the effective population size has little effect:
 
 .. code-block:: python
 
     def beta_low_scaling_example():
-        ts = msprime.simulate(
-            sample_size=2, random_seed=1, Ne=10,
+        ts = msprime.sim_ancestry(
+            sample_size=1, ploidy=2, random_seed=1, population_size=10,
             model=msprime.BetaCoalescent(alpha=1.1, truncation_point=1))
         tree = ts.first()
         print(tree.tmrca(0,1))
-        ts = msprime.simulate(
-            sample_size=2, random_seed=1, Ne=1000,
+        ts = msprime.sim_ancestry(
+            sample_size=1, ploidy=2, random_seed=1, population_size=1000,
             model=msprime.BetaCoalescent(alpha=1.1, truncation_point=1))
         tree = ts.first()
         print(tree.tmrca(0,1))
 
 which gives::
 
-    2.185320238451494
-    3.4634991692692694
+    16.311807036386615
+    25.85247192870844
 
-The Dirac-Xi-coalescent is simulated similarly:
+The Dirac-coalescent is simulated similarly in both the diploid case:
 
 .. code-block:: python
 
     def dirac_multiple_merger_example():
-        ts = msprime.simulate(
-            sample_size=10, random_seed=1,
+        ts = msprime.sim_ancestry(
+            sample_size=5, ploidy=2, random_seed=1,
             model=msprime.DiracCoalescent(psi=0.9, c=10))
         tree = ts.first()
         print(tree.draw(format="unicode"))
 
 which gives::
 
-           14
-       ┏━━━━┻━━━┓
-       ┃       13
-       ┃      ┏━┻━━┓
-      12      ┃    ┃
-    ┏━┳┻━━┓   ┃    ┃
-    ┃ ┃  11   ┃   10
-    ┃ ┃ ┏━╋━┓ ┃ ┏━┳┻┳━┓
-    2 6 3 4 8 1 0 5 7 9
+       15
+     ┏━━┻━━━┓
+     ┃     14
+     ┃  ┏━━━┻━━━┓
+     ┃  ┃      13
+     ┃  ┃    ┏━━┻━━━┓
+    12  ┃    ┃      ┃
+    ┏┻┓ ┃    ┃      ┃
+    ┃ ┃ ┃   10     11
+    ┃ ┃ ┃ ┏━┳┻┳━┓ ┏━╋━┓
+    1 2 6 0 5 7 9 3 4 8
 
-Larger values of the parameter :math:`c > 0` result in more frequent multiple
-mergers, while larger values of :math:`0 < \psi \leq 1` result in multiple mergers
+and in the haploid case:
+
+.. code-block:: python
+
+    def dirac_haploid_multiple_merger_example():
+        ts = msprime.sim_ancestry(
+            sample_size=10, ploidy=1, random_seed=1,
+            model=msprime.DiracCoalescent(psi=0.9, c=10))
+        tree = ts.first()
+        print(tree.draw(format="unicode"))
+
+which gives::
+
+        11
+    ┏━━━━┻━━━━┓
+    ┃        10
+    ┃ ┏━┳━┳━┳━╋━┳━┳━┳━┓
+    1 0 2 3 4 5 6 7 8 9
+
+As with the Beta-coalescent, a haploid simulation results in larger individual
+mergers than a polyploid simulation because large mergers typically get broken
+up into multiple simultaneous mergers in the polyploid model. Larger values
+of the parameter :math:`c > 0` result in more frequent multiple mergers,
+while larger values of :math:`0 < \psi \leq 1` result in multiple mergers
 with more participating lineages. Setting either parameter to 0 would correspond
 to the standard coalescent.
 
-The Dirac-Xi-coalescent is obtained as the infinite population scaling limit of
-Moran models, and therefore the coalescence rate is proportional to
-:math:`1/N_e^2` generations.
+The Dirac-coalescent is obtained as the infinite population scaling limit of
+Moran models, and therefore branch lengths are proportional to :math:`N_e^2`
+generations, as opposed to :math:`N_e` generations under the standard coalescent.
 
 *********
 Old stuff

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2058,14 +2058,14 @@ A haploid simulation results in larger individual mergers than a polyploid simul
 because large mergers typically get broken up into multiple simultaneous mergers
 in the polyploid model.
 
-The timescale of the Beta-coalescent depends nonlinearly on both :math:`\alpha`
-and the effective population size :math:`N_e` as detailed in
-:ref:`sec_api_simulation_models_multiple_mergers`. For a fixed :math:`\alpha`,
-the number of generations between common ancestor events is proportional to
-:math:`N_e^{\alpha - 1}`, albeit with a complicated constant of proportionality
-that depends on :math:`\alpha`. The dependence on :math:`\alpha` for fixed :math:`N_e`
-is not monotone. Thus, both branch lengths and the number of generations until a
-most recent common ancestor depend on both of these parameters.
+The number of generations between merger events in the Beta-coalescent depends
+nonlinearly on both :math:`\alpha` and the effective population size :math:`N_e`
+as detailed in :ref:`sec_api_simulation_models_multiple_mergers`.
+For a fixed :math:`\alpha`, the number of generations between common ancestor events
+is proportional to :math:`N_e^{\alpha - 1}`, albeit with a complicated constant of
+proportionality that depends on :math:`\alpha`. The dependence on :math:`\alpha`
+for fixed :math:`N_e` is not monotone. Thus, branch lengths and the number of
+generations until a most recent common ancestor depend on both of these parameters.
 
 To illustrate, for :math:`\alpha` close to 2 the relationship between effective
 population size and number of generations is almost linear:

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -6179,13 +6179,14 @@ beta_compute_timescale(msp_t *self, population_t *pop)
 {
     double alpha = self->model.params.beta_coalescent.alpha;
     double truncation_point = self->model.params.beta_coalescent.truncation_point;
-    double m = 2 + exp(alpha * log(2) + (1 - alpha) * log(3) - log(alpha - 1));
+    double m = 1 + exp(alpha * log(2) + (1 - alpha) * log(3) - log(alpha - 1));
     double pop_size = pop->initial_size;
     /* For ploidy > 1 we assume N/2 two-parent families, so that the rate
      * with which 2 lineages belong to a common family is based on "population size"
      * N/2 */
     if (self->ploidy > 1) {
         pop_size /= 2.0;
+        m += 1.0;
     }
     double timescale = exp(alpha * log(m) + (alpha - 1) * log(pop_size) - log(alpha)
                            - gsl_sf_lnbeta(2 - alpha, alpha)

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1205,12 +1205,13 @@ class BetaCoalescent(ParametricSimulationModel):
     two lineages undergo a common ancestor event is
 
     .. math::
-        \\frac{m^{\\alpha} N_e^{\\alpha - 1}}{\\alpha B(2 - \\alpha, \\alpha)},
+        G = \\frac{m^{\\alpha} N_e^{\\alpha - 1}}{\\alpha B(2 - \\alpha, \\alpha)},
 
     if ploidy = 1, and
 
     .. math::
-        \\frac{m^{\\alpha} (N_e / 2)^{\\alpha - 1}}{2 p \\alpha B(2 - \\alpha, \\alpha)},
+        G = \\frac{m^{\\alpha} (N_e / 2)^{\\alpha - 1}}
+            {2 p \\alpha B(2 - \\alpha, \\alpha)},
 
     if ploidy = :math:`p > 1`, where :math:`m` is the mean number of juveniles per
     family, and is given by
@@ -1225,13 +1226,14 @@ class BetaCoalescent(ParametricSimulationModel):
     two-parent families in which reproduction takes place.
 
     .. warning::
-        The time scale depends both on the effective population size :math:`N_e`
-        and :math:`\\alpha`, and can be dramatically shorter than that of the
+        The number of generations between common ancestor events :math:`G` depends
+        both on the effective population size :math:`N_e` and :math:`\\alpha`,
+        and can be dramatically shorter than in the case of the
         standard coalescent. For :math:`\\alpha \\approx 1` that is due to
-        insensitivity of the time scale to :math:`N_e` --- see
+        insensitivity of :math:`G` to :math:`N_e` --- see
         :ref:`sec_api_simulation_models_multiple_mergers` for an illustration.
-        For :math:`\\alpha \\approx 2` the time scale is almost linear in
-        :math:`N_e`, but can nevertheless be short because
+        For :math:`\\alpha \\approx 2`, :math:`G` is almost linear in
+        :math:`N_e`, but can nevertheless be small because
         :math:`B(2 - \\alpha, \\alpha) \\rightarrow \\infty` as
         :math:`\\alpha \\rightarrow 2`. As a result, effective population sizes
         must often be many orders of magnitude larger than census population sizes
@@ -1239,7 +1241,8 @@ class BetaCoalescent(ParametricSimulationModel):
 
     See `Schweinsberg (2003)
     <https://www.sciencedirect.com/science/article/pii/S0304414903000280>`_
-    for the derivation of the common ancestor event rate, as well as the time scaling.
+    for the derivation of the common ancestor event rate,
+    as well as the number of generations between common ancestor events.
     Note however that Schweinsberg (2003) only covers the haploid case.
     For details of the diploid extension, see
     `Blath et al. (2013) <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3527250/>`_.
@@ -1259,7 +1262,7 @@ class BetaCoalescent(ParametricSimulationModel):
         participating in a common ancestor event is determined by moments
         of the Beta:math:`(2 - \\alpha, \\alpha)` distribution conditioned on not
         exceeding :math:`\\tau`, and the Beta-function in the expression
-        for the time scale is also replaced by the incomplete Beta-function
+        for :math:`G` is also replaced by the incomplete Beta-function
         :math:`B(\\tau; 2 - \\alpha, \\alpha)`.
     """
 

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1177,10 +1177,10 @@ class ParametricSimulationModel(SimulationModel):
 @attr.s
 class BetaCoalescent(ParametricSimulationModel):
     """
-    A diploid Xi-coalescent with up to four simultaneous multiple mergers and
-    crossover recombination.
+    A Lambda-coalescent with multiple mergers in the haploid cases, or a
+    Xi-coalescent with simultaneous multiple mergers in the polyploid case.
 
-    There are two main differences between the Beta-Xi-coalescent and the
+    There are two main differences between the Beta-coalescent and the
     standard coalescent. Firstly, the number of lineages that take part in each
     common ancestor event is random, with distribution determined by moments of
     the :math:`Beta(2 - \\alpha, \\alpha)`-distribution. In particular, when there
@@ -1188,35 +1188,41 @@ class BetaCoalescent(ParametricSimulationModel):
     common ancestor event at rate
 
     .. math::
-        \\frac{8}{B(2 - \\alpha, \\alpha)}
+        \\frac{1}{B(2 - \\alpha, \\alpha)}
         \\int_0^1 x^{k - \\alpha - 1} (1 - x)^{n - k + \\alpha - 1} dx,
 
     where :math:`B(2 - \\alpha, \\alpha)` is the Beta-function.
 
-    In a common ancestor event, all participating lineages are randomly split
-    into four groups, corresponding to the four parental chromosomes in a diploid,
-    bi-parental reproduction event. All lineages within each group merge simultaneously.
+    If ploidy = 1, then all participating lineages merge into one common ancestor,
+    corresponding to haploid, single-parent reproduction.
+    If ploidy = :math:`p > 1`, all participating lineages split randomly into
+    :math:`2 p` groups, corresponding to two-parent reproduction with :math:`p` copies
+    of each chromosome per parent. All lineages within each group merge simultaneously.
 
-    .. warning::
-        The prefactor of 8 in the common ancestor event rate arises as the product
-        of two terms. A factor of 4 compensates for the fact that only one quarter
-        of binary common ancestor events result in a merger due to diploidy.
-        A further factor of 2 is included for consistency with the implementation
-        of the Hudson model, in which :math:`n` lineages undergo binary mergers at
-        rate :math:`n (n - 1)`.
-
-    Secondly, the time scale predicted by the Beta-Xi-coalescent is proportional
-    to :math:`N_e^{\\alpha - 1}` generations, where :math:`N_e` is the effective
-    population size. Specifically, one unit of coalescent time corresponds to
-    a number of generations given by
+    Secondly, the number of generations between common ancestor events predicted by the
+    Beta-coalescent is proportional to :math:`N_e^{\\alpha - 1}`, where :math:`N_e` is
+    the effective population size. Specifically, the mean number of generations until
+    two lineages undergo a common ancestor event is
 
     .. math::
         \\frac{m^{\\alpha} N_e^{\\alpha - 1}}{\\alpha B(2 - \\alpha, \\alpha)},
 
-    where
+    if ploidy = 1, and
 
     .. math::
-        m = 2 + \\frac{2^{\\alpha}}{3^{\\alpha - 1} (\\alpha - 1)}.
+        \\frac{m^{\\alpha} (N_e / 2)^{\\alpha - 1}}{2 p \\alpha B(2 - \\alpha, \\alpha)},
+
+    if ploidy = :math:`p > 1`, where :math:`m` is the mean number of juveniles per
+    family, and is given by
+
+    .. math::
+        m = q + \\frac{2^{\\alpha}}{3^{\\alpha - 1} (\\alpha - 1)},
+
+    where :math:`q = 1` ploidy = 1, and :math:`q = 2` if ploidy > 1.
+
+    In the polyploid case we divide the effective population size :math:`N_e` by two
+    because we assume the :math:`N_e` polyploid individuals form :math:`N_e / 2`
+    two-parent families in which reproduction takes place.
 
     .. warning::
         The time scale depends both on the effective population size :math:`N_e`
@@ -1224,8 +1230,8 @@ class BetaCoalescent(ParametricSimulationModel):
         standard coalescent. For :math:`\\alpha \\approx 1` that is due to
         insensitivity of the time scale to :math:`N_e` --- see
         :ref:`sec_api_simulation_models_multiple_mergers` for an illustration.
-        For :math:`\\alpha \\approx 2` the time scale is short despite depending on
-        :math:`N_e` almost linearly, matching the standard coalescent, because
+        For :math:`\\alpha \\approx 2` the time scale is almost linear in
+        :math:`N_e`, but can nevertheless be short because
         :math:`B(2 - \\alpha, \\alpha) \\rightarrow \\infty` as
         :math:`\\alpha \\rightarrow 2`. As a result, effective population sizes
         must often be many orders of magnitude larger than census population sizes
@@ -1234,9 +1240,12 @@ class BetaCoalescent(ParametricSimulationModel):
     See `Schweinsberg (2003)
     <https://www.sciencedirect.com/science/article/pii/S0304414903000280>`_
     for the derivation of the common ancestor event rate, as well as the time scaling.
-    Note however that the model of Schweinsberg (2003) is haploid, so that
-    all participating lineages merge in a common ancestor event without
-    splitting into four groups.
+    Note however that Schweinsberg (2003) only covers the haploid case.
+    For details of the diploid extension, see
+    `Blath et al. (2013) <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3527250/>`_.
+    The general polyploid model is analogous to the diploid case, with
+    :math:`2 p` available copies of parental chromsomes per common ancestor event,
+    and hence up to :math:`2 p` simultaneous mergers.
 
     :param float alpha: Determines the degree of skewness in the family size
         distribution, and must satisfy :math:`1 < \\alpha < 2`. Smaller values of
@@ -1246,12 +1255,12 @@ class BetaCoalescent(ParametricSimulationModel):
         population replaced by offspring in one reproduction event, and must
         satisfy :math:`0 < \\tau \\leq 1`, where :math:`\\tau` is the truncation point.
         The default is :math:`\\tau = 1`, which corresponds to the standard
-        Beta-Xi-coalescent. When :math:`\\tau < 1`, the number of lineages
+        Beta-coalescent. When :math:`\\tau < 1`, the number of lineages
         participating in a common ancestor event is determined by moments
-        of the :math:`Beta(2 - \\alpha, \\alpha)` distribution conditioned on not
+        of the Beta:math:`(2 - \\alpha, \\alpha)` distribution conditioned on not
         exceeding :math:`\\tau`, and the Beta-function in the expression
-        for the time scale is also replaced by the incomplete Beta function
-        :math:`Beta(\\tau; 2 - \\alpha, \\alpha)`.
+        for the time scale is also replaced by the incomplete Beta-function
+        :math:`B(\\tau; 2 - \\alpha, \\alpha)`.
     """
 
     name = "beta"
@@ -1263,29 +1272,30 @@ class BetaCoalescent(ParametricSimulationModel):
 @attr.s
 class DiracCoalescent(ParametricSimulationModel):
     """
-    A diploid Xi-coalescent with up to four simultaneous multiple mergers and
-    crossover recombination.
+    A Lambda-coalescent with multiple mergers in the haploid cases, or a
+    Xi-coalescent with simultaneous multiple mergers in the polyploid case.
 
-    The Dirac-Xi-coalescent is an implementation of the model of
+    The Dirac-coalescent is an implementation of the model of
     `Blath et al. (2013) <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3527250/>`_
     The simulation proceeds similarly to the standard coalescent.
-    In addition to binary common ancestor events at rate :math:`n (n - 1)` when
+    In addition to binary common ancestor events at rate :math:`n (n - 1) / 2` when
     there are :math:`n` lineages, potential multiple merger events take place
-    at rate :math:`2 c > 0`. Each lineage participates in each multiple merger
-    event independently with probability :math:`0 < \\psi \\leq 1`. All participating
-    lineages are randomly split into four groups, corresponding to the four
-    parental chromosomes present in a diploid, bi-parental reproduction event,
-    and the lineages within each group merge simultaneously.
+    at rate :math:`c > 0`. Each lineage participates in each multiple merger
+    event independently with probability :math:`0 < \\psi \\leq 1`.
+
+    If ploidy = 1, then all participating lineages merge into one common ancestor,
+    corresponding to haploid, single-parent reproduction.
+    If ploidy = :math:`p > 1`, all participating lineages split randomly into
+    :math:`2 p` groups, corresponding to two-parent reproduction with :math:`p` copies
+    of each chromosome per parent. All lineages within each group merge simultaneously.
 
     .. warning::
-        The Dirac-Xi-coalescent is obtained as a scaling limit of Moran models,
-        rather than Wright-Fisher models. As a consequence, one unit of coalescent
-        time is proportional to :math:`N_e^2` generations,
+        The Dirac-coalescent is obtained as a scaling limit of Moran models,
+        rather than Wright-Fisher models. As a consequence, the number of generations
+        between coalescence events is proportional to :math:`N_e^2`,
         rather than :math:`N_e` generations as in the standard coalescent.
-        However, the coalescent recombination rate is obtained from the
-        per-generation recombination probability by rescaling with
-        :math:`N_e`. See :ref:`sec_tutorial_multiple_mergers`
-        for an illustration of how this affects simulation output in practice.
+        See :ref:`sec_tutorial_multiple_mergers` for an illustration of how this
+        affects simulation output in practice.
 
     :param float c: Determines the rate of potential multiple merger events.
         We require :math:`c > 0`.

--- a/verification.py
+++ b/verification.py
@@ -2633,10 +2633,11 @@ class BetaGrowth(XiGrowth):
         )
 
     def compute_beta_timescale(self, pop_size, alpha, ploidy):
-        m = 2 + np.exp(alpha * np.log(2) + (1 - alpha) * np.log(3) - np.log(alpha - 1))
+        m = 1 + np.exp(alpha * np.log(2) + (1 - alpha) * np.log(3) - np.log(alpha - 1))
         N = pop_size
         if ploidy > 1:
             N = pop_size / 2
+            m = m + 1
         ret = np.exp(
             alpha * np.log(m)
             + (alpha - 1) * np.log(N)


### PR DESCRIPTION
Docs for haploid multiple mergers ready for your perusal @jeromekelleher. I also found one niggling detail to fix in the timescale of the haploid Beta-coalescent.

I haven't provided any explanation of the interaction between the sample_size and ploidy arguments here, assuming that that would get covered somewhere more central. Happy to add more detail if you think it worth repeating though.