### PR TITLE
Multiple merger

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1971,8 +1971,8 @@ The diploid Beta-Xi-coalescent can be simulated as follows:
 
     def beta_multiple_merger_example():
         ts = msprime.sim_ancestry(
-            sample_size=5, ploidy=2, random_seed=1,
-            model=msprime.BetaCoalescent(alpha=1.001, truncation_point=1))
+            samples=5, ploidy=2, random_seed=1,
+            model=msprime.BetaCoalescent(alpha=1.001))
         tree = ts.first()
         print(tree.draw(format="unicode"))
 
@@ -2001,8 +2001,8 @@ no multiple mergers for small sample sizes:
 
     def beta_few_multiple_mergers_example():
         ts = msprime.sim_ancestry(
-            sample_size=5, ploidy=2, random_seed=1,
-            model=msprime.BetaCoalescent(alpha=1.8, truncation_point=1))
+            samples=5, ploidy=2, random_seed=1,
+            model=msprime.BetaCoalescent(alpha=1.8))
         tree = ts.first()
         print(tree.draw(format="unicode"))
 
@@ -2035,8 +2035,8 @@ can take place at a given time:
 
     def beta_haploid_multiple_merger_example():
         ts = msprime.sim_ancestry(
-            sample_size=10, ploidy=1, random_seed=1,
-            model=msprime.BetaCoalescent(alpha=1.001, truncation_point=1))
+            samples=10, ploidy=1, random_seed=1,
+            model=msprime.BetaCoalescent(alpha=1.001))
         tree = ts.first()
         print(tree.draw(format="unicode"))
 
@@ -2074,13 +2074,13 @@ population size and number of generations is almost linear:
 
     def beta_high_scaling_example():
         ts = msprime.sim_ancestry(
-            sample_size=1, ploidy=2, random_seed=1, population_size=10,
-            model=msprime.BetaCoalescent(alpha=1.99, truncation_point=1))
+            samples=1, ploidy=2, random_seed=1, population_size=10,
+            model=msprime.BetaCoalescent(alpha=1.99))
         tree = ts.first()
         print(tree.tmrca(0,1))
         ts = msprime.sim_ancestry(
-            sample_size=1, ploidy=2, random_seed=1, population_size=1000,
-            model=msprime.BetaCoalescent(alpha=1.99, truncation_point=1))
+            samples=1, ploidy=2, random_seed=1, population_size=1000,
+            model=msprime.BetaCoalescent(alpha=1.99))
         tree = ts.first()
         print(tree.tmrca(0,1))
 
@@ -2095,13 +2095,13 @@ For :math:`\alpha` close to 1 the effective population size has little effect:
 
     def beta_low_scaling_example():
         ts = msprime.sim_ancestry(
-            sample_size=1, ploidy=2, random_seed=1, population_size=10,
-            model=msprime.BetaCoalescent(alpha=1.1, truncation_point=1))
+            samples=1, ploidy=2, random_seed=1, population_size=10,
+            model=msprime.BetaCoalescent(alpha=1.1))
         tree = ts.first()
         print(tree.tmrca(0,1))
         ts = msprime.sim_ancestry(
-            sample_size=1, ploidy=2, random_seed=1, population_size=1000,
-            model=msprime.BetaCoalescent(alpha=1.1, truncation_point=1))
+            samples=1, ploidy=2, random_seed=1, population_size=1000,
+            model=msprime.BetaCoalescent(alpha=1.1))
         tree = ts.first()
         print(tree.tmrca(0,1))
 
@@ -2116,7 +2116,7 @@ The Dirac-coalescent is simulated similarly in both the diploid case:
 
     def dirac_multiple_merger_example():
         ts = msprime.sim_ancestry(
-            sample_size=5, ploidy=2, random_seed=1,
+            samples=5, ploidy=2, random_seed=1,
             model=msprime.DiracCoalescent(psi=0.9, c=10))
         tree = ts.first()
         print(tree.draw(format="unicode"))
@@ -2141,7 +2141,7 @@ and in the haploid case:
 
     def dirac_haploid_multiple_merger_example():
         ts = msprime.sim_ancestry(
-            sample_size=10, ploidy=1, random_seed=1,
+            samples=10, ploidy=1, random_seed=1,
             model=msprime.DiracCoalescent(psi=0.9, c=10))
         tree = ts.first()
         print(tree.draw(format="unicode"))

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -1716,7 +1716,7 @@ test_beta_coalescent_bad_parameters(void)
     msp_t msp;
     unsigned int n = 10;
     double alphas[] = { -1e6, 0, 0.001, 1.0, 2.0, 1e6 };
