### PR TITLE
Make msp_binary_interval_search behave like standard binary search algos

### DIFF
--- a/lib/rate_map.c
+++ b/lib/rate_map.c
@@ -156,17 +156,17 @@ rate_map_position_to_mass(rate_map_t *self, double pos)
     double offset;
     size_t index;
 
-    /* TODO we should add an LRU cache with ~3 items here to cache recent
-     * hits and avoid looking up the map for them. This will make a difference
-     * in the large recombination map case.*/
-    if (pos == position[0]) {
+    assert(pos >= 0.0);
+    if (pos <= position[0]) {
         return 0;
     }
+    assert(pos <= position[self->size]);
     if (pos >= position[self->size]) {
         return self->cumulative_mass[self->size];
     }
-    /* TODO replace this with tsk_search_sorted */
-    index = msp_binary_interval_search(pos, position, self->size + 1);
+    /* search for upper bounds strictly before the max position
+       any position greather than or equal to max position returns self->size */
+    index = msp_binary_interval_search(pos, position, self->size);
     assert(index > 0);
     index--;
     offset = pos - position[index];
@@ -185,11 +185,13 @@ rate_map_mass_to_position(rate_map_t *self, double mass)
     double mass_in_interval, pos;
     size_t index;
 
-    if (mass == 0.0) {
+    assert(mass >= 0.0);
+    if (mass <= 0.0) {
         return position[0];
     }
-    /* replace with tsk_search_sorted */
-    index = msp_binary_interval_search(mass, self->cumulative_mass, self->size + 1);
+    /* search for upper bounds strictly before the final cum mass
+       any mass greather than or equal to final cum mass returns self->size */
+    index = msp_binary_interval_search(mass, self->cumulative_mass, self->size);
     assert(index > 0);
     index--;
     mass_in_interval = mass - self->cumulative_mass[index];

--- a/lib/tests/test_rate_map.c
+++ b/lib/tests/test_rate_map.c
@@ -230,10 +230,10 @@ test_msp_binary_interval_search(void)
     CU_ASSERT_EQUAL(idx, 3);
     // from the top - return last element
     idx = msp_binary_interval_search(31, values, size);
-    CU_ASSERT_EQUAL(idx, 3);
-    // way above - same
+    CU_ASSERT_EQUAL(idx, 4);
+    // way above - one past, like numpy.searchsorted and C++ std::lower_bound
     idx = msp_binary_interval_search(300, values, size);
-    CU_ASSERT_EQUAL(idx, 3);
+    CU_ASSERT_EQUAL(idx, 4);
 }
 
 static void
@@ -275,7 +275,7 @@ test_msp_binary_interval_search_edge_cases(void)
     CU_ASSERT_EQUAL(idx, 0);
     // above
     idx = msp_binary_interval_search(11, values_one, 1);
-    CU_ASSERT_EQUAL(idx, 0);
+    CU_ASSERT_EQUAL(idx, 1);
 
     // Size 2 list
     double values_two[] = { 10, 20 };
@@ -288,7 +288,7 @@ test_msp_binary_interval_search_edge_cases(void)
     idx = msp_binary_interval_search(20, values_two, 2);
     CU_ASSERT_EQUAL(idx, 1);
     idx = msp_binary_interval_search(21, values_two, 2);
-    CU_ASSERT_EQUAL(idx, 1);
+    CU_ASSERT_EQUAL(idx, 2);
 
     // All zeros
     double values_zeros[] = { 0, 0, 0 };
@@ -297,7 +297,7 @@ test_msp_binary_interval_search_edge_cases(void)
     idx = msp_binary_interval_search(0, values_zeros, 3);
     CU_ASSERT_EQUAL(idx, 0);
     idx = msp_binary_interval_search(1, values_zeros, 3);
-    CU_ASSERT_EQUAL(idx, 2);
+    CU_ASSERT_EQUAL(idx, 3);
 }
 
 static void

--- a/lib/util.c
+++ b/lib/util.c
@@ -310,24 +310,29 @@ __msp_safe_free(void **ptr)
     }
 }
 
-/* Find the `index` of the interval within `values` the `query` fits, such that
- * values[index-1] < query <= values[index]
- * Will find the leftmost such index
- * Assumes `values` are sorted
+/* This function follows standard semantics of:
+ *   numpy.searchsorted(..., side='left') and
+ *   std::lower_bound() from the standard C++ <algorithm> library
+ * PRE-CONDITION:
+ *   1) `values` are sorted and not NaN
+ * RETURNS:
+ *   First (leftmost) `index` of upper bounds of `query`
+ *   **or** `n_values` if no such upper bound is in `values`
+ * POST-CONDITION:
+ *   If `query` is not strictly greather than all values, then::w
+ *     values[index-1] < query <= values[index]
  */
 size_t
 msp_binary_interval_search(double query, const double *values, size_t n_values)
 {
-    if (n_values == 0) {
-        return 0;
-    }
     size_t l = 0;
-    size_t r = n_values - 1;
+    size_t r = n_values;
     size_t m;
 
     while (l < r) {
         m = (l + r) / 2UL;
-
+        /* TODO: uncomment assert when #1203 done and this longer slows down release
+           assert(values[l] <= values[m]); */
         if (values[m] < query) {
             l = m + 1;
         } else {


### PR DESCRIPTION
Closes #1195

  - msp_binary_interval_search has binary search semantics like:
      * numpy.searchsorted(..., side='left')
      * std::lower_bound() of the C++ <algorithm> library
  - also add and use new macro `expensive_assert()` per #1192