### PR TITLE
Simulate GC left as part of GC within process.

### DIFF
--- a/lib/rate_map.c
+++ b/lib/rate_map.c
@@ -140,6 +140,7 @@ rate_map_mass_between(rate_map_t *self, double left, double right)
 {
     double left_mass = rate_map_position_to_mass(self, left);
     double right_mass = rate_map_position_to_mass(self, right);
+    assert(left <= right);
     return right_mass - left_mass;
 }
 


### PR DESCRIPTION
This isn't as straightforward as we might hope @fbaumdicker  - it's easy enough to add in the extra GC mass for the first segment, but it does break the assumption that we can convert a mass to a position value when we're choosing segments. I think we could probably work around this (as I mention in the comments) but I wonder if it's worth it. We know that using a single GC process like this will result in a "many" GC events that do nothing, as the left and right breakpoints both end up being left of the left endpoint of the individual.

The question is, how much will this matter? If we do a large simulation, then won't we have lots of individuals consisting of little segments, and then the "GC null" events will end up dominating the simulation? Is there any back-of-the-envelope calculation we could do to guess the basic magnitudes of the number of events for, say, a human chromosome?

Maybe it's better to instead  focus energy on improving the GC left process? (Which, I have some fairly solid ideas for).