-    double truncation_points[] = { -1e6, 0, 1.001, 1e6 };
+    double truncation_points[] = { -1e6, 0 };
     gsl_rng *rng = safe_rng_alloc();
     tsk_table_collection_t tables;
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -167,7 +167,7 @@ msp_strerror_internal(int err)
             ret = "Bad alpha. Must have 1 < alpha < 2";
             break;
         case MSP_ERR_BAD_TRUNCATION_POINT:
-            ret = "Bad truncation_point. Must have 0 < truncation_point <= 1";
+            ret = "Bad truncation_point. Must have 0 < truncation_point.";
             break;
         case MSP_ERR_BAD_RATE_VALUE:
             ret = "Rates must be non-negative and finite";
@@ -265,6 +265,7 @@ msp_strerror_internal(int err)
             break;
         case MSP_ERR_UNKNOWN_TIME_NOT_SUPPORTED:
             ret = "Kept mutations must have known mutation times.";
+            break;
         case MSP_ERR_DTWF_DIPLOID_ONLY:
             ret = "The DTWF model only supports ploidy = 2";
             break;

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1500,42 +1500,47 @@ class BetaCoalescent(ParametricSimulationModel):
     of each chromosome per parent. All lineages within each group merge simultaneously.
 
     Secondly, the number of generations between common ancestor events predicted by the
-    Beta-coalescent is proportional to :math:`N_e^{\\alpha - 1}`, where :math:`N_e` is
-    the effective population size. Specifically, the mean number of generations until
+    Beta-coalescent is proportional to :math:`N^{\\alpha - 1}`, where :math:`N` is
+    the population size. Specifically, the mean number of generations until
     two lineages undergo a common ancestor event is
 
     .. math::
-        G = \\frac{m^{\\alpha} N_e^{\\alpha - 1}}{\\alpha B(2 - \\alpha, \\alpha)},
+        G = \\frac{m^{\\alpha} N^{\\alpha - 1}}{\\alpha B(2 - \\alpha, \\alpha)},
 
     if ploidy = 1, and
 
     .. math::
-        G = \\frac{m^{\\alpha} (N_e / 2)^{\\alpha - 1}}
+        G = \\frac{m^{\\alpha} (N / 2)^{\\alpha - 1}}
             {2 p \\alpha B(2 - \\alpha, \\alpha)},
 
     if ploidy = :math:`p > 1`, where :math:`m` is the mean number of juveniles per
-    family, and is given by
+    family given by
 
     .. math::
-        m = q + \\frac{2^{\\alpha}}{3^{\\alpha - 1} (\\alpha - 1)},
+        m = 2 + \\frac{2^{\\alpha}}{3^{\\alpha - 1} (\\alpha - 1)},
 
-    where :math:`q = 1` ploidy = 1, and :math:`q = 2` if ploidy > 1.
+    if ploidy > 1, and
 
-    In the polyploid case we divide the effective population size :math:`N_e` by two
-    because we assume the :math:`N_e` polyploid individuals form :math:`N_e / 2`
+    .. math::
+        m = 1 + \\frac{1}{2^{\\alpha - 1} (\\alpha - 1)},
+
+    if ploidy = 1.
+
+    In the polyploid case we divide the population size :math:`N` by two
+    because we assume the :math:`N` polyploid individuals form :math:`N / 2`
     two-parent families in which reproduction takes place.
 
     .. warning::
         The number of generations between common ancestor events :math:`G` depends
-        both on the effective population size :math:`N_e` and :math:`\\alpha`,
+        both on the population size :math:`N` and :math:`\\alpha`,
         and can be dramatically shorter than in the case of the
         standard coalescent. For :math:`\\alpha \\approx 1` that is due to
-        insensitivity of :math:`G` to :math:`N_e` --- see
+        insensitivity of :math:`G` to :math:`N` --- see
         :ref:`sec_api_simulation_models_multiple_mergers` for an illustration.
         For :math:`\\alpha \\approx 2`, :math:`G` is almost linear in
-        :math:`N_e`, but can nevertheless be small because
+        :math:`N`, but can nevertheless be small because
         :math:`B(2 - \\alpha, \\alpha) \\rightarrow \\infty` as
-        :math:`\\alpha \\rightarrow 2`. As a result, effective population sizes
+        :math:`\\alpha \\rightarrow 2`. As a result, population sizes
         must often be many orders of magnitude larger than census population sizes
         to obtain realistic amounts of diversity in simulated samples.
 
