### PR TITLE
Proposal for bug_assert macro

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -453,6 +453,22 @@ of the declaration.
 Error codes are defined in ``err.h``, and these can be translated into a
 message using ``msp_strerror(err)``.
 
++++++++++++++++++
+Using assertions
++++++++++++++++++
+
+There are two different ways to express assertions in the msprime code.
+The first is using the custom ``bug_assert`` macro, which is used to
+make inexpensive checks at key points during execution. These assertions
+are always run, regardless of the compiler settings, and should not
+contribute significantly to the overall runtime.
+
+More expensive assertions, used, for example, to check pre and post conditions
+on performance critical loops should be expressed using the standard
+``assert`` macro from ``assert.h``. These assertions will be checked
+during the execution of C unit tests, but will not be enabled when
+compiled into the Python C module.
+
 ++++++++++++++++
 Running valgrind
 ++++++++++++++++

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -453,22 +453,6 @@ of the declaration.
 Error codes are defined in ``err.h``, and these can be translated into a
 message using ``msp_strerror(err)``.
 
-+++++++++++++++++
-Using assertions
-+++++++++++++++++
-
-There are two different ways to express assertions in the msprime code.
-The first is using the custom ``bug_assert`` macro, which is used to
-make inexpensive checks at key points during execution. These assertions
-are always run, regardless of the compiler settings, and should not
-contribute significantly to the overall runtime.
-
-More expensive assertions, used, for example, to check pre and post conditions
-on performance critical loops should be expressed using the standard
-``assert`` macro from ``assert.h``. These assertions will be checked
-during the execution of C unit tests, but will not be enabled when
-compiled into the Python C module.
-
 ++++++++++++++++
 Running valgrind
 ++++++++++++++++

--- a/lib/fenwick.c
+++ b/lib/fenwick.c
@@ -53,7 +53,7 @@ fenwick_verify(fenwick_t *self, double eps)
 
     for (j = 1; j <= self->size; j++) {
         computed_value = fenwick_compute_tree_value(self, j);
-        bug_assert(gsl_fcmp(computed_value, self->values[j], eps) == 0);
+        tsk_bug_assert(gsl_fcmp(computed_value, self->values[j], eps) == 0);
     }
 }
 
@@ -242,7 +242,7 @@ fenwick_increment(fenwick_t *self, size_t index, double value)
      * code where we don't have to reason about setting the segment
      * mass to the same value. */
     if (value != 0) {
-        bug_assert(0 < index && index <= size);
+        tsk_bug_assert(0 < index && index <= size);
         fenwick_increment_total(self, value);
 
         self->values[index] += value;
@@ -266,7 +266,7 @@ fenwick_get_cumulative_sum(fenwick_t *self, size_t index)
     const double *restrict tree = self->tree;
     size_t j;
 
-    bug_assert(0 < index && index <= self->size);
+    tsk_bug_assert(0 < index && index <= self->size);
     for (j = index; j > 0; j -= (j & -j)) {
         ret += tree[j];
     }
@@ -276,7 +276,7 @@ fenwick_get_cumulative_sum(fenwick_t *self, size_t index)
 double
 fenwick_get_value(fenwick_t *self, size_t index)
 {
-    bug_assert(0 < index && index <= self->size);
+    tsk_bug_assert(0 < index && index <= self->size);
     return self->values[index];
 }
 

--- a/lib/fenwick.c
+++ b/lib/fenwick.c
@@ -26,7 +26,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <string.h>
 
 #include <gsl/gsl_math.h>
@@ -54,7 +53,7 @@ fenwick_verify(fenwick_t *self, double eps)
 
     for (j = 1; j <= self->size; j++) {
         computed_value = fenwick_compute_tree_value(self, j);
-        assert(gsl_fcmp(computed_value, self->values[j], eps) == 0);
+        bug_assert(gsl_fcmp(computed_value, self->values[j], eps) == 0);
     }
 }
 
