### PR TITLE
Refesh development docs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,7 @@ jobs:
       - run:
           name: Compile Python
           command: |
-            CFLAGS="--coverage -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-field-initializers" \
-              python setup.py build_ext --inplace
+            make allchecks
 
       - run:
           name: Run highlevel tests and upload coverage

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,30 @@
 # simple makefile for development.
-
 SRC=msprime/_msprimemodule.c
 
-ext3: ${SRC}
+# The default target builds the C module in the simplest way.
+cmodule: ${SRC}
 	python3 setup.py build_ext --inplace
 
+# allchecks turns on as many checks as make sense when building
+# Python-C extensions.
 allchecks: ${SRC}
-	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-missing-field-initializers -Wno-cast-function-type" \
+	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter "\
+	"-Wno-missing-field-initializers -Wno-cast-function-type" \
 	python3 setup.py build_ext --inplace
 
-ext3-coverage: ${SRC}
+# Turn on coverage builds
+coverage: ${SRC}
 	rm -fR build
 	CFLAGS="-coverage" python3 setup.py build_ext --inplace
 
-docs: ext3
-	cd docs && make clean && make html
-	
+# Format the C code ready for a PR
+clang-format:
+	clang-format -i lib/tests/* lib/*.[c,h]
+
 tags:
 	ctags -f TAGS msprime/*.c lib/*.[c,h] msprime/*.py tests/*.py
 
+
 clean:
 	rm -fR build
-	rm -f msprime/*.o msprime/*.so
+	rm -f msprime/*.so

--- a/lib/avl.c
+++ b/lib/avl.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*****************************************************************************
 
     avl.c - Source code for the AVL-tree library.
@@ -600,3 +601,4 @@ void avl_rebalance(avl_tree_t *avltree, avl_node_t *avlnode) {
 		avlnode = parent;
 	}
 }
+// clang-format on

--- a/lib/avl.h
+++ b/lib/avl.h
@@ -1,3 +1,4 @@
+// clang-format off
 /*****************************************************************************
 
     avl.h - Source code for the AVL-tree library.
@@ -192,3 +193,4 @@ extern unsigned int avl_index(const avl_node_t *);
 }
 #endif
 #endif
+// clang-format on

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*
 ** Copyright (C) 2014-2020 University of Oxford
 **
@@ -4503,7 +4504,7 @@ msprime_sim_mutations(PyObject *self, PyObject *args, PyObject *kwds)
         flags |= MSP_KEEP_SITES;
     }
     if (kept_mutations_before_end_time) {
-        flags |= MSP_KEPT_MUTATIONS_BEFORE_END_TIME; 
+        flags |= MSP_KEPT_MUTATIONS_BEFORE_END_TIME;
     }
     err = mutgen_generate(&mutgen, flags);
     if (err != 0) {
@@ -4701,3 +4702,4 @@ PyInit__msprime(void)
 
     return module;
 }
+// clang-format on


### PR DESCRIPTION
- Update the makefile to be more obvious and add clang-format target
- Make it more difficult to mess up with clang-format by adding
  format-off in files we don't format.
- Fix compile bug that somehow slipped through the net.
- Make a pass through dev docs to refresh.

Closes #1122
Closes #1208