@@ -1554,22 +1559,24 @@ class BetaCoalescent(ParametricSimulationModel):
         distribution, and must satisfy :math:`1 < \\alpha < 2`. Smaller values of
         :math:`\\alpha` correspond to greater skewness, and :math:`\\alpha = 2`
         would coincide with the standard coalescent.
-    :param float truncation_point: Determines the maximum fraction of the
-        population replaced by offspring in one reproduction event, and must
-        satisfy :math:`0 < \\tau \\leq 1`, where :math:`\\tau` is the truncation point.
-        The default is :math:`\\tau = 1`, which corresponds to the standard
-        Beta-coalescent. When :math:`\\tau < 1`, the number of lineages
-        participating in a common ancestor event is determined by moments
+    :param float truncation_point: The maximum number of juveniles :math:`K` born to
+        one family as a fraction of the population size :math:`N`. Must satisfy
+        :math:`0 < K \\leq \\inf`. Determines the maximum fraction of the population
+        replaced by offspring in one reproduction event, :math:`\\tau`, via
+        :math:`\\tau = K / (K + m)`, where :math:`m` is the mean juvenile number
+        above. The default is :math:`K = \\inf`, which corresponds to the standard
+        Beta-coalescent with :math:`\\tau = 1`. When :math:`K < \\inf`, the number of
+        lineages participating in a common ancestor event is determined by moments
         of the Beta:math:`(2 - \\alpha, \\alpha)` distribution conditioned on not
         exceeding :math:`\\tau`, and the Beta-function in the expression
-        for :math:`G` is also replaced by the incomplete Beta-function
+        for :math:`G` is replaced by the incomplete Beta-function
         :math:`B(\\tau; 2 - \\alpha, \\alpha)`.
     """
 
     name = "beta"
 
     alpha = attr.ib(default=None)
-    truncation_point = attr.ib(default=1)
+    truncation_point = attr.ib(default=sys.float_info.max)
 
 
 @attr.s
@@ -1595,8 +1602,8 @@ class DiracCoalescent(ParametricSimulationModel):
     .. warning::
         The Dirac-coalescent is obtained as a scaling limit of Moran models,
         rather than Wright-Fisher models. As a consequence, the number of generations
-        between coalescence events is proportional to :math:`N_e^2`,
-        rather than :math:`N_e` generations as in the standard coalescent.
+        between coalescence events is proportional to :math:`N^2`,
+        rather than :math:`N` generations as in the standard coalescent.
         See :ref:`sec_tutorial_multiple_mergers` for an illustration of how this
         affects simulation output in practice.
 

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1178,7 +1178,7 @@ class TestSimulator(LowLevelTestCase):
             model = get_simulation_model("beta", alpha=alpha, truncation_point=1)
             with self.assertRaises(_msprime.InputError):
                 sim = make_sim(model=model)
-        for truncation_point in [-1e9, -1, 0, 1.1, 2, 1e9]:
+        for truncation_point in [-1e9, -1, 0]:
             model = get_simulation_model(
                 "beta", alpha=1.5, truncation_point=truncation_point
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -391,7 +391,7 @@ class TestParametricModels(unittest.TestCase):
 
     def test_beta_coalescent_parameters(self):
         for alpha in [1.01, 1.5, 1.99]:
-            model = msprime.BetaCoalescent(alpha)
+            model = msprime.BetaCoalescent(alpha, truncation_point=1)
             self.assertEqual(model.alpha, alpha)
             self.assertEqual(model.truncation_point, 1)
             d = model.get_ll_representation()
@@ -458,7 +458,7 @@ class TestMultipleMergerModels(unittest.TestCase):
         self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
 
     def test_beta_coalescent(self):
-        model = msprime.BetaCoalescent(alpha=1.5, truncation_point=1)
+        model = msprime.BetaCoalescent(alpha=1.5)
         ts = msprime.simulate(Ne=5, sample_size=10, model=model)
         self.assertTrue(all(tree.num_roots == 1 for tree in ts.trees()))
 
@@ -759,9 +759,7 @@ class TestMixedModels(unittest.TestCase):
                 msprime.SimulationModelChange(20, msprime.SmcApproxCoalescent()),
                 msprime.SimulationModelChange(30, msprime.SmcPrimeApproxCoalescent()),
                 msprime.SimulationModelChange(40, msprime.DiscreteTimeWrightFisher()),
-                msprime.SimulationModelChange(
-                    50, msprime.BetaCoalescent(alpha=1.1, truncation_point=1)
-                ),
+                msprime.SimulationModelChange(50, msprime.BetaCoalescent(alpha=1.1)),
                 msprime.SimulationModelChange(60, msprime.StandardCoalescent()),
             ],
             random_seed=10,

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -153,7 +153,9 @@ class TestBuildObjects(unittest.TestCase):
             msprime.StandardCoalescent(),
             msprime.SimulationModelChange(10, msprime.DiscreteTimeWrightFisher()),
             msprime.SimulationModelChange(20, msprime.SmcApproxCoalescent()),
-            msprime.SimulationModelChange(30, msprime.BetaCoalescent(alpha=1.1)),
+            msprime.SimulationModelChange(
+                30, msprime.BetaCoalescent(alpha=1.1, truncation_point=1)
+            ),
         ]
         ts = sim_func(10, model=model_instances)
         decoded = self.decode(ts.provenance(0).record)

--- a/verification.py
+++ b/verification.py
@@ -2615,7 +2615,7 @@ class BetaSFS(KnownSFS):
         Runs simulations of the xi beta model and compares to the expected SFS.
         """
         logging.debug(f"running Beta SFS for {sample_size} {alpha}")