@@ -243,7 +242,7 @@ fenwick_increment(fenwick_t *self, size_t index, double value)
      * code where we don't have to reason about setting the segment
      * mass to the same value. */
     if (value != 0) {
-        assert(0 < index && index <= size);
+        bug_assert(0 < index && index <= size);
         fenwick_increment_total(self, value);
 
         self->values[index] += value;
@@ -267,7 +266,7 @@ fenwick_get_cumulative_sum(fenwick_t *self, size_t index)
     const double *restrict tree = self->tree;
     size_t j;
 
-    assert(0 < index && index <= self->size);
+    bug_assert(0 < index && index <= self->size);
     for (j = index; j > 0; j -= (j & -j)) {
         ret += tree[j];
     }
@@ -277,7 +276,7 @@ fenwick_get_cumulative_sum(fenwick_t *self, size_t index)
 double
 fenwick_get_value(fenwick_t *self, size_t index)
 {
-    assert(0 < index && index <= self->size);
+    bug_assert(0 < index && index <= self->size);
     return self->values[index];
 }
 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -666,12 +666,12 @@ msp_alloc_segment(msp_t *self, double left, double right, tsk_id_t value,
     if (seg == NULL) {
         goto out;
     }
-    bug_assert(left < right);
+    tsk_bug_assert(left < right);
     if (self->recomb_mass_index != NULL) {
-        bug_assert(fenwick_get_value(&self->recomb_mass_index[label], seg->id) == 0);
+        tsk_bug_assert(fenwick_get_value(&self->recomb_mass_index[label], seg->id) == 0);
     }
     if (self->gc_mass_index != NULL) {
-        bug_assert(fenwick_get_value(&self->gc_mass_index[label], seg->id) == 0);
+        tsk_bug_assert(fenwick_get_value(&self->gc_mass_index[label], seg->id) == 0);
     }
     seg->prev = prev;
     seg->next = next;
@@ -707,7 +707,7 @@ msp_alloc(msp_t *self, tsk_table_collection_t *tables, gsl_rng *rng)
     /* Use the standard coalescent by default. */
     self->model.type = -1;
     ret = msp_set_simulation_model_hudson(self);
-    bug_assert(ret == 0);
+    tsk_bug_assert(ret == 0);
     self->rng = rng;
     self->discrete_genome = true;
 
@@ -821,7 +821,7 @@ msp_free_pedigree(msp_t *self)
 
     ind = self->pedigree->inds;
     if (ind != NULL) {
-        bug_assert(self->pedigree->num_inds > 0);
+        tsk_bug_assert(self->pedigree->num_inds > 0);
         for (i = 0; i < self->pedigree->num_inds; i++) {
             msp_safe_free(ind->parents);
             msp_safe_free(ind->segments);
@@ -940,8 +940,8 @@ msp_get_segment(msp_t *self, size_t id, label_id_t label)
 {
     segment_t *u = object_heap_get_object(&self->segment_heap[label], id - 1);
 
-    bug_assert(u != NULL);
-    bug_assert(u->id == id);
+    tsk_bug_assert(u != NULL);
+    tsk_bug_assert(u->id == id);
     return u;
 }
 
@@ -969,7 +969,7 @@ msp_insert_individual(msp_t *self, segment_t *u)
     int ret = 0;
     avl_node_t *node;
 
-    bug_assert(u != NULL);
+    tsk_bug_assert(u != NULL);
     node = msp_alloc_avl_node(self);
     if (node == NULL) {
         ret = MSP_ERR_NO_MEMORY;
@@ -977,7 +977,7 @@ msp_insert_individual(msp_t *self, segment_t *u)
     }
     avl_init_node(node, u);
     node = avl_insert_node(msp_get_segment_population(self, u), node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 out:
     return ret;
 }
@@ -988,9 +988,9 @@ msp_remove_individual(msp_t *self, segment_t *u)
     avl_node_t *node;
     avl_tree_t *pop = msp_get_segment_population(self, u);
 
-    bug_assert(u != NULL);
+    tsk_bug_assert(u != NULL);
     node = avl_search(pop, u);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     avl_unlink_node(pop, node);
     msp_free_avl_node(self, node);
 }
@@ -1032,7 +1032,7 @@ msp_insert_breakpoint(msp_t *self, double left)
     m->value = 0;
     avl_init_node(node, m);
     node = avl_insert_node(&self->breakpoints, node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 out:
     return ret;
 }
@@ -1080,12 +1080,12 @@ msp_verify_segment_index(
                         } else {
                             left_bound = self->discrete_genome ? u->left + 1 : u->left;
                         }
-                        bug_assert(left_bound <= u->right);
+                        tsk_bug_assert(left_bound <= u->right);
                         s = rate_map_mass_between(rate_map, left_bound, u->right);
                     }
-                    bug_assert(s >= 0);
+                    tsk_bug_assert(s >= 0);
                     ss = fenwick_get_value(&mass_index_array[k], u->id);
-                    bug_assert(doubles_almost_equal(s, ss, epsilon));
+                    tsk_bug_assert(doubles_almost_equal(s, ss, epsilon));
                     total_mass += ss;
                     right = u->right;
                     u = u->next;
@@ -1100,9 +1100,9 @@ msp_verify_segment_index(
                 node = node->next;
             }
         }
-        bug_assert(doubles_almost_equal(
+        tsk_bug_assert(doubles_almost_equal(
             total_mass, fenwick_get_total(&mass_index_array[k]), epsilon));
-        bug_assert(doubles_almost_equal(total_mass, alt_total_mass, epsilon));
+        tsk_bug_assert(doubles_almost_equal(total_mass, alt_total_mass, epsilon));
     }
 }
 
@@ -1131,37 +1131,38 @@ msp_verify_segments(msp_t *self, bool verify_breakpoints)
             node = (&self->populations[j].ancestors[k])->head;
             while (node != NULL) {
                 u = (segment_t *) node->item;
-                bug_assert(u->prev == NULL);
+                tsk_bug_assert(u->prev == NULL);
                 while (u != NULL) {
                     label_segments++;
-                    bug_assert(u->population == (population_id_t) j);
-                    bug_assert(u->label == (label_id_t) k);
-                    bug_assert(u->left < u->right);
-                    bug_assert(u->right <= self->sequence_length);
+                    tsk_bug_assert(u->population == (population_id_t) j);
+                    tsk_bug_assert(u->label == (label_id_t) k);
+                    tsk_bug_assert(u->left < u->right);
+                    tsk_bug_assert(u->right <= self->sequence_length);
                     if (u->prev != NULL) {
-                        bug_assert(u->prev->next == u);
+                        tsk_bug_assert(u->prev->next == u);
                     }
                     if (verify_breakpoints && u->left != 0) {
-                        bug_assert(msp_has_breakpoint(self, u->left));
+                        tsk_bug_assert(msp_has_breakpoint(self, u->left));
                     }
                     if (self->discrete_genome) {
-                        bug_assert(floor(u->left) == u->left);
+                        tsk_bug_assert(floor(u->left) == u->left);
                     }
                     u = u->next;
                 }
                 node = node->next;
             }
         }
-        bug_assert(
+        tsk_bug_assert(
             label_segments == object_heap_get_num_allocated(&self->segment_heap[k]));
     }
     total_avl_nodes = msp_get_num_ancestors(self) + avl_count(&self->breakpoints)
                       + avl_count(&self->overlap_counts)
                       + avl_count(&self->non_empty_populations);
-    bug_assert(total_avl_nodes == object_heap_get_num_allocated(&self->avl_node_heap));
-    bug_assert(total_avl_nodes - msp_get_num_ancestors(self)
-                   - avl_count(&self->non_empty_populations)
-               == object_heap_get_num_allocated(&self->node_mapping_heap));
+    tsk_bug_assert(
+        total_avl_nodes == object_heap_get_num_allocated(&self->avl_node_heap));
+    tsk_bug_assert(total_avl_nodes - msp_get_num_ancestors(self)
+                       - avl_count(&self->non_empty_populations)
+                   == object_heap_get_num_allocated(&self->node_mapping_heap));
     if (self->recomb_mass_index != NULL) {
         msp_verify_segment_index(
             self, self->recomb_mass_index, &self->recomb_map, false);
@@ -1171,13 +1172,13 @@ msp_verify_segments(msp_t *self, bool verify_breakpoints)
     }
     /* Check that the mass indexes are set appropriately */
     if (self->model.type == MSP_MODEL_DTWF || self->model.type == MSP_MODEL_WF_PED) {
-        bug_assert(self->recomb_mass_index == NULL);
-        bug_assert(self->gc_mass_index == NULL);
+        tsk_bug_assert(self->recomb_mass_index == NULL);
+        tsk_bug_assert(self->gc_mass_index == NULL);
     } else {
-        bug_assert((self->recomb_mass_index != NULL)
-                   == (rate_map_get_total_mass(&self->recomb_map) > 0));
-        bug_assert((self->gc_mass_index != NULL)
-                   == (rate_map_get_total_mass(&self->gc_map) > 0));
+        tsk_bug_assert((self->recomb_mass_index != NULL)
+                       == (rate_map_get_total_mass(&self->recomb_map) > 0));
+        tsk_bug_assert((self->gc_mass_index != NULL)
+                       == (rate_map_get_total_mass(&self->gc_map) > 0));
     }
 }
 
