### PR TITLE
Move rate_map_t declarations into new rate_map.h

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -30,6 +30,7 @@
 #include "avl.h"
 #include "fenwick.h"
 #include "object_heap.h"
+#include "rate_map.h"
 
 #define MSP_MODEL_HUDSON 0
 #define MSP_MODEL_SMC 1
@@ -171,13 +172,6 @@ typedef struct _simulation_model_t {
     /* If the model allocates memory this function should be non-null. */
     void (*free)(struct _simulation_model_t *model);
 } simulation_model_t;
-
-typedef struct {
-    size_t size;
-    double *position;
-    double *rate;
-    double *cumulative_mass;
-} rate_map_t;
 
 typedef struct {
     double left;
@@ -460,21 +454,6 @@ size_t msp_get_num_common_ancestor_events(msp_t *self);
 size_t msp_get_num_rejected_common_ancestor_events(msp_t *self);
 size_t msp_get_num_recombination_events(msp_t *self);
 size_t msp_get_num_gene_conversion_events(msp_t *self);
-
-int rate_map_alloc(rate_map_t *self, size_t size, double *position, double *value);
-int rate_map_alloc_single(rate_map_t *self, double sequence_length, double value);
-int rate_map_copy(rate_map_t *to, rate_map_t *from);
-int rate_map_free(rate_map_t *self);
-void rate_map_print_state(rate_map_t *self, FILE *out);
-double rate_map_get_sequence_length(rate_map_t *self);
-size_t rate_map_get_size(rate_map_t *self);
-size_t rate_map_get_num_intervals(rate_map_t *self);
-size_t rate_map_get_index(rate_map_t *self, double x);
-double rate_map_get_total_mass(rate_map_t *self);
-double rate_map_mass_between(rate_map_t *self, double left, double right);
-double rate_map_mass_to_position(rate_map_t *self, double mass);
-double rate_map_position_to_mass(rate_map_t *self, double position);
-double rate_map_shift_by_mass(rate_map_t *self, double pos, double mass);
 
 int matrix_mutation_model_factory(mutation_model_t *self, int model);
 int matrix_mutation_model_alloc(mutation_model_t *self, size_t num_alleles,

--- a/lib/rate_map.c
+++ b/lib/rate_map.c
@@ -16,12 +16,15 @@
 ** You should have received a copy of the GNU General Public License
 ** along with msprime.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdio.h>
+
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
 #include "util.h"
-#include "msprime.h"
+#include "rate_map.h"
+
+#include <tskit/core.h>
 
 void
 rate_map_print_state(rate_map_t *self, FILE *out)

--- a/lib/rate_map.h
+++ b/lib/rate_map.h
@@ -1,0 +1,48 @@
+/*
+** Copyright (C) 2020 University of Oxford
+**
+** This file is part of msprime.
+**
+** msprime is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** msprime is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with msprime.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef __RATE_MAP_H__
+#define __RATE_MAP_H__
+
+#include <stddef.h>
+#include <stdio.h>
+
+typedef struct {
+    size_t size;
+    double *position;
+    double *rate;
+    double *cumulative_mass;
+} rate_map_t;
+
+int rate_map_alloc(rate_map_t *self, size_t size, double *position, double *value);
+int rate_map_alloc_single(rate_map_t *self, double sequence_length, double value);
+int rate_map_copy(rate_map_t *to, rate_map_t *from);
+int rate_map_free(rate_map_t *self);
+void rate_map_print_state(rate_map_t *self, FILE *out);
+double rate_map_get_sequence_length(rate_map_t *self);
+size_t rate_map_get_size(rate_map_t *self);
+size_t rate_map_get_num_intervals(rate_map_t *self);
+size_t rate_map_get_index(rate_map_t *self, double x);
+double rate_map_get_total_mass(rate_map_t *self);
+double rate_map_mass_between(rate_map_t *self, double left, double right);
+double rate_map_mass_to_position(rate_map_t *self, double mass);
+double rate_map_position_to_mass(rate_map_t *self, double position);
+double rate_map_shift_by_mass(rate_map_t *self, double pos, double mass);
+
+#endif /*__RATE_MAP_H__*/


### PR DESCRIPTION
There is currently ratemap.c and test/test_rate_map.c. Looking at file sizes, seems to make sense to move the rate_map_t declarations into its own rate_map.h. For the new perf improving code I'm writing I'm thinking of adding them into rate_map.h/c since they are targeted at speeding up rate_map_t execution (at least for now).

Let me know what you think. Feel free to merge this PR into master or wait until a less trivial PR. Either way, I'll keep the branch name around for cleaner diffs.