-        model = (msprime.BetaCoalescent(alpha=alpha, truncation_point=1),)
+        model = (msprime.BetaCoalescent(alpha=alpha),)
         name = f"n={sample_size}_alpha={alpha}_ploidy={ploidy}"
         self.compare_sfs(sample_size, ploidy, model, num_replicates, sfs, name)
 
@@ -2800,7 +2800,7 @@ class BetaGrowth(XiGrowth):
     def _run(self, pop_size, alpha, growth_rate, num_replicates=10000):
         logging.debug(f"running Beta growth for {pop_size} {alpha} {growth_rate}")
         b = growth_rate * (alpha - 1)
-        model = (msprime.BetaCoalescent(alpha=alpha, truncation_point=1),)
+        model = (msprime.BetaCoalescent(alpha=alpha),)
         ploidy = 2
         a = 1 / (2 * ploidy * self.compute_beta_timescale(pop_size, alpha, ploidy))
         name = f"N={pop_size}_alpha={alpha}_growth_rate={growth_rate}_ploidy={ploidy}"
@@ -2815,11 +2815,14 @@ class BetaGrowth(XiGrowth):
         )
 
     def compute_beta_timescale(self, pop_size, alpha, ploidy):
-        m = 1 + np.exp(alpha * np.log(2) + (1 - alpha) * np.log(3) - np.log(alpha - 1))
-        N = pop_size
         if ploidy > 1:
             N = pop_size / 2
-            m = m + 1
+            m = 2 + np.exp(
+                alpha * np.log(2) + (1 - alpha) * np.log(3) - np.log(alpha - 1)
+            )
+        else:
+            N = pop_size
+            m = 1 + np.exp((1 - alpha) * np.log(2) - np.log(alpha - 1))
         ret = np.exp(
             alpha * np.log(m)
             + (alpha - 1) * np.log(N)
@@ -2945,7 +2948,7 @@ class ArgRecordTest(Test):
     we simplify an ARG as we get in a direct simulation.
     """
 
-    def _run(self, num_replicates=10000, **kwargs):
+    def _run(self, num_replicates=1000, **kwargs):
 
         ts_node_counts = np.array([])
         arg_node_counts = np.array([])
@@ -2991,7 +2994,7 @@ class ArgRecordTest(Test):
         self._run(sample_size=1000, recombination_rate=0.2)
 
     def test_arg_beta_n100_rho_2(self):
-        model = msprime.BetaCoalescent(alpha=1.1, truncation_point=1)
+        model = msprime.BetaCoalescent(alpha=1.1)
         self._run(sample_size=100, recombination_rate=2, model=model)
 
     def test_arg_dirac_n100_rho_2(self):


### PR DESCRIPTION
- Replaced references to Ne with N in the multiple merger documentation.
- Changed `truncation_point` for the Beta-coalescent as discussed in #1216. In particular, the range is now (0, inf] and the default is inf, which gives the same behaviour as the previous default. Some tests had to change too because they were testing for the validity of the previous (0,1] range, and were now expecting errors from valid parameters, or vice versa.
- Fixed a minor error in the mean juvenile count `m` under the Beta-coalescent, and simplified some computations by extracting out two new static functions to perform some brief computations.

Ping @eldonb - I can't request you as a reviewer for some reason.