### PR TITLE
use gcovr to generate cobertura.xml for codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: Install dependencies and set path
           command: |
             sudo apt-get update
-            sudo apt-get install libgsl0-dev libcunit1-dev libconfig-dev ninja-build valgrind clang
+            sudo apt-get install libgsl0-dev libcunit1-dev libconfig-dev ninja-build valgrind clang gcovr
             pip install --user -r requirements/development.txt
             pip install --user meson twine
             # way to set path persistently https://circleci.com/docs/2.0/env-vars/#setting-path
@@ -70,20 +70,11 @@ jobs:
             ninja -C build-gcc test
 
       - run:
-          name: Run gcov manually, as the one used in codecov doesn't work here.
+          name: Run gcovr and upload C coverage
           command: |
-            gcov -pb -o ./build/temp.linux*/msprime msprime/_msprimemodule.c
-            cd build-gcc
-            # TODO should be able to do this with 'find', but it's tricky and opaque.
-            gcov -pb ./libmsprime.a.p/fenwick.c.gcno ../lib/fenwick.c
-            gcov -pb ./libmsprime.a.p/msprime.c.gcno ../lib/msprime.c
-            gcov -pb ./libmsprime.a.p/mutgen.c.gcno ../lib/mutgen.c
-            gcov -pb ./libmsprime.a.p/object_heap.c.gcno ../lib/object_heap.c
-            gcov -pb ./libmsprime.a.p/interval_map.c.gcno ../lib/interval_map.c
-            gcov -pb ./libmsprime.a.p/util.c.gcno ../lib/util.c
-            gcov -pb ./libmsprime.a.p/likelihood.c.gcno ../lib/likelihood.c
-            gcov -pb ./libmsprime.a.p/rate_map.c.gcno ../lib/rate_map.c
-            cd ..
+            SEARCH=$(dirname $(ls ./build-gcc/*/msprime.c.gcda))
+            SEARCH+=" ./build/temp.linux*/msprime"
+            gcovr --root . --xml --output cobertura.xml $SEARCH
             codecov -X gcov -F C
 
       - run:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # simple makefile for development.
 SRC=msprime/_msprimemodule.c
 
@@ -8,9 +10,10 @@ cmodule: ${SRC}
 # allchecks turns on as many checks as make sense when building
 # Python-C extensions.
 allchecks: ${SRC}
-	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter "\
-	"-Wno-missing-field-initializers -Wno-cast-function-type" \
-	python3 setup.py build_ext --inplace
+	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter" && \
+	CFLAGS+=" -Wno-missing-field-initializers -Wno-cast-function-type" && \
+	CFLAGS+=" --coverage" && \
+	export CFLAGS && python3 setup.py build_ext --inplace
 
 # Turn on coverage builds
 coverage: ${SRC}


### PR DESCRIPTION
Fixes #1240

  - enable exclusion of lines via LCOV_EXCL_LINE (see util.c for example)
  - also generate C coverage data for Python/C layer
