### PR TITLE
enable coverage data for _msprimemodule.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 # simple makefile for development.
 SRC=msprime/_msprimemodule.c
 
@@ -8,9 +10,10 @@ cmodule: ${SRC}
 # allchecks turns on as many checks as make sense when building
 # Python-C extensions.
 allchecks: ${SRC}
-	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter "\
-	"-Wno-missing-field-initializers -Wno-cast-function-type" \
-	python3 setup.py build_ext --inplace
+	CFLAGS="-std=c99 -Wall -Wextra -Werror -Wno-unused-parameter" && \
+	CFLAGS+=" -Wno-missing-field-initializers -Wno-cast-function-type" && \
+	CFLAGS+=" --coverage" && \
+	export CFLAGS && python3 setup.py build_ext --inplace
 
 # Turn on coverage builds
 coverage: ${SRC}


### PR DESCRIPTION
Closes #1244

Just sharing this since I already had it on my computer.

@benjeffery Feel free to choose a smaller change. I was also trying out a different way of appending to an temp shell environment variable across multiple lines using `+=`. I think it's a less fragile approach since it's not depending on whitespace being just right outside the quotes. I actually got bitten by that when I first tweaked the file.
