### PR TITLE
raise an error when nonzero GC rate used in sweeps code (#1162)

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4732,6 +4732,12 @@ msp_run_sweep(msp_t *self)
     double p_rec_b, p_rec_B;
     bool sweep_over;
 
+    if (rate_map_get_total_mass(&self->gc_map) != 0.0) {
+        /* Could be, we just haven't implemented it */
+        ret = MSP_ERR_SWEEPS_GC_NOT_SUPPORTED;
+        goto out;
+    }
+
     /* Keep the compiler happy */
     sweep_pop_tot_rate = 0;
     p_coal_b = 0;

--- a/lib/tests/test_sweeps.c
+++ b/lib/tests/test_sweeps.c
@@ -286,7 +286,8 @@ test_sweep_genic_selection_gc(void)
     ret = msp_set_simulation_model_sweep_genic_selection(&msp, 5, 0.1, 0.9, 0.1, 0.01);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
-    CU_ASSERT_TRUE(ret >= 0);
+    /* GC rate in sweep model is not implemented */
+    CU_ASSERT_TRUE(ret == MSP_ERR_SWEEPS_GC_NOT_SUPPORTED);
     msp_print_state(&msp, _devnull);
     ret = msp_finalise_tables(&msp);
     CU_ASSERT_EQUAL(ret, 0);

--- a/lib/util.c
+++ b/lib/util.c
@@ -251,6 +251,9 @@ msp_strerror_internal(int err)
         case MSP_ERR_DTWF_GC_NOT_SUPPORTED:
             ret = "Gene conversion is not supported in the DTWF model";
             break;
+        case MSP_ERR_SWEEPS_GC_NOT_SUPPORTED:
+            ret = "Gene conversion is not supported in the selective sweep model";
+            break;
         default:
             ret = "Error occurred generating error string. Please file a bug "
                   "report!";

--- a/lib/util.h
+++ b/lib/util.h
@@ -103,6 +103,7 @@
 #define MSP_ERR_BAD_PLOIDY                                          -63
 #define MSP_ERR_DTWF_MIGRATION_MATRIX_NOT_STOCHASTIC                -64
 #define MSP_ERR_DTWF_GC_NOT_SUPPORTED                               -65
+#define MSP_ERR_SWEEPS_GC_NOT_SUPPORTED                             -66
 
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */


### PR DESCRIPTION
@jeromekelleher I just mimicked DTWF code to raise an error when nonzero GC rate used in sweeps code and modified a test function in test_sweeps.c to match the return value. Let me know if other updates are needed for this issue (#1162).