@@ -1218,7 +1219,7 @@ overlap_counter_free(overlap_counter_t *self)
 {
     segment_t *curr_overlap, *next_overlap;
 
-    bug_assert(self->overlaps->prev == NULL);
+    tsk_bug_assert(self->overlaps->prev == NULL);
     curr_overlap = self->overlaps;
     while (curr_overlap != NULL) {
         next_overlap = curr_overlap->next;
@@ -1231,7 +1232,7 @@ overlap_counter_free(overlap_counter_t *self)
 static uint32_t
 overlap_counter_overlaps_at(overlap_counter_t *self, double pos)
 {
-    bug_assert(pos >= 0 && pos < self->seq_length);
+    tsk_bug_assert(pos >= 0 && pos < self->seq_length);
     segment_t *curr_overlap = self->overlaps;
     while (curr_overlap->next != NULL) {
         if (curr_overlap->left <= pos && pos < curr_overlap->right) {
@@ -1309,7 +1310,7 @@ msp_verify_overlaps(msp_t *self)
     overlap_counter_t counter;
 
     int ok = overlap_counter_alloc(&counter, self->sequence_length, 0);
-    bug_assert(ok == 0);
+    tsk_bug_assert(ok == 0);
 
     /* add in the overlaps for ancient samples */
     for (j = self->next_sampling_event; j < self->num_sampling_events; j++) {
@@ -1332,7 +1333,7 @@ msp_verify_overlaps(msp_t *self)
     for (node = self->overlap_counts.head; node->next != NULL; node = node->next) {
         nm = (node_mapping_t *) node->item;
         count = overlap_counter_overlaps_at(&counter, nm->position);
-        bug_assert(nm->value == count);
+        tsk_bug_assert(nm->value == count);
     }
 
     overlap_counter_free(&counter);
@@ -1348,16 +1349,16 @@ msp_verify_non_empty_populations(msp_t *self)
     for (avl_node = self->non_empty_populations.head; avl_node != NULL;
          avl_node = avl_node->next) {
         j = (tsk_id_t)(intptr_t) avl_node->item;
-        bug_assert(msp_get_num_population_ancestors(self, j) > 0);
+        tsk_bug_assert(msp_get_num_population_ancestors(self, j) > 0);
     }
 
     for (j = 0; j < (tsk_id_t) self->num_populations; j++) {
         search = (void *) (intptr_t) j;
         avl_node = avl_search(&self->non_empty_populations, search);
         if (msp_get_num_population_ancestors(self, j) == 0) {
-            bug_assert(avl_node == NULL);
+            tsk_bug_assert(avl_node == NULL);
         } else {
-            bug_assert(avl_node != NULL);
+            tsk_bug_assert(avl_node != NULL);
         }
     }
 }
@@ -1374,7 +1375,7 @@ msp_verify_migration_destinations(msp_t *self)
     for (j = 0; j < N; j++) {
         pop = &self->populations[j];
         for (k = 0; k < (tsk_id_t) pop->num_potential_destinations; k++) {
-            bug_assert(M[j * N + pop->potential_destinations[k]] > 0);
+            tsk_bug_assert(M[j * N + pop->potential_destinations[k]] > 0);
         }
     }
     for (j = 0; j < N; j++) {
@@ -1387,7 +1388,7 @@ msp_verify_migration_destinations(msp_t *self)
                     break;
                 }
             }
-            bug_assert(found == (M[j * N + k] != 0));
+            tsk_bug_assert(found == (M[j * N + k] != 0));
         }
     }
 }
@@ -1402,7 +1403,7 @@ msp_verify_initial_state(msp_t *self)
 
     for (overlap = self->initial_overlaps; overlap->left < self->sequence_length;
          overlap++) {
-        bug_assert(overlap->left > last_overlap_left);
+        tsk_bug_assert(overlap->left > last_overlap_left);
         last_overlap_left = overlap->left;
     }
     /* Last overlap should be a sentinal */
@@ -1410,7 +1411,7 @@ msp_verify_initial_state(msp_t *self)
     overlap->count = UINT32_MAX;
 
     /* First overlap should be 0 */
-    bug_assert(self->initial_overlaps->left == 0);
+    tsk_bug_assert(self->initial_overlaps->left == 0);
 
     /* Check the root segments */
     for (j = 0; j < self->input_position.nodes; j++) {
@@ -1419,12 +1420,12 @@ msp_verify_initial_state(msp_t *self)
             prev = NULL;
             for (seg = head; seg != NULL; seg = seg->next) {
                 if (prev != NULL) {
-                    bug_assert(prev->next == seg);
-                    bug_assert(seg->prev == prev);
-                    bug_assert(prev->right <= seg->left);
+                    tsk_bug_assert(prev->next == seg);
+                    tsk_bug_assert(seg->prev == prev);
+                    tsk_bug_assert(prev->right <= seg->left);
                 }
-                bug_assert(seg->left < seg->right);
-                bug_assert(seg->value == (tsk_id_t) j);
+                tsk_bug_assert(seg->left < seg->right);
+                tsk_bug_assert(seg->value == (tsk_id_t) j);
                 prev = seg;
             }
         }
@@ -1466,9 +1467,9 @@ msp_print_pedigree_inds(msp_t *self, FILE *out)
     individual_t *ind;
     size_t i;
 
-    bug_assert(self->pedigree != NULL);
-    bug_assert(self->pedigree->inds != NULL);
-    bug_assert(self->pedigree->num_inds > 0);
+    tsk_bug_assert(self->pedigree != NULL);
+    tsk_bug_assert(self->pedigree->inds != NULL);
+    tsk_bug_assert(self->pedigree->num_inds > 0);
     fprintf(out, "Pedigree:\n");
 
     for (i = 0; i < self->pedigree->num_inds; i++) {
@@ -1507,7 +1508,7 @@ msp_print_initial_overlaps(msp_t *self, FILE *out)
          overlap++) {
         fprintf(out, "\t%f -> %d\n", overlap->left, overlap->count);
     }
-    bug_assert(overlap->left == self->sequence_length);
+    tsk_bug_assert(overlap->left == self->sequence_length);
     fprintf(out, "\t%f -> %d\n", overlap->left, overlap->count);
 }
 
