### PR TITLE
Halve number of machine instruction running in bottleneck function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,10 @@ jobs:
             gcov -pb ./libmsprime.a.p/msprime.c.gcno ../lib/msprime.c
             gcov -pb ./libmsprime.a.p/mutgen.c.gcno ../lib/mutgen.c
             gcov -pb ./libmsprime.a.p/object_heap.c.gcno ../lib/object_heap.c
-            gcov -pb ./libmsprime.a.p/recomb_map.c.gcno ../lib/recomb_map.c
             gcov -pb ./libmsprime.a.p/interval_map.c.gcno ../lib/interval_map.c
             gcov -pb ./libmsprime.a.p/util.c.gcno ../lib/util.c
             gcov -pb ./libmsprime.a.p/likelihood.c.gcno ../lib/likelihood.c
+            gcov -pb ./libmsprime.a.p/rate_map.c.gcno ../lib/rate_map.c
             cd ..
             codecov -X gcov -F C
 

--- a/lib/rate_map.h
+++ b/lib/rate_map.h
@@ -23,11 +23,14 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#include "util.h"
+
 typedef struct {
     size_t size;
     double *position;
     double *rate;
     double *cumulative_mass;
+    fast_search_t position_lookup;
 } rate_map_t;
 
 int rate_map_alloc(rate_map_t *self, size_t size, double *position, double *value);

--- a/lib/tests/test_rate_map.c
+++ b/lib/tests/test_rate_map.c
@@ -339,6 +339,244 @@ test_binary_search_edge_cases(void)
 }
 
 static void
