### PR TITLE
Add and use strict upper bound binary search function

### DIFF
--- a/lib/util.c
+++ b/lib/util.c
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <assert.h>
 
 #include <gsl/gsl_math.h>
 
@@ -317,16 +316,16 @@ __msp_safe_free(void **ptr)
  *   numpy.searchsorted(..., side='left') and
  *   std::lower_bound() from the standard C++ <algorithm> library
  * PRE-CONDITION:
- *   1) `values` are sorted and not NaN
+ *   1) `values` are sorted
  * RETURNS:
  *   First (leftmost) `index` of upper bounds of `query`
- *   **or** `n_values` if no such upper bound is in `values`
+ *   **or** `n_values` if all `values` are strict lower bounds of `query`
  * POST-CONDITION:
- *   If `query` is not strictly greather than all values, then::w
- *     values[index-1] < query <= values[index]
+ *   values[index-1] < query <= values[index]
+ *   (ignoring comparisons with invalid [] indexing)
  */
 size_t
-msp_binary_interval_search(double query, const double *values, size_t n_values)
+idx_1st_upper_bound(const double *values, size_t n_values, double query)
 {
     size_t l = 0;
     size_t r = n_values;
@@ -343,6 +342,40 @@ msp_binary_interval_search(double query, const double *values, size_t n_values)
         }
     }
     return l;
+}
+
+/* This function follows standard semantics of:
+ *   std::upper_bound() from the standard C++ <algorithm> library
+ *   and numpy.searchsorted(..., side='right') [Caveat]
+ * PRE-CONDITION:
+ *   1) `values` are sorted
+ * RETURNS:
+ *   First (leftmost) `index` of strict upper bounds of `query`
+ *   **or** `n_values` if all `values` are lower bounds of `query`
+ * POST-CONDITION:
+ *    values[index-1] <= query < values[index]
+ *    (ignoring comparisons with invalid [] indexing)
+ * [Caveat]:
+ *   This function matches NaN semantics of std::upper_bound, not numpy
+ */
+size_t
+idx_1st_strict_upper_bound(const double *elements, size_t n_elements, double query)
+{
+    size_t start = 0;
+    size_t stop = n_elements;
+    size_t mid;
+
+    while (start < stop) {
+        mid = (start + stop) / 2;
+        /* TODO: uncomment assert when #1203 done and this longer slows down release
+        assert(elements[start] <= elements[mid]); */
+        if (!(elements[mid] > query)) { // match NaN logic of std::upper_bound
+            start = mid + 1;
+        } else {
+            stop = mid;
+        }
+    }
+    return stop;
 }
 
 bool
@@ -370,7 +403,7 @@ doubles_almost_equal(double a, double b, double eps)
  *
  */
 static inline size_t
-positive_interval_select(double x, size_t num_intervals, double const *restrict lengths)
+positive_interval_select(double x, size_t num_intervals, const double *lengths)
 {
     size_t i = 0;
     double sum = 0.0;

--- a/lib/util.h
+++ b/lib/util.h
@@ -21,6 +21,7 @@
 
 #include <stdbool.h>
 #include <math.h>
+#include <assert.h>
 
 #ifdef __GNUC__
 /*
@@ -121,7 +122,10 @@ void __msp_safe_free(void **ptr);
 
 #define msp_safe_free(pointer) __msp_safe_free((void **) &(pointer))
 
-size_t msp_binary_interval_search(double query, const double *values, size_t n_values);
+size_t idx_1st_upper_bound(const double *values, size_t n_values, double query);
+size_t idx_1st_strict_upper_bound(
+    const double *elements, size_t n_elements, double query);
+
 bool doubles_almost_equal(double a, double b, double eps);
 
 size_t probability_list_select(double u, size_t num_probs, double const *probs);


### PR DESCRIPTION
This is a stepping stone towards #1197 and #1159. Some more explanation is in #1197.

Add and use strict upper bound binary search function
      - add function for strict upper bound binary search
      - use strict upper bound search in rate_map_mass_to_position
      - streamline rate_map_mass_to_position to run a little faster
      - rename binary search functions to be consistent
      - expand binary search unit tests to include new variant
      - add extreme cases to unit test for rate_map_mass_to_position

I'm not sure about the new function names. They make sense to me, but maybe making then consistent with the C++ algo library makes more sense. I actually find the C++ algo library names kind of confusing. So I'm trying to do better than a standard (which is always suspect :)). This relates to #1195.

The `ptr_...` inline functions get used in #1197 and make that code easier to understand I think.