@@ -1771,8 +1772,8 @@ msp_store_edge(msp_t *self, double left, double right, tsk_id_t parent, tsk_id_t
     tsk_edge_t *edge;
     const double *node_time = self->tables->nodes.time;
 
-    bug_assert(parent > child);
-    bug_assert(parent < (tsk_id_t) self->tables->nodes.num_rows);
+    tsk_bug_assert(parent > child);
+    tsk_bug_assert(parent < (tsk_id_t) self->tables->nodes.num_rows);
     if (self->num_buffered_edges == self->max_buffered_edges - 1) {
         /* Grow the array */
         self->max_buffered_edges *= 2;
@@ -1936,7 +1937,7 @@ msp_remove_non_empty_population(msp_t *self, tsk_id_t population)
     void *value = (void *) (intptr_t) population;
 
     node = avl_search(&self->non_empty_populations, value);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     avl_unlink_node(&self->non_empty_populations, node);
     msp_free_avl_node(self, node);
     return ret;
@@ -1961,7 +1962,7 @@ msp_insert_overlap_count(msp_t *self, double left, uint32_t v)
     m->value = v;
     avl_init_node(node, m);
     node = avl_insert_node(&self->overlap_counts, node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 out:
     return ret;
 }
@@ -1979,11 +1980,11 @@ msp_copy_overlap_count(msp_t *self, double k)
 
     search.position = k;
     avl_search_closest(&self->overlap_counts, &search, &node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     nm = (node_mapping_t *) node->item;
     if (nm->position > k) {
         node = node->prev;
-        bug_assert(node != NULL);
+        tsk_bug_assert(node != NULL);
         nm = (node_mapping_t *) node->item;
     }
     ret = msp_insert_overlap_count(self, k, nm->value);
@@ -1999,7 +2000,7 @@ msp_compress_overlap_counts(msp_t *self, double l, double r)
 
     search.position = l;
     node1 = avl_search(&self->overlap_counts, &search);
-    bug_assert(node1 != NULL);
+    tsk_bug_assert(node1 != NULL);
     if (node1->prev != NULL) {
         node1 = node1->prev;
     }
@@ -2122,7 +2123,7 @@ msp_reset_individual(msp_t *self, individual_t *ind)
            reaching the pedigree founders, which means all segments are moved
            back into the population pool before a reset is possible. Might need
            more here when we support early termination. */
-        bug_assert(avl_count(&ind->segments[i]) == 0);
+        tsk_bug_assert(avl_count(&ind->segments[i]) == 0);
     }
     return ret;
 }
@@ -2147,7 +2148,7 @@ msp_reset_pedigree(msp_t *self)
        reaching the pedigree founders, which means no individuals will remain in
        the pedigree heap when a reset is possibile. Might need more here when we
        support early termination. */
-    bug_assert(avl_count(&self->pedigree->ind_heap) == 0);
+    tsk_bug_assert(avl_count(&self->pedigree->ind_heap) == 0);
 
     self->pedigree->state = MSP_PED_STATE_UNCLIMBED;
 
@@ -2207,7 +2208,7 @@ msp_set_pedigree(msp_t *self, tsk_id_t *parents, double *times, tsk_flags_t *is_
     size_t sample_num;
     individual_t *ind = NULL;
 
-    bug_assert(self->pedigree != NULL);
+    tsk_bug_assert(self->pedigree != NULL);
 
     ind = self->pedigree->inds;
     sample_num = 0;
@@ -2226,7 +2227,7 @@ msp_set_pedigree(msp_t *self, tsk_id_t *parents, double *times, tsk_flags_t *is_
         // Set samples
         sample_flag = is_sample[i];
         if (sample_flag != 0) {
-            bug_assert(sample_flag == 1);
+            tsk_bug_assert(sample_flag == 1);
             self->pedigree->samples[sample_num] = ind;
             sample_num++;
         }
@@ -2245,7 +2246,7 @@ msp_check_samples(msp_t *self)
     for (i = 0; i < self->pedigree->num_samples; i++) {
         sample = self->pedigree->samples[i];
         for (j = 0; j < self->ploidy; j++) {
-            bug_assert(avl_count(&sample->segments[j]) == 1);
+            tsk_bug_assert(avl_count(&sample->segments[j]) == 1);
         }
     }
 }
@@ -2257,8 +2258,8 @@ msp_pedigree_add_individual_segment(
     int ret;
     avl_node_t *node;
 
-    bug_assert(ind->segments != NULL);
-    bug_assert(parent_ix < self->ploidy);
+    tsk_bug_assert(ind->segments != NULL);
+    tsk_bug_assert(parent_ix < self->ploidy);
 
     node = msp_alloc_avl_node(self);
     if (node == NULL) {
@@ -2267,7 +2268,7 @@ msp_pedigree_add_individual_segment(
     }
     avl_init_node(node, segment);
     node = avl_insert_node(&ind->segments[parent_ix], node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 
     ret = 0;
 out:
@@ -2285,8 +2286,8 @@ msp_pedigree_load_pop(msp_t *self)
     avl_node_t *node;
     label_id_t label = 0;
 
-    bug_assert(self->num_populations == 1); // Only support single pop for now
-    bug_assert(self->ploidy > 0);
+    tsk_bug_assert(self->num_populations == 1); // Only support single pop for now
+    tsk_bug_assert(self->ploidy > 0);
 
     pop = &self->populations[0];
     ploidy = self->ploidy;
@@ -2326,7 +2327,7 @@ msp_pedigree_push_ind(msp_t *self, individual_t *ind)
     int ret;
     avl_node_t *node;
 
-    bug_assert(ind->queued == false);
+    tsk_bug_assert(ind->queued == false);
 
     node = msp_alloc_avl_node(self);
     if (node == NULL) {
@@ -2335,7 +2336,7 @@ msp_pedigree_push_ind(msp_t *self, individual_t *ind)
     }
     avl_init_node(node, ind);
     node = avl_insert_node(&self->pedigree->ind_heap, node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     ind->queued = true;
 
     ret = 0;
@@ -2350,8 +2351,8 @@ msp_pedigree_build_ind_queue(msp_t *self)
     size_t i;
     individual_t *ind;
 
-    bug_assert(self->pedigree->num_samples > 0);
-    bug_assert(self->pedigree->samples != NULL);
+    tsk_bug_assert(self->pedigree->num_samples > 0);
+    tsk_bug_assert(self->pedigree->samples != NULL);
 
     for (i = 0; i < self->pedigree->num_samples; i++) {
         ind = self->pedigree->samples[i];
@@ -2371,12 +2372,12 @@ msp_pedigree_pop_ind(msp_t *self, individual_t **ind)
     int ret;
     avl_node_t *node;
 
-    bug_assert(avl_count(&self->pedigree->ind_heap) > 0);
+    tsk_bug_assert(avl_count(&self->pedigree->ind_heap) > 0);
 
     node = self->pedigree->ind_heap.head;
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     *ind = node->item;
-    bug_assert((*ind)->queued);
+    tsk_bug_assert((*ind)->queued);
     (*ind)->queued = false;
     msp_free_avl_node(self, node);
     avl_unlink_node(&self->pedigree->ind_heap, node);
@@ -2400,7 +2401,7 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
     s2.next = NULL;
     ix = (int) gsl_rng_uniform_int(self->rng, 2);
     seg_tails[ix]->next = x;
-    bug_assert(x->prev == NULL);
+    tsk_bug_assert(x->prev == NULL);
 
     while (x != NULL) {
         seg_tails[ix] = x;
@@ -2408,7 +2409,7 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
 
         if (x->right > k) {
             // Make new segment
-            bug_assert(x->left < k);
+            tsk_bug_assert(x->left < k);
             self->num_re_events++;
             ix = (ix + 1) % 2;
 
@@ -2424,7 +2425,7 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
                 goto out;
             }
             msp_set_segment_mass(self, z);
-            bug_assert(z->left < z->right);
+            tsk_bug_assert(z->left < z->right);
             if (x->next != NULL) {
                 x->next->prev = z;
             }
@@ -2433,7 +2434,7 @@ msp_dtwf_recombine(msp_t *self, segment_t *x, segment_t **u, segment_t **v)
             x->next = NULL;
             x->right = k;
             msp_set_segment_mass(self, x);
-            bug_assert(x->left < x->right);
+            tsk_bug_assert(x->left < x->right);
             x = z;
             k = msp_dtwf_generate_breakpoint(self, k);
         } else if (x->right <= k && y != NULL && y->left >= k) {
@@ -2513,7 +2514,7 @@ msp_choose_uniform_breakpoint(msp_t *self, int label, rate_map_t *rate_map,
          * segment y that is associated with this *cumulative* value. */
         random_mass = gsl_ran_flat(self->rng, 0, fenwick_get_total(tree));
         y = msp_get_segment(self, fenwick_find(tree, random_mass), label);
-        bug_assert(fenwick_get_value(tree, y->id) > 0);
+        tsk_bug_assert(fenwick_get_value(tree, y->id) > 0);
         x = y->prev;
         y_cumulative_mass = fenwick_get_cumulative_sum(tree, y->id);
         y_right_mass = rate_map_position_to_mass(rate_map, y->right);
@@ -2536,7 +2537,7 @@ msp_choose_uniform_breakpoint(msp_t *self, int label, rate_map_t *rate_map,
                 break;
             }
         } else {
-            bug_assert(x->right <= y->left);
+            tsk_bug_assert(x->right <= y->left);
             if (x->right <= breakpoint && breakpoint < y->right) {
                 break;
             }
@@ -2564,7 +2565,7 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
     segment_t *x, *y, *alpha, *lhs_tail;
 
     self->num_re_events++;
-    bug_assert(self->recomb_mass_index != NULL);
+    tsk_bug_assert(self->recomb_mass_index != NULL);
 
     ret = msp_choose_uniform_breakpoint(
         self, label, &self->recomb_map, self->recomb_mass_index, false, &breakpoint, &y);
@@ -2574,7 +2575,7 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
     x = y->prev;
 
     if (y->left < breakpoint) {
-        bug_assert(breakpoint < y->right);
+        tsk_bug_assert(breakpoint < y->right);
         alpha = msp_alloc_segment(self, breakpoint, y->right, y->value, y->population,
             y->label, NULL, y->next);
         if (alpha == NULL) {
@@ -2596,16 +2597,16 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
             }
         }
         lhs_tail = y;
-        bug_assert(y->left < y->right);
+        tsk_bug_assert(y->left < y->right);
     } else {
-        bug_assert(x != NULL);
+        tsk_bug_assert(x != NULL);
         x->next = NULL;
         y->prev = NULL;
         alpha = y;
         self->num_trapped_re_events++;
         lhs_tail = x;
     }
-    bug_assert(alpha->left < alpha->right);
+    tsk_bug_assert(alpha->left < alpha->right);
     msp_set_segment_mass(self, alpha);
     ret = msp_insert_individual(self, alpha);
     if (ret != 0) {
@@ -2639,7 +2640,7 @@ msp_gene_conversion_event(msp_t *self, label_id_t label)
     bool insert_alpha;
     int num_resamplings = 0;
 
-    bug_assert(self->gc_mass_index != NULL);
+    tsk_bug_assert(self->gc_mass_index != NULL);
     self->num_gc_events++;
     ret = msp_choose_uniform_breakpoint(
         self, label, &self->gc_map, self->gc_mass_index, true, &left_breakpoint, &y);
@@ -2926,12 +2927,12 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                 /* Now get overlap count at the left */
                 search.position = l;
                 node = avl_search(&self->overlap_counts, &search);
-                bug_assert(node != NULL);
+                tsk_bug_assert(node != NULL);
                 nm = (node_mapping_t *) node->item;
                 if (nm->value == 2) {
                     nm->value = 0;
                     node = node->next;
-                    bug_assert(node != NULL);
+                    tsk_bug_assert(node != NULL);
                     nm = (node_mapping_t *) node->item;
                     r = nm->position;
                 } else {
@@ -2939,7 +2940,7 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                     while (nm->value != 2 && r < r_max) {
                         nm->value--;
                         node = node->next;
-                        bug_assert(node != NULL);
+                        tsk_bug_assert(node != NULL);
                         nm = (node_mapping_t *) node->item;
                         r = nm->position;
                     }
@@ -2950,7 +2951,7 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                         goto out;
                     }
                 }
-                bug_assert(v != x->value);
+                tsk_bug_assert(v != x->value);
                 ret = msp_store_edge(self, l, r, v, x->value);
                 if (ret != 0) {
                     goto out;
@@ -2990,7 +2991,7 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                     defrag_required
                         |= z->right == alpha->left && z->value == alpha->value;
                 }
-                bug_assert(z->right <= alpha->left);
+                tsk_bug_assert(z->right <= alpha->left);
                 z->next = alpha;
             }
             alpha->prev = z;
@@ -3033,7 +3034,7 @@ msp_priority_queue_insert(msp_t *self, avl_tree_t *Q, segment_t *u)
     int ret = 0;
     avl_node_t *node;
 
-    bug_assert(u != NULL);
+    tsk_bug_assert(u != NULL);
     node = msp_alloc_avl_node(self);
     if (node == NULL) {
         ret = MSP_ERR_NO_MEMORY;
@@ -3041,7 +3042,7 @@ msp_priority_queue_insert(msp_t *self, avl_tree_t *Q, segment_t *u)
     }
     avl_init_node(node, u);
     node = avl_insert_node(Q, node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 out:
     return ret;
 }
@@ -3157,12 +3158,12 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
              * has not coalesced. */
             search.position = l;
             node = avl_search(&self->overlap_counts, &search);
-            bug_assert(node != NULL);
+            tsk_bug_assert(node != NULL);
             nm = (node_mapping_t *) node->item;
             if (nm->value == h) {
                 nm->value = 0;
                 node = node->next;
-                bug_assert(node != NULL);
+                tsk_bug_assert(node != NULL);
                 nm = (node_mapping_t *) node->item;
                 r = nm->position;
             } else {
@@ -3170,7 +3171,7 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                 while (nm->value != h && r < r_max) {
                     nm->value -= h - 1;
                     node = node->next;
-                    bug_assert(node != NULL);
+                    tsk_bug_assert(node != NULL);
                     nm = (node_mapping_t *) node->item;
                     r = nm->position;
                 }
@@ -3184,7 +3185,7 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
             /* Store the edges and update the priority queue */
             for (j = 0; j < h; j++) {
                 x = H[j];
-                bug_assert(v != x->value);
+                tsk_bug_assert(v != x->value);
                 ret = msp_store_edge(self, l, r, v, x->value);
                 if (ret != 0) {
                     goto out;
@@ -3219,7 +3220,7 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
                    keep reference to merged segments instead */
                 if (self->pedigree != NULL
                     && self->pedigree->state == MSP_PED_STATE_CLIMBING) {
-                    bug_assert(merged_segment != NULL);
+                    tsk_bug_assert(merged_segment != NULL);
                     set_merged = true; // TODO: Must be better way of checking this
                     *merged_segment = alpha;
                 } else {
@@ -3289,7 +3290,7 @@ msp_migration_event(msp_t *self, population_id_t source_pop, population_id_t des
     self->num_migration_events[index]++;
     j = (uint32_t) gsl_rng_uniform_int(self->rng, avl_count(source));
     node = avl_at(source, j);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     ret = msp_move_individual(self, node, source, dest_pop, label);
     return ret;
 }
@@ -3564,7 +3565,7 @@ msp_apply_demographic_events(msp_t *self)
     int ret = 0;
     demographic_event_t *event;
 
-    bug_assert(self->next_demographic_event != NULL);
+    tsk_bug_assert(self->next_demographic_event != NULL);
     /* Process all events with equal time in one block. */
     self->time = self->next_demographic_event->time;
     while (self->next_demographic_event != NULL
@@ -3574,7 +3575,7 @@ msp_apply_demographic_events(msp_t *self)
          * state of the simulation.
          */
         event = self->next_demographic_event;
-        bug_assert(event->change_state != NULL);
+        tsk_bug_assert(event->change_state != NULL);
         ret = event->change_state(self, event);
         if (ret != 0) {
             goto out;
@@ -3620,7 +3621,7 @@ msp_reset(msp_t *self)
         ret = msp_set_tsk_error(ret);
         goto out;
     }
-    bug_assert(self->tables->populations.num_rows == self->num_populations);
+    tsk_bug_assert(self->tables->populations.num_rows == self->num_populations);
 
     ret = msp_reset_population_state(self);
     if (ret != 0) {
@@ -3772,7 +3773,7 @@ static double
 handle_zero_waiting_time(double t)
 {
     double ret = nextafter(t, DBL_MAX) - t;
-    bug_assert(ret != 0);
+    tsk_bug_assert(ret != 0);
     return ret;
 }
 
@@ -3838,7 +3839,7 @@ msp_compute_population_indexes(msp_t *self)
         avl_unlink_node(&self->non_empty_populations, avl_node);
         msp_free_avl_node(self, avl_node);
     }
-    bug_assert(avl_count(&self->non_empty_populations) == 0);
+    tsk_bug_assert(avl_count(&self->non_empty_populations) == 0);
     for (j = 0; j < N; j++) {
         if (msp_get_num_population_ancestors(self, j) > 0) {
             ret = msp_insert_non_empty_population(self, j);
@@ -4046,7 +4047,7 @@ msp_gene_conversion_left_event(msp_t *self, label_id_t label)
         alpha = y;
     }
     msp_set_segment_mass(self, alpha);
-    bug_assert(alpha->prev == NULL);
+    tsk_bug_assert(alpha->prev == NULL);
     ret = msp_insert_individual(self, alpha);
 out:
     return ret;
@@ -4135,11 +4136,11 @@ msp_run_coalescent(msp_t *self, double max_time, unsigned long max_events)
             pop_id_j = (tsk_id_t)(intptr_t) avl_node->item;
             pop = &self->populations[pop_id_j];
             n = avl_count(&pop->ancestors[label]);
-            bug_assert(n > 0);
+            tsk_bug_assert(n > 0);
             for (i = 0; i < (tsk_id_t) pop->num_potential_destinations; i++) {
                 pop_id_k = pop->potential_destinations[i];
                 lambda = n * self->migration_matrix[pop_id_j * N + pop_id_k];
-                bug_assert(lambda > 0);
+                tsk_bug_assert(lambda > 0);
                 t_temp = gsl_ran_exponential(self->rng, 1.0 / lambda);
                 if (t_temp < mig_t_wait) {
                     mig_t_wait = t_temp;
@@ -4273,9 +4274,9 @@ msp_pedigree_climb(msp_t *self)
     segment_t *u[2]; // Will need to update for different ploidy
     avl_tree_t *segments = NULL;
 
-    bug_assert(self->num_populations == 1);
-    bug_assert(avl_count(&self->pedigree->ind_heap) > 0);
-    bug_assert(self->pedigree->state == MSP_PED_STATE_UNCLIMBED);
+    tsk_bug_assert(self->num_populations == 1);
+    tsk_bug_assert(avl_count(&self->pedigree->ind_heap) > 0);
+    tsk_bug_assert(self->pedigree->state == MSP_PED_STATE_UNCLIMBED);
 
     self->pedigree->state = MSP_PED_STATE_CLIMBING;
 
@@ -4287,7 +4288,7 @@ msp_pedigree_climb(msp_t *self)
         if (ret != 0) {
             goto out;
         }
-        bug_assert(ind->time >= self->time);
+        tsk_bug_assert(ind->time >= self->time);
         self->time = ind->time;
 
         for (i = 0; i < self->ploidy; i++) {
@@ -4319,8 +4320,8 @@ msp_pedigree_climb(msp_t *self)
                 // This lineage has coalesced
                 continue;
             }
-            bug_assert(avl_count(segments) == 0);
-            bug_assert(merged_segment->prev == NULL);
+            tsk_bug_assert(avl_count(segments) == 0);
+            tsk_bug_assert(merged_segment->prev == NULL);
 
             /* If parent is NULL, we are at a pedigree founder and we add the
              * lineage back to its original population */
@@ -4348,7 +4349,7 @@ msp_pedigree_climb(msp_t *self)
                 if (u[j] == NULL) {
                     continue;
                 }
-                /* bug_assert(u[j]->prev == NULL); */
+                assert(u[j]->prev == NULL);
                 ret = msp_pedigree_add_individual_segment(self, parent, u[j], j);
                 if (ret != 0) {
                     goto out;
@@ -4528,11 +4529,11 @@ msp_store_simultaneous_migration_events(
     // Choose node to migrate
     j = (uint32_t) gsl_rng_uniform_int(self->rng, avl_count(source));
     node = avl_at(source, j);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 
     avl_unlink_node(source, node);
     node = avl_insert_node(nodes, node);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
 
     return ret;
 }
@@ -4588,8 +4589,8 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
     /* Only support a single structured coalescent label at the moment */
     label_id_t label = 0;
 
-    bug_assert(self->recomb_mass_index == NULL);
-    bug_assert(self->gc_mass_index == NULL);
+    tsk_bug_assert(self->recomb_mass_index == NULL);
+    tsk_bug_assert(self->gc_mass_index == NULL);
     if (rate_map_get_total_mass(&self->gc_map) != 0.0) {
         /* Could be, we just haven't implemented it */
         ret = MSP_ERR_DTWF_GC_NOT_SUPPORTED;
@@ -4638,7 +4639,7 @@ msp_run_dtwf(msp_t *self, double max_time, unsigned long max_events)
                 mig_tmp[k] = self->migration_matrix[j * self->num_populations + k];
                 sum += mig_tmp[k];
             }
-            bug_assert(mig_tmp[j] == 0);
+            tsk_bug_assert(mig_tmp[j] == 0);
 
             // Must check that row sums of migration matrix are <=1 in the main
             // loop, as multiple indices can change in the same generation
@@ -4754,7 +4755,7 @@ msp_sweep_initialise(msp_t *self, double switch_proba)
 
     /* Move ancestors to new labels. */
     for (j = 0; j < self->num_populations; j++) {
-        bug_assert(avl_count(&self->populations[j].ancestors[1]) == 0);
+        tsk_bug_assert(avl_count(&self->populations[j].ancestors[1]) == 0);
         pop = &self->populations[j].ancestors[0];
         node = pop->head;
         while (node != NULL) {
@@ -4810,7 +4811,7 @@ msp_change_label(msp_t *self, segment_t *ind, label_id_t label)
 
     /* Find the this individual in the AVL tree. */
     node = avl_search(pop, ind);
-    bug_assert(node != NULL);
+    tsk_bug_assert(node != NULL);
     ret = msp_move_individual(self, node, pop, ind->population, label);
     return ret;
 }
@@ -5131,7 +5132,7 @@ msp_insert_uncoalesced_edges(msp_t *self)
                 /* For every segment add an edge pointing to this new node */
                 for (seg = (segment_t *) a->item; seg != NULL; seg = seg->next) {
                     if (seg->value != node) {
-                        bug_assert(nodes->time[node] > nodes->time[seg->value]);
+                        tsk_bug_assert(nodes->time[node] > nodes->time[seg->value]);
                         ret = tsk_edge_table_add_row(&self->tables->edges, seg->left,
                             seg->right, node, seg->value, NULL, 0);
                         if (ret < 0) {
@@ -5481,7 +5482,7 @@ msp_add_demographic_event(msp_t *self, double time, demographic_event_t **event)
         self->demographic_events_head = ret_event;
         self->demographic_events_tail = ret_event;
     } else {
-        bug_assert(self->demographic_events_tail != NULL);
+        tsk_bug_assert(self->demographic_events_tail != NULL);
         self->demographic_events_tail->next = ret_event;
         self->demographic_events_tail = ret_event;
     }
@@ -5578,7 +5579,7 @@ msp_add_population_parameters_change(
         goto out;
     }
     if (initial_size < 0) {
-        bug_assert(!gsl_isnan(initial_size));
+        tsk_bug_assert(!gsl_isnan(initial_size));
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
@@ -5827,7 +5828,7 @@ msp_simple_bottleneck(msp_t *self, demographic_event_t *event)
             }
             avl_init_node(q_node, u);
             q_node = avl_insert_node(&Q, q_node);
-            bug_assert(q_node != NULL);
+            tsk_bug_assert(q_node != NULL);
         }
         node = next;
     }
@@ -5983,7 +5984,7 @@ msp_instantaneous_bottleneck(msp_t *self, demographic_event_t *event)
             }
             avl_init_node(set_node, individual);
             set_node = avl_insert_node(&sets[u], set_node);
-            bug_assert(set_node != NULL);
+            tsk_bug_assert(set_node != NULL);
         }
     }
     for (j = 0; j < num_roots; j++) {
@@ -6166,12 +6167,12 @@ msp_std_common_ancestor_event(
     n = avl_count(ancestors);
     j = (uint32_t) gsl_rng_uniform_int(self->rng, n);
     x_node = avl_at(ancestors, j);
-    bug_assert(x_node != NULL);
+    tsk_bug_assert(x_node != NULL);
     x = (segment_t *) x_node->item;
     avl_unlink_node(ancestors, x_node);
     j = (uint32_t) gsl_rng_uniform_int(self->rng, n - 1);
     y_node = avl_at(ancestors, j);
-    bug_assert(y_node != NULL);
+    tsk_bug_assert(y_node != NULL);
     y = (segment_t *) y_node->item;
     avl_unlink_node(ancestors, y_node);
 
@@ -6180,12 +6181,12 @@ msp_std_common_ancestor_event(
     if (msp_reject_ca_event(self, x, y)) {
         self->num_rejected_ca_events++;
         /* insert x and y back into the population */
-        bug_assert(x_node->item == x);
+        tsk_bug_assert(x_node->item == x);
         node = avl_insert_node(ancestors, x_node);
-        bug_assert(node != NULL);
-        bug_assert(y_node->item == y);
+        tsk_bug_assert(node != NULL);
+        tsk_bug_assert(y_node->item == y);
         node = avl_insert_node(ancestors, y_node);
-        bug_assert(node != NULL);
+        tsk_bug_assert(node != NULL);
     } else {
         self->num_ca_events++;
         msp_free_avl_node(self, x_node);
@@ -6298,12 +6299,12 @@ msp_dirac_common_ancestor_event(msp_t *self, population_id_t pop_id, label_id_t 
             n = avl_count(ancestors);
             j = (uint32_t) gsl_rng_uniform_int(self->rng, n);
             x_node = avl_at(ancestors, j);
-            bug_assert(x_node != NULL);
+            tsk_bug_assert(x_node != NULL);
             x = (segment_t *) x_node->item;
             avl_unlink_node(ancestors, x_node);
             j = (uint32_t) gsl_rng_uniform_int(self->rng, n - 1);
             y_node = avl_at(ancestors, j);
-            bug_assert(y_node != NULL);
+            tsk_bug_assert(y_node != NULL);
             y = (segment_t *) y_node->item;
             avl_unlink_node(ancestors, y_node);
             self->num_ca_events++;
@@ -6451,7 +6452,7 @@ msp_multi_merger_common_ancestor_event(
             for (l = 0; l < pot_size; l++) {
                 j = (uint32_t) gsl_rng_uniform_int(self->rng, avl_count(ancestors));
                 node = avl_at(ancestors, j);
-                bug_assert(node != NULL);
+                tsk_bug_assert(node != NULL);
 
                 u = (segment_t *) node->item;
                 avl_unlink_node(ancestors, node);
@@ -6464,7 +6465,7 @@ msp_multi_merger_common_ancestor_event(
                 }
                 avl_init_node(q_node, u);
                 q_node = avl_insert_node(&Q[i], q_node);
-                bug_assert(q_node != NULL);
+                tsk_bug_assert(q_node != NULL);
             }
         }
     }
@@ -6623,7 +6624,7 @@ genic_selection_generate_trajectory(sweep_t *self, msp_t *simulator,
             num_steps++;
         }
     }
-    bug_assert(num_steps < max_steps); /* num_steps + 1 above guarantees this */
+    tsk_bug_assert(num_steps < max_steps); /* num_steps + 1 above guarantees this */
     time[num_steps] = t;
     allele_frequency[num_steps] = trajectory.start_frequency;
     num_steps++;
@@ -6756,10 +6757,10 @@ msp_set_simulation_model_wf_ped(msp_t *self)
     for (j = 0; j < num_individuals; j++) {
         ret = tsk_individual_table_get_row(
             &self->tables->individuals, (tsk_id_t) j, &ind);
-        bug_assert(ret == 0);
+        tsk_bug_assert(ret == 0);
         ind_parents = (const tsk_id_t *) ind.metadata;
         /* This is a temporary hack anyway */
-        bug_assert(ind.metadata_length == self->ploidy * sizeof(tsk_id_t));
+        tsk_bug_assert(ind.metadata_length == self->ploidy * sizeof(tsk_id_t));
         for (k = 0; k < self->ploidy; k++) {
             if (ind_parents[k] < TSK_NULL
                 || ind_parents[k] >= (tsk_id_t) num_individuals) {
@@ -6774,8 +6775,8 @@ msp_set_simulation_model_wf_ped(msp_t *self)
      * checking here, just getting it sort-of working for now. */
     for (j = 0; j < self->tables->nodes.num_rows; j++) {
         ret = tsk_node_table_get_row(&self->tables->nodes, (tsk_id_t) j, &node);
-        bug_assert(ret == 0);
-        bug_assert(node.individual != TSK_NULL);
+        tsk_bug_assert(ret == 0);
+        tsk_bug_assert(node.individual != TSK_NULL);
         is_sample[node.individual] = !!(node.flags & TSK_NODE_IS_SAMPLE);
         time[node.individual] = node.time;
     }

--- a/lib/object_heap.c
+++ b/lib/object_heap.c
@@ -18,7 +18,6 @@
 */
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 #include <stdlib.h>
 
 #include "util.h"
@@ -133,7 +132,7 @@ object_heap_alloc_object(object_heap_t *self)
 inline void
 object_heap_free_object(object_heap_t *self, void *obj)
 {
-    assert(self->top < self->size);
+    bug_assert(self->top < self->size);
     self->heap[self->top] = obj;
     self->top++;
 }

--- a/lib/object_heap.c
+++ b/lib/object_heap.c
@@ -132,7 +132,7 @@ object_heap_alloc_object(object_heap_t *self)
 inline void
 object_heap_free_object(object_heap_t *self, void *obj)
 {
-    bug_assert(self->top < self->size);
+    tsk_bug_assert(self->top < self->size);
     self->heap[self->top] = obj;
     self->top++;
 }

--- a/lib/util.h
+++ b/lib/util.h
@@ -38,6 +38,16 @@
 #define restrict
 #endif
 
+#define bug_assert(condition)                                                           \
+    if (!(condition)) {                                                                 \
+        fprintf(stderr,                                                                 \
+            "Bug detected in %s at line %d. Please open an issue on GitHub, "           \
+            "ideally with a reproducible example. "                                     \
+            "https://github.com/tskit-dev/msprime/issues\n",                            \
+            __FILE__, __LINE__);                                                        \
+        abort();                                                                        \
+    }
+
 /* clang-format off */
 /* Error codes */
 #define MSP_ERR_GENERIC                                             -1

--- a/lib/util.h
+++ b/lib/util.h
@@ -22,6 +22,9 @@
 #include <stdbool.h>
 #include <math.h>
 #include <assert.h>
+#include <stdio.h>
+
+#include "tskit.h"
 
 #ifdef __GNUC__
 /*
@@ -37,16 +40,6 @@
 /* Don't bother with restrict for MSVC */
 #define restrict
 #endif
-
-#define bug_assert(condition)                                                           \
-    if (!(condition)) {                                                                 \
-        fprintf(stderr,                                                                 \
-            "Bug detected in %s at line %d. Please open an issue on GitHub, "           \
-            "ideally with a reproducible example. "                                     \
-            "https://github.com/tskit-dev/msprime/issues\n",                            \
-            __FILE__, __LINE__);                                                        \
-        abort();                                                                        \
-    }
 
 /* clang-format off */
 /* Error codes */

--- a/setup.py
+++ b/setup.py
@@ -122,8 +122,6 @@ if IS_WINDOWS:
 _msprime_module = Extension(
     "msprime._msprime",
     sources=sources,
-    # Enable asserts by default.
-    undef_macros=["NDEBUG"],
     extra_compile_args=["-std=c99"],
     libraries=libraries,
     define_macros=defines,


### PR DESCRIPTION
Recent discussions with @castedo have highlighted that the current usage of ``assert`` in the msprime code is problematic (#1192). Here's a proposal for a new ``bug_assert`` macro, which is basically a drop-in replacement for our current usage of ``assert``, which is (a) more useful in that it tells the user what do do; and (b) solves some annoying distribution problems with compiler warnings.

Annoyingly, we can't turn off the NDEBUG flag without generating some compiler warnings from tskit, so I think we'll have to push this change through to tskit too, if we think it's a good idea. So, the proposal would be

1) Add a new ``tsk_bug_assert()`` macro to tskit, which has the same definition as this one. Update tskit to use this, and tag a C release.
2) Pull in the new tskit C release to msprime, and update this PR to use ``tsk_bug_assert``.

Thoughts? @molpopgen, @castedo, @benjeffery?