+verify_search(fast_search_t *fastie, const double *values, size_t n)
+{
+    int i;
+    double x;
+    size_t expect, got;
+
+    for (i = 0; i < n; i++) {
+        x = values[i];
+        expect = idx_1st_strict_upper_bound(values, n, x);
+        got = fast_search_idx_strict_upper(fastie, x);
+        CU_ASSERT_EQUAL(expect, got);
+
+        x = nextafter(x, INFINITY);
+        expect = idx_1st_strict_upper_bound(values, n, x);
+        got = fast_search_idx_strict_upper(fastie, x);
+        CU_ASSERT_EQUAL(expect, got);
+    }
+}
+
+static bool
+fast_search_verify(fast_search_t *self)
+{
+    size_t start, stop;
+    size_t idx;
+
+    if (!(self->query_multiplier >= 0.0)) { // NaN not valid
+        return false;
+    }
+    if (self->num_lookups < 2) {
+        return false;
+    }
+    for (idx = 1; idx < self->num_lookups; idx++) {
+        if (self->lookups[idx - 1] > self->lookups[idx]) {
+            return false;
+        }
+    }
+    start = self->lookups[0];
+    stop = self->lookups[self->num_lookups - 1];
+    if (stop <= start || start != 0 || self->elements[0] != 0.0) {
+        return false;
+    }
+    return true;
+}
+
+static void
+fast_search_alloc_verify(fast_search_t *self, const double *elements, size_t n_elements)
+{
+    CU_ASSERT_EQUAL_FATAL(0, fast_search_alloc(self, elements, n_elements));
+    CU_ASSERT(fast_search_verify(self));
+}
+
+static void
+test_fast_search_identity(void)
+{
+    size_t expect, got;
+    double p[] = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0 };
+    for (size_t n = 2; n <= 6; n++) {
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(1.0, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(n + 1, fastie.num_lookups);
+        for (size_t i = 0; i <= n; i++) {
+            CU_ASSERT_EQUAL(i, fastie.lookups[i]);
+        }
+        verify_search(&fastie, p, n);
+        {
+            expect = idx_1st_strict_upper_bound(p, n, n);
+            got = fast_search_idx_strict_upper(&fastie, n);
+            CU_ASSERT_EQUAL(expect, got);
+
+            double x = nextafter(n, INFINITY);
+            expect = idx_1st_strict_upper_bound(p, n, x);
+            got = fast_search_idx_strict_upper(&fastie, x);
+            CU_ASSERT_EQUAL(expect, got);
+        }
+    }
+}
+
+static void
+test_fast_search_2powers(void)
+{
+    {
+        double p[] = { 0, 2 };
+        size_t n = 2;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(0.5, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(3, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[n]);
+        verify_search(&fastie, p, n);
+        CU_ASSERT_EQUAL(n, fast_search_idx_strict_upper(&fastie, 2.1));
+        CU_ASSERT_EQUAL(n, fast_search_idx_strict_upper(&fastie, 4.0));
+        fast_search_free(&fastie);
+    }
+    {
+        double p[] = { 0, 0.25 };
+        size_t n = 2;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(4.0, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(3, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[n]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+    {
+        double p[] = { 0, 8 };
+        size_t n = 2;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(0.125, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(3, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[n]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+}
+
+static void
+test_fast_search(void)
+{
+    {
+        double p[] = { 0, 0.3, 0.3, 0.5, 1.1, 1.1 };
+        size_t n = 6;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(4.0, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(6, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(1, fastie.lookups[1]);
+        CU_ASSERT_EQUAL(3, fastie.lookups[2]);
+        CU_ASSERT_EQUAL(4, fastie.lookups[3]);
+        CU_ASSERT_EQUAL(4, fastie.lookups[4]);
+        CU_ASSERT_EQUAL(6, fastie.lookups[5]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+    {
+        double p[] = { 0, 6, 13 };
+        size_t n = 3;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(0.125, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(3, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(2, fastie.lookups[1]);
+        CU_ASSERT_EQUAL(3, fastie.lookups[2]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+}
+
+static void
+test_fast_search_zeros(void)
+{
+    const double highest_power = exp2(DBL_MAX_EXP - 1);
+    CU_ASSERT_EQUAL_FATAL(2, highest_power * DBL_MIN);
+    double p[] = { 0.0, 0.0, 0.0, nextafter(0.0, 1), DBL_MIN, DBL_MIN };
+    {
+        size_t n = 1;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(2, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[1]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+    {
+        size_t n = 3;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(highest_power, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(2, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[1]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+    {
+        size_t n = 4;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(highest_power, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(2, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[1]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+    {
+        size_t n = 6;
+        fast_search_t fastie;
+        fast_search_alloc_verify(&fastie, p, n);
+        CU_ASSERT_EQUAL(highest_power, fastie.query_multiplier);
+        CU_ASSERT_EQUAL(4, fastie.num_lookups);
+        CU_ASSERT_EQUAL(0, fastie.lookups[0]);
+        CU_ASSERT_EQUAL(4, fastie.lookups[1]);
+        CU_ASSERT_EQUAL(4, fastie.lookups[2]);
+        CU_ASSERT_EQUAL(n, fastie.lookups[3]);
+        verify_search(&fastie, p, n);
+        fast_search_free(&fastie);
+    }
+}
+
+static void
+test_fast_search_bad_input(void)
+{
+    {
+        double p[] = {};
+        fast_search_t fastie;
+        CU_ASSERT_EQUAL(fast_search_alloc(&fastie, p, 0), MSP_ERR_BAD_PARAM_VALUE);
+        fast_search_free(&fastie);
+    }
+    {
+        double p[] = { 1, 2 };
+        fast_search_t fastie;
+        CU_ASSERT_EQUAL(fast_search_alloc(&fastie, p, 2), MSP_ERR_BAD_PARAM_VALUE);
+        fast_search_free(&fastie);
+    }
+    {
+        double p[] = { 0, 1, INFINITY };
+        fast_search_t fastie;
+        CU_ASSERT_EQUAL(fast_search_alloc(&fastie, p, 3), MSP_ERR_BAD_PARAM_VALUE);
+        fast_search_free(&fastie);
+    }
+    {
+        double p[] = { 0, 2, 1 };
+        fast_search_t fastie;
+        CU_ASSERT_EQUAL(fast_search_alloc(&fastie, p, 3), MSP_ERR_BAD_PARAM_VALUE);
+        fast_search_free(&fastie);
+    }
+}
+
+static void
 test_interval_map(void)
 {
     int ret;
@@ -392,6 +630,11 @@ main(int argc, char **argv)
         { "test_binary_search", test_binary_search },
         { "test_binary_search_repeating", test_binary_search_repeating },
         { "test_binary_search_edge_cases", test_binary_search_edge_cases },
+        { "test_fast_search_identity", test_fast_search_identity },
+        { "test_fast_search_2powers", test_fast_search_2powers },
+        { "test_fast_search", test_fast_search },
+        { "test_fast_search_zeros", test_fast_search_zeros },
+        { "test_fast_search_bad_input", test_fast_search_bad_input },
         { "test_interval_map", test_interval_map },
         CU_TEST_INFO_NULL,
     };

--- a/lib/util.h
+++ b/lib/util.h
@@ -125,12 +125,80 @@ void __msp_safe_free(void **ptr);
 
 #define msp_safe_free(pointer) __msp_safe_free((void **) &(pointer))
 
+bool doubles_almost_equal(double a, double b, double eps);
+
+size_t probability_list_select(double u, size_t num_probs, double const *probs);
+
+/* binary search functions */
+
 size_t idx_1st_upper_bound(const double *values, size_t n_values, double query);
 size_t idx_1st_strict_upper_bound(
     const double *elements, size_t n_elements, double query);
 
-bool doubles_almost_equal(double a, double b, double eps);
+typedef struct {
+    const double *elements;
+    double query_multiplier;
+    double query_cutoff;
+    size_t num_lookups;
+    unsigned *lookups;
+} fast_search_t;
 
-size_t probability_list_select(double u, size_t num_probs, double const *probs);
+int fast_search_alloc(fast_search_t *self, const double *values, size_t n_values);
+int fast_search_free(fast_search_t *self);
+inline size_t fast_search_idx_strict_upper(fast_search_t *self, double query);
+
+/***********************************
+ * INLINE FUNCTION IMPLEMENTATIONS *
+ ***********************************/
+
+inline size_t
+sub_idx_1st_strict_upper_bound(
+    const double *base, size_t start, size_t stop, double query)
+{
+    while (start < stop) {
+        size_t mid = (start + stop) / 2;
+        assert(base[start] <= base[mid]);
+        if (!(base[mid] > query)) { // match NaN logic of std::upper_bound
+            start = mid + 1;
+        } else {
+            stop = mid;
+        }
+    }
+    return stop;
+}
+
+/* PRE-CONDITIONS:
+ *   1) query >= 0.0
+ * RETURNS:
+ *   See idx_1st_strict_upper_bound
+ * NOTE:
+ *   A non-strict version of this function can be achieved by reimplementing it
+ *   to call a non-strict version of `idx_1st_strict_upper_bound`
+ */
+inline size_t
+fast_search_idx_strict_upper(fast_search_t *self, double query)
+{
+    size_t ret;
+    unsigned *lookups = self->lookups;
+    assert(query >= 0.0);
+    if (query < self->query_cutoff) {
+        int64_t idx = (int64_t)(query * self->query_multiplier);
+        /* The query range of [A, B) maps to `idx` where
+         * A = idx/query_multiplier and B = (idx + 1)/query_multiplier).
+         * The lookup table has been initialized such that
+         * `lookup[idx]` and `lookup[idx+1]` points to the first upper bound of A and B
+         * respectively in the element values.
+         */
+        ret = sub_idx_1st_strict_upper_bound(
+            self->elements, lookups[idx], lookups[idx + 1], query);
+    } else {
+        ret = lookups[self->num_lookups - 1];
+    }
+    assert(ret
+           == idx_1st_strict_upper_bound(
+                  self->elements, lookups[self->num_lookups - 1], query));
+    /* function interface is in terms of index to target array of element values */
+    return ret;
+}
 
 #endif /*__UTIL_H__*/


### PR DESCRIPTION
This is improvement on PR #1197. This new commit drops the number of instructions per call of the bottleneck function `rate_map_position_to_mass` by more than half. From 79 to 38 instructions per call. The `rate_map_position_to_mass` execution path runs an order of magnitude more than all other paths in the time_human_chr22 benchmark.

This new PR also has the lookup table use half as much memory, without any execution time trade-off.

More details to follow.

Closes #1159.