### PR TITLE
changed track_length to tract_length

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -677,7 +677,7 @@ class Simulator:
         self.L = tables.sequence_length
         self.recomb_map = recombination_map
         self.gc_map = RateMap([0, self.L], [gene_conversion_rate, 0])
-        self.track_length = gene_conversion_length
+        self.tract_length = gene_conversion_length
         self.discrete_genome = discrete_genome
         self.migration_matrix = migration_matrix
         self.num_labels = num_labels
@@ -948,12 +948,12 @@ class Simulator:
         gc_left_total = 0
         num_ancestors = sum(pop.get_num_ancestors() for pop in self.P)
         mean_gc_rate = self.gc_map.mean_rate
-        gc_left_total = num_ancestors * mean_gc_rate * self.track_length
+        gc_left_total = num_ancestors * mean_gc_rate * self.tract_length
         return gc_left_total
 
     def find_cleft_individual(self, label, cleft_value):
         mean_gc_rate = self.gc_map.mean_rate
-        individual_index = math.floor(cleft_value / (mean_gc_rate * self.track_length))
+        individual_index = math.floor(cleft_value / (mean_gc_rate * self.tract_length))
         for pop in self.P:
             num_ancestors = pop.get_num_ancestors()
             if individual_index < num_ancestors:
@@ -1469,8 +1469,8 @@ class Simulator:
             self.gc_mass_index[label], self.gc_map
         )
         x = y.prev
-        # generate track_length
-        tl = np.random.geometric(1 / self.track_length)
+        # generate tract_length
+        tl = np.random.geometric(1 / self.tract_length)
         assert tl > 0
         right_breakpoint = left_breakpoint + tl
         if y.left >= right_breakpoint:
@@ -1588,8 +1588,8 @@ class Simulator:
         y = self.find_cleft_individual(label, random_gc_left)
         assert y is not None
 
-        # generate track_length
-        tl = np.random.geometric(1 / self.track_length)
+        # generate tract_length
+        tl = np.random.geometric(1 / self.tract_length)
 
         bp = y.left + tl
         while y is not None and y.right <= bp:
@@ -2189,7 +2189,7 @@ def run_simulate(args):
     m = args.sequence_length
     rho = args.recombination_rate
     gc_rate = args.gene_conversion_rate[0]
-    mean_track_length = args.gene_conversion_rate[1]
+    mean_tract_length = args.gene_conversion_rate[1]
     num_populations = args.num_populations
     migration_matrix = [
         [args.migration_rate * int(j != k) for j in range(num_populations)]
@@ -2294,7 +2294,7 @@ def run_simulate(args):
         sweep_trajectory=sweep_trajectory,
         time_slice=args.time_slice,
         gene_conversion_rate=gc_rate,
-        gene_conversion_length=mean_track_length,
+        gene_conversion_length=mean_tract_length,
         pedigree=pedigree,
         discrete_genome=args.discrete,
     )

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -94,7 +94,7 @@ class Hudson(LargeSimulationBenchmark):
             Ne=10 ** 4,
             gene_conversion_rate=1e-8,
             # 100Kb tract length.
-            gene_conversion_track_length=100 * 1e3,
+            gene_conversion_tract_length=100 * 1e3,
             random_seed=43,
         )
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,10 +59,10 @@ For gene conversion there are two parameters. The gene conversion rate determine
 and is again per unit of sequence length and per generation in ``msprime``.
 Thus, given the per generation gene conversion rate :math:`g`, the overall rate of
 gene conversion initiation between the ends of the sequence is :math:`\rho = 4 N_e g L` in
-coalescent time units. The second parameter :math:`track\_len` is the expected track length
-of a gene conversion. At each gene conversion initiation site the track of the conversion
-extends to the right and the length of the track is geometric distributed with parameter
-:math:`1/track\_len`. Currently recombination maps for gene conversion are not supported.
+coalescent time units. The second parameter :math:`tract\_len` is the expected tract length
+of a gene conversion. At each gene conversion initiation site the tract of the conversion
+extends to the right and the length of the tract is geometric distributed with parameter
+:math:`1/tract\_len`. Currently recombination maps for gene conversion are not supported.
 However, recombination (with or without recombination maps) and a constant gene conversion
 rate along the genome can be combined in ``msprime``.
 

--- a/lib/dev-tools/dev-cli.c
+++ b/lib/dev-tools/dev-cli.c
@@ -616,7 +616,7 @@ get_configuration(gsl_rng *rng, msp_t *msp, tsk_table_collection_t *tables,
     int ret = 0;
     int err;
     int int_tmp;
-    double start_time, gene_conversion_rate, gene_conversion_track_length;
+    double start_time, gene_conversion_rate, gene_conversion_tract_length;
     const char *from_ts_path;
     config_t *config = malloc(sizeof(config_t));
     config_setting_t *t;
@@ -662,15 +662,15 @@ get_configuration(gsl_rng *rng, msp_t *msp, tsk_table_collection_t *tables,
         fatal_error("gene_conversion_rate is a required parameter");
     }
     if (config_lookup_float(
-            config, "gene_conversion_track_length", &gene_conversion_track_length)
+            config, "gene_conversion_tract_length", &gene_conversion_tract_length)
         == CONFIG_FALSE) {
-        fatal_error("gene_conversion_track_length is a required parameter");
+        fatal_error("gene_conversion_tract_length is a required parameter");
     }
     ret = msp_set_gene_conversion_rate(msp, gene_conversion_rate);
     if (ret != 0) {
         fatal_msprime_error(ret, __LINE__);
     }
-    ret = msp_set_gene_conversion_track_length(msp, gene_conversion_track_length);
+    ret = msp_set_gene_conversion_tract_length(msp, gene_conversion_tract_length);
     if (ret != 0) {
         fatal_msprime_error(ret, __LINE__);
     }

--- a/lib/dev-tools/example.cfg
+++ b/lib/dev-tools/example.cfg
@@ -51,7 +51,7 @@ recombination_map = (
 );
 
 gene_conversion_rate = 1.1;
-gene_conversion_track_length = 1.0;
+gene_conversion_tract_length = 1.0;
 
 # The mutation rate per generation.
 mutation_rate = 0.02;

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -293,15 +293,15 @@ msp_set_recombination_rate(msp_t *self, double rate)
 }
 
 int
-msp_set_gene_conversion_track_length(msp_t *self, double track_length)
+msp_set_gene_conversion_tract_length(msp_t *self, double tract_length)
 {
     int ret = 0;
 
-    if (track_length < 0 || track_length > self->sequence_length) {
+    if (tract_length < 0 || tract_length > self->sequence_length) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    self->gc_track_length = track_length;
+    self->gc_tract_length = tract_length;
 out:
     return ret;
 }
@@ -1552,7 +1552,7 @@ msp_print_state(msp_t *self, FILE *out)
     fprintf(out, "start_time = %f\n", self->start_time);
     fprintf(out, "recombination map:\n");
     rate_map_print_state(&self->recomb_map, out);
-    fprintf(out, "gene_conversion_track_length = %f\n", self->gc_track_length);
+    fprintf(out, "gene_conversion_tract_length = %f\n", self->gc_tract_length);
     fprintf(out, "gene conversion map:\n");
     rate_map_print_state(&self->gc_map, out);
 
@@ -2650,15 +2650,15 @@ msp_gene_conversion_event(msp_t *self, label_id_t label)
 
     x = y->prev;
 
-    /* generate track length */
+    /* generate tract length */
     do {
-        tl = gsl_ran_exponential(self->rng, self->gc_track_length);
+        tl = gsl_ran_exponential(self->rng, self->gc_tract_length);
         if (self->discrete_genome) {
-            /* We want the track length to be at least 1 */
+            /* We want the tract length to be at least 1 */
             tl = ceil(tl);
         }
         if (num_resamplings == 10) {
-            ret = MSP_ERR_TRACKLEN_RESAMPLE_OVERFLOW;
+            ret = MSP_ERR_TRACTLEN_RESAMPLE_OVERFLOW;
             goto out;
         }
         num_resamplings++;
@@ -3902,7 +3902,7 @@ msp_get_total_gc_left(msp_t *self)
 
     size_t num_ancestors = msp_get_num_ancestors(self);
     double mean_gc_rate = rate_map_get_total_mass(&self->gc_map) / self->sequence_length;
-    total = (double) num_ancestors * mean_gc_rate * self->gc_track_length;
+    total = (double) num_ancestors * mean_gc_rate * self->gc_tract_length;
     return total;
 }
 
@@ -3915,7 +3915,7 @@ msp_find_gc_left_individual(msp_t *self, label_id_t label, double value)
     segment_t *ind;
 
     double mean_gc_rate = rate_map_get_total_mass(&self->gc_map) / self->sequence_length;
-    individual_index = (size_t) floor(value / (mean_gc_rate * self->gc_track_length));
+    individual_index = (size_t) floor(value / (mean_gc_rate * self->gc_tract_length));
     for (j = 0; j < self->num_populations; j++) {
         num_ancestors = msp_get_num_population_ancestors(self, (tsk_id_t) j);
         if (individual_index < num_ancestors) {
@@ -3973,15 +3973,15 @@ msp_gene_conversion_left_event(msp_t *self, label_id_t label)
     y = msp_find_gc_left_individual(self, label, h);
     assert(y != NULL);
 
-    /* generate track length */
+    /* generate tract length */
     do {
-        tl = gsl_ran_exponential(self->rng, self->gc_track_length);
+        tl = gsl_ran_exponential(self->rng, self->gc_tract_length);
         if (self->discrete_genome) {
-            /* We want the track length to be at least 1 */
+            /* We want the tract length to be at least 1 */
             tl = ceil(tl);
         }
         if (num_resamplings == 10) {
-            ret = MSP_ERR_TRACKLEN_RESAMPLE_OVERFLOW;
+            ret = MSP_ERR_TRACTLEN_RESAMPLE_OVERFLOW;
             goto out;
         }
         num_resamplings++;

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -189,7 +189,7 @@ typedef struct _msp_t {
     bool discrete_genome;
     rate_map_t recomb_map;
     rate_map_t gc_map;
-    double gc_track_length;
+    double gc_tract_length;
     uint32_t num_populations;
     uint32_t num_labels;
     uint32_t ploidy;
@@ -393,7 +393,7 @@ int msp_set_recombination_rate(msp_t *self, double rate);
 int msp_set_gene_conversion_map(
     msp_t *self, size_t size, double *position, double *rate);
 int msp_set_gene_conversion_rate(msp_t *self, double rate);
-int msp_set_gene_conversion_track_length(msp_t *self, double track_length);
+int msp_set_gene_conversion_tract_length(msp_t *self, double tract_length);
 int msp_set_discrete_genome(msp_t *self, bool is_discrete);
 int msp_set_num_labels(msp_t *self, size_t num_labels);
 int msp_set_node_mapping_block_size(msp_t *self, size_t block_size);

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -1118,7 +1118,7 @@ test_dtwf_errors(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_gene_conversion_rate(&msp, 1);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_gene_conversion_track_length(&msp, 1);
+    ret = msp_set_gene_conversion_tract_length(&msp, 1);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1430,7 +1430,7 @@ test_mixed_hudson_smc(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_gene_conversion_rate(&msp, 3);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_gene_conversion_track_length(&msp, 2);
+    ret = msp_set_gene_conversion_tract_length(&msp, 2);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1477,7 +1477,7 @@ test_mixed_hudson_smc(void)
 }
 
 static void
-run_gc_simulation(double sequence_length, double gc_rate, double track_length,
+run_gc_simulation(double sequence_length, double gc_rate, double tract_length,
     double recombination_rate, bool discrete_genome)
 {
     int ret;
@@ -1497,7 +1497,7 @@ run_gc_simulation(double sequence_length, double gc_rate, double track_length,
     CU_ASSERT_EQUAL_FATAL(msp_set_discrete_genome(&msp, discrete_genome), 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, recombination_rate), 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_gene_conversion_rate(&msp, gc_rate), 0);
-    CU_ASSERT_EQUAL_FATAL(msp_set_gene_conversion_track_length(&msp, track_length), 0);
+    CU_ASSERT_EQUAL_FATAL(msp_set_gene_conversion_tract_length(&msp, tract_length), 0);
     /* Set a very small block size to force lots of fenwick tree rebuilds */
     CU_ASSERT_EQUAL_FATAL(msp_set_segment_block_size(&msp, 16), 0);
     ret = msp_initialise(&msp);
@@ -1543,14 +1543,14 @@ test_gc_single_locus(void)
 }
 
 static void
-test_gc_track_lengths(void)
+test_gc_tract_lengths(void)
 {
-    double track_lengths[] = { 1.0, 1.3333, 5, 10 };
+    double tract_lengths[] = { 1.0, 1.3333, 5, 10 };
     size_t j;
 
-    for (j = 0; j < sizeof(track_lengths) / sizeof(double); j++) {
-        run_gc_simulation(10, 1.0, track_lengths[j], 0.1, true);
-        run_gc_simulation(10, 1.0, track_lengths[j], 0.1, false);
+    for (j = 0; j < sizeof(tract_lengths) / sizeof(double); j++) {
+        run_gc_simulation(10, 1.0, tract_lengths[j], 0.1, true);
+        run_gc_simulation(10, 1.0, tract_lengths[j], 0.1, false);
     }
 }
 
@@ -1802,9 +1802,9 @@ test_simulator_getters_setters(void)
 
     ret = msp_set_gene_conversion_rate(&msp, -1);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_RATE_VALUE);
-    ret = msp_set_gene_conversion_track_length(&msp, -1);
+    ret = msp_set_gene_conversion_tract_length(&msp, -1);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
-    ret = msp_set_gene_conversion_track_length(&msp, tables.sequence_length + 1);
+    ret = msp_set_gene_conversion_tract_length(&msp, tables.sequence_length + 1);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(
         msp_set_gene_conversion_map(&msp, 1, position, &rate), MSP_ERR_BAD_RATE_MAP);
@@ -2953,7 +2953,7 @@ main(int argc, char **argv)
         { "test_mixed_hudson_smc", test_mixed_hudson_smc },
 
         { "test_gc_single_locus", test_gc_single_locus },
-        { "test_gc_track_lengths", test_gc_track_lengths },
+        { "test_gc_tract_lengths", test_gc_tract_lengths },
         { "test_gc_zero_recombination", test_gc_zero_recombination },
         { "test_gc_rates", test_gc_rates },
 

--- a/lib/tests/test_sweeps.c
+++ b/lib/tests/test_sweeps.c
@@ -251,7 +251,7 @@ test_sweep_genic_selection_gc(void)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 1), 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_gene_conversion_rate(&msp, 1), 0);
-    CU_ASSERT_EQUAL_FATAL(msp_set_gene_conversion_track_length(&msp, 1), 0);
+    CU_ASSERT_EQUAL_FATAL(msp_set_gene_conversion_tract_length(&msp, 1), 0);
     ret = msp_set_num_labels(&msp, 2);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
@@ -350,7 +350,7 @@ sweep_genic_selection_mimic_msms_single_run(unsigned long int seed)
     // To mimic the verfication.py call
     msp_set_discrete_genome(&msp, 0);
     msp_set_gene_conversion_rate(&msp, 0);
-    msp_set_gene_conversion_track_length(&msp, 1);
+    msp_set_gene_conversion_tract_length(&msp, 1);
     msp_set_avl_node_block_size(&msp, 65536);
     msp_set_node_mapping_block_size(&msp, 65536);
     msp_set_segment_block_size(&msp, 65536);

--- a/lib/util.c
+++ b/lib/util.c
@@ -228,9 +228,9 @@ msp_strerror_internal(int err)
                   "parameters, and if they make sense help us fix the problem "
                   "by opening an issue on GitHub.";
             break;
-        case MSP_ERR_TRACKLEN_RESAMPLE_OVERFLOW:
+        case MSP_ERR_TRACTLEN_RESAMPLE_OVERFLOW:
             ret = "An unlikely numerical error occured computing gene conversion"
-                  "track lengths (resample overflow). Please check your "
+                  "tract lengths (resample overflow). Please check your "
                   "parameters, and if they make sense help us fix the problem "
                   "by opening an issue on GitHub.";
             break;

--- a/lib/util.h
+++ b/lib/util.h
@@ -102,7 +102,7 @@
 #define MSP_ERR_MUTATION_ID_OVERFLOW                                -58
 #define MSP_ERR_BREAKPOINT_MASS_NON_FINITE                          -59
 #define MSP_ERR_BREAKPOINT_RESAMPLE_OVERFLOW                        -60
-#define MSP_ERR_TRACKLEN_RESAMPLE_OVERFLOW                          -61
+#define MSP_ERR_TRACTLEN_RESAMPLE_OVERFLOW                          -61
 #define MSP_ERR_FENWICK_REBUILD_FAILED                              -62
 #define MSP_ERR_BAD_PLOIDY                                          -63
 #define MSP_ERR_DTWF_MIGRATION_MATRIX_NOT_STOCHASTIC                -64

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -3162,7 +3162,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
         "demographic_events", "model", "avl_node_block_size", "segment_block_size",
         "node_mapping_block_size", "store_migrations", "start_time",
         "store_full_arg", "num_labels", "gene_conversion_rate",
-        "gene_conversion_track_length", "discrete_genome",
+        "gene_conversion_tract_length", "discrete_genome",
         "ploidy", NULL};
     PyObject *migration_matrix = NULL;
     PyObject *population_configuration = NULL;
@@ -3182,7 +3182,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     int discrete_genome = true;
     double start_time = -1;
     double gene_conversion_rate = 0;
-    double gene_conversion_track_length = 1.0;
+    double gene_conversion_tract_length = 1.0;
     int ploidy = 2;
 
     self->sim = NULL;
@@ -3200,7 +3200,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             &avl_node_block_size, &segment_block_size,
             &node_mapping_block_size, &store_migrations, &start_time,
             &store_full_arg, &num_labels,
-            &gene_conversion_rate, &gene_conversion_track_length,
+            &gene_conversion_rate, &gene_conversion_tract_length,
             &discrete_genome, &ploidy)) {
         goto out;
     }
@@ -3270,10 +3270,10 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             handle_input_error("set_gene_conversion_rate", sim_ret);
             goto out;
         }
-        sim_ret = msp_set_gene_conversion_track_length(self->sim,
-                gene_conversion_track_length);
+        sim_ret = msp_set_gene_conversion_tract_length(self->sim,
+                gene_conversion_tract_length);
         if (sim_ret != 0) {
-            handle_input_error("set_gene_conversion_track_length", sim_ret);
+            handle_input_error("set_gene_conversion_tract_length", sim_ret);
             goto out;
         }
     }
@@ -3522,13 +3522,13 @@ out:
 }
 
 static PyObject *
-Simulator_get_gene_conversion_track_length(Simulator *self, void *closure)
+Simulator_get_gene_conversion_tract_length(Simulator *self, void *closure)
 {
     PyObject *ret = NULL;
     if (Simulator_check_sim(self) != 0) {
         goto out;
     }
-    ret = Py_BuildValue("d", self->sim->gc_track_length);
+    ret = Py_BuildValue("d", self->sim->gc_tract_length);
 out:
     return ret;
 }
@@ -4351,9 +4351,9 @@ static PyGetSetDef Simulator_getsetters[] = {
     {"start_time",
             (getter) Simulator_get_start_time, NULL,
             "The start time for this simulator."},
-    {"gene_conversion_track_length",
-            (getter) Simulator_get_gene_conversion_track_length, NULL,
-            "The gene conversion track length for this simulator."},
+    {"gene_conversion_tract_length",
+            (getter) Simulator_get_gene_conversion_tract_length, NULL,
+            "The gene conversion tract length for this simulator."},
     {"record_migrations",
             (getter) Simulator_get_record_migrations, NULL,
             "True if the simulator should store migration records." },

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -290,7 +290,7 @@ def _parse_simulate(
     record_full_arg=False,
     num_labels=None,
     gene_conversion_rate=None,
-    gene_conversion_track_length=None,
+    gene_conversion_tract_length=None,
     demography=None,
     ploidy=None,
 ):
@@ -400,8 +400,8 @@ def _parse_simulate(
                 "Cannot specify gene_conversion_rate along with "
                 "a non discrete genome."
             )
-    if gene_conversion_track_length is None:
-        gene_conversion_track_length = 1
+    if gene_conversion_tract_length is None:
+        gene_conversion_tract_length = 1
     gene_conversion_map = intervals.RateMap.uniform(
         recombination_map.sequence_length, gene_conversion_rate
     )
@@ -434,7 +434,7 @@ def _parse_simulate(
         tables=tables,
         recombination_map=recombination_map,
         gene_conversion_map=gene_conversion_map,
-        gene_conversion_track_length=gene_conversion_track_length,
+        gene_conversion_tract_length=gene_conversion_tract_length,
         discrete_genome=discrete_genome,
         ploidy=ploidy,
         random_generator=random_generator,
@@ -511,7 +511,7 @@ def simulate(
     record_provenance=True,
     # FIXME add documentation for these.
     gene_conversion_rate=None,
-    gene_conversion_track_length=None,
+    gene_conversion_tract_length=None,
     demography=None,
 ):
     """
@@ -705,7 +705,7 @@ def simulate(
         record_full_arg=record_full_arg,
         num_labels=num_labels,
         gene_conversion_rate=gene_conversion_rate,
-        gene_conversion_track_length=gene_conversion_track_length,
+        gene_conversion_tract_length=gene_conversion_tract_length,
         demography=demography,
     )
 
@@ -885,7 +885,7 @@ def _parse_sim_ancestry(
     sequence_length=None,
     recombination_rate=None,
     gene_conversion_rate=None,
-    gene_conversion_track_length=None,
+    gene_conversion_tract_length=None,
     discrete_genome=None,
     population_size=None,
     demography=None,
@@ -958,21 +958,21 @@ def _parse_sim_ancestry(
     gene_conversion_map = _parse_rate_map(
         gene_conversion_rate, sequence_length, "gene conversion"
     )
-    if gene_conversion_track_length is None:
+    if gene_conversion_tract_length is None:
         if gene_conversion_rate is None:
-            # It doesn't matter what the track_length is, just set a
+            # It doesn't matter what the tract_length is, just set a
             # value to keep the low-level code happy.
-            gene_conversion_track_length = 1
+            gene_conversion_tract_length = 1
         else:
             raise ValueError(
-                "Must specify track length when simulating gene conversion"
+                "Must specify tract length when simulating gene conversion"
             )
     else:
         if gene_conversion_rate is None:
             raise ValueError(
-                "Must specify gene conversion rate along with track length"
+                "Must specify gene conversion rate along with tract length"
             )
-        gene_conversion_track_length = float(gene_conversion_track_length)
+        gene_conversion_tract_length = float(gene_conversion_tract_length)
 
     # Default to diploid
     ploidy = 2 if ploidy is None else ploidy
@@ -1041,7 +1041,7 @@ def _parse_sim_ancestry(
         random_generator=random_generator,
         recombination_map=recombination_map,
         gene_conversion_map=gene_conversion_map,
-        gene_conversion_track_length=gene_conversion_track_length,
+        gene_conversion_tract_length=gene_conversion_tract_length,
         discrete_genome=discrete_genome,
         ploidy=ploidy,
         demography=demography,
@@ -1062,7 +1062,7 @@ def sim_ancestry(
     discrete_genome=None,
     recombination_rate=None,
     gene_conversion_rate=None,
-    gene_conversion_track_length=None,
+    gene_conversion_tract_length=None,
     population_size=None,
     demography=None,
     ploidy=None,
@@ -1111,10 +1111,10 @@ def sim_ancestry(
     :param gene_conversion_rate: The rate of gene conversion along the sequence;
         can be either a single value (specifying a single rate over the entire
         sequence) or an instance of :class:`RateMap`. If provided, a value
-        for ``gene_conversion_track_length`` must also be specified.
+        for ``gene_conversion_tract_length`` must also be specified.
         See :ref:`sec_ancestry_gene_conversion` for usage examples
         for this parameter and how it interacts with other parameters.
-    :param gene_conversion_track_length: TODO
+    :param gene_conversion_tract_length: TODO
     """
     random_generator = _parse_random_seed(random_seed)
     record_provenance = True if record_provenance is None else record_provenance
@@ -1129,7 +1129,7 @@ def sim_ancestry(
         sequence_length=sequence_length,
         recombination_rate=recombination_rate,
         gene_conversion_rate=gene_conversion_rate,
-        gene_conversion_track_length=gene_conversion_track_length,
+        gene_conversion_tract_length=gene_conversion_tract_length,
         discrete_genome=discrete_genome,
         population_size=population_size,
         demography=demography,
@@ -1167,7 +1167,7 @@ class Simulator(_msprime.Simulator):
         tables,
         recombination_map,
         gene_conversion_map,
-        gene_conversion_track_length,
+        gene_conversion_tract_length,
         discrete_genome,
         ploidy,
         random_generator,
@@ -1224,7 +1224,7 @@ class Simulator(_msprime.Simulator):
             avl_node_block_size=avl_node_block_size,
             node_mapping_block_size=node_mapping_block_size,
             gene_conversion_rate=gene_conversion_rate,
-            gene_conversion_track_length=gene_conversion_track_length,
+            gene_conversion_tract_length=gene_conversion_tract_length,
             discrete_genome=discrete_genome,
             ploidy=ploidy,
         )

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -205,7 +205,7 @@ class SimulationRunner:
         precision=3,
         random_seeds=None,
         scaled_gene_conversion_rate=0,
-        gene_conversion_track_length=1,
+        gene_conversion_tract_length=1,
         hotspots=None,
     ):
         self._sample_size = sample_size
@@ -247,7 +247,7 @@ class SimulationRunner:
             migration_matrix=migration_matrix,
             demographic_events=demographic_events,
             gene_conversion_rate=scaled_gene_conversion_rate,
-            gene_conversion_track_length=gene_conversion_track_length,
+            gene_conversion_tract_length=gene_conversion_tract_length,
             random_generator=self._random_generator,
             discrete_genome=True,
         )
@@ -458,7 +458,7 @@ def create_simulation_runner(parser, arg_list):
 
     # ms uses a ratio to define the GC rate, but if the recombination rate
     # is zero we define the gc rate directly.
-    gc_param, gc_track_length = args.gene_conversion
+    gc_param, gc_tract_length = args.gene_conversion
     gc_rate = 0
     if r == 0.0:
         if num_loci > 1:
@@ -685,7 +685,7 @@ def create_simulation_runner(parser, arg_list):
         scaled_recombination_rate=r,
         scaled_mutation_rate=mu,
         scaled_gene_conversion_rate=gc_rate,
-        gene_conversion_track_length=gc_track_length,
+        gene_conversion_tract_length=gc_tract_length,
         precision=args.precision,
         print_trees=args.trees,
         random_seeds=args.random_seeds,
@@ -779,7 +779,7 @@ def get_mspms_parser(error_handler=None):
         type=float,
         nargs=2,
         default=(0, 1),
-        metavar=("gc_recomb_ratio", "track_length"),
+        metavar=("gc_recomb_ratio", "tract_length"),
         help=mscompat_gene_conversion_help,
     )
     group.add_argument(

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -440,7 +440,7 @@ class TestParseSimAncestry:
         assert sim.copy_tables().sequence_length == sim.sequence_length
 
         sim = ancestry._parse_sim_ancestry(
-            10, gene_conversion_rate=rate_map, gene_conversion_track_length=1
+            10, gene_conversion_rate=rate_map, gene_conversion_tract_length=1
         )
         assert sim.sequence_length == rate_map.sequence_length
         assert sim.copy_tables().sequence_length == sim.sequence_length
@@ -458,7 +458,7 @@ class TestParseSimAncestry:
             ancestry._parse_sim_ancestry(10, recombination_rate=1)
         with pytest.raises(ValueError):
             ancestry._parse_sim_ancestry(
-                10, gene_conversion_rate=1, gene_conversion_track_length=1
+                10, gene_conversion_rate=1, gene_conversion_tract_length=1
             )
 
         # A rate map with a value that disagrees with sequence length
@@ -471,7 +471,7 @@ class TestParseSimAncestry:
             ancestry._parse_sim_ancestry(
                 10,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
                 sequence_length=1,
             )
 
@@ -482,14 +482,14 @@ class TestParseSimAncestry:
                 10,
                 recombination_rate=other_rate_map,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
             )
         with pytest.raises(ValueError):
             ancestry._parse_sim_ancestry(
                 10,
                 recombination_rate=other_rate_map,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
                 sequence_length=other_rate_map.sequence_length,
             )
         with pytest.raises(ValueError):
@@ -497,7 +497,7 @@ class TestParseSimAncestry:
                 10,
                 recombination_rate=other_rate_map,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
                 sequence_length=rate_map.sequence_length,
             )
         # Both maps disagree with sequence_length
@@ -506,7 +506,7 @@ class TestParseSimAncestry:
                 10,
                 recombination_rate=other_rate_map,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
                 sequence_length=56789,
             )
 
@@ -522,14 +522,14 @@ class TestParseSimAncestry:
             ancestry._parse_sim_ancestry(
                 initial_state=initial_state,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
             )
         with pytest.raises(ValueError):
             ancestry._parse_sim_ancestry(
                 initial_state=initial_state,
                 recombination_rate=other_rate_map,
                 gene_conversion_rate=rate_map,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
             )
 
     def test_sequence_length_discrete_genome(self):
@@ -557,25 +557,25 @@ class TestParseSimAncestry:
                 10,
                 sequence_length=10,
                 gene_conversion_rate=rate,
-                gene_conversion_track_length=5,
+                gene_conversion_tract_length=5,
             )
             assert sim.sequence_length == 10
             gc_map = sim.gene_conversion_map
             assert gc_map.sequence_length == 10
             assert len(gc_map) == 1
             assert gc_map.rate[0] == 1234
-            assert sim.gene_conversion_track_length == 5
+            assert sim.gene_conversion_tract_length == 5
 
     def test_gene_conversion_errors(self):
-        # No track length is an error
+        # No tract length is an error
         with pytest.raises(ValueError):
             ancestry._parse_sim_ancestry(
                 10, sequence_length=10, gene_conversion_rate=1234
             )
-        # Specifying a track_length and no map is also an error.
+        # Specifying a tract_length and no map is also an error.
         with pytest.raises(ValueError):
             ancestry._parse_sim_ancestry(
-                10, sequence_length=10, gene_conversion_track_length=5.5
+                10, sequence_length=10, gene_conversion_tract_length=5.5
             )
 
         for bad_type in [[], {}]:
@@ -584,7 +584,7 @@ class TestParseSimAncestry:
                     10,
                     sequence_length=10,
                     gene_conversion_rate=bad_type,
-                    gene_conversion_track_length=1,
+                    gene_conversion_tract_length=1,
                 )
 
             with pytest.raises(TypeError):
@@ -592,7 +592,7 @@ class TestParseSimAncestry:
                     10,
                     sequence_length=10,
                     gene_conversion_rate=1,
-                    gene_conversion_track_length=bad_type,
+                    gene_conversion_tract_length=bad_type,
                 )
 
     def test_discrete_genome(self):
@@ -1357,7 +1357,7 @@ class TestSimAncestryInterface:
         ts = msprime.sim_ancestry(
             10,
             gene_conversion_rate=1,
-            gene_conversion_track_length=2,
+            gene_conversion_tract_length=2,
             sequence_length=10,
             random_seed=14,
         )
@@ -1709,7 +1709,7 @@ class TestSimulateInterface:
         ts = msprime.simulate(
             n,
             gene_conversion_rate=1,
-            gene_conversion_track_length=1,
+            gene_conversion_tract_length=1,
             length=10,
             recombination_rate=1,
             discrete_genome=True,
@@ -1723,7 +1723,7 @@ class TestSimulateInterface:
             msprime.simulate(
                 10,
                 gene_conversion_rate=1,
-                gene_conversion_track_length=1,
+                gene_conversion_tract_length=1,
                 discrete_genome=False,
             )
 
@@ -1733,7 +1733,7 @@ class TestSimulateInterface:
             n,
             length=10,
             gene_conversion_rate=1,
-            gene_conversion_track_length=1,
+            gene_conversion_tract_length=1,
             discrete_genome=True,
         )
         assert isinstance(ts, tskit.TreeSequence)

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1087,7 +1087,7 @@ class TestSimulator(LowLevelTestCase):
             with pytest.raises(TypeError):
                 make_sim(gene_conversion_rate=bad_type)
             with pytest.raises(TypeError):
-                make_sim(gene_conversion_track_length=bad_type)
+                make_sim(gene_conversion_tract_length=bad_type)
         # Check for bad values.
         with pytest.raises(_msprime.InputError):
             make_sim(avl_node_block_size=0)
@@ -1101,11 +1101,11 @@ class TestSimulator(LowLevelTestCase):
             make_sim(num_labels=-1)
         with pytest.raises(_msprime.InputError):
             make_sim(gene_conversion_rate=-1)
-        # Track length is ignored if gene_conversion_rate is 0
+        # Tract length is ignored if gene_conversion_rate is 0
         with pytest.raises(_msprime.InputError):
             make_sim(
                 gene_conversion_rate=1,
-                gene_conversion_track_length=-100,
+                gene_conversion_tract_length=-100,
             )
 
         # Check for other type specific errors.

--- a/verification.py
+++ b/verification.py
@@ -3140,7 +3140,7 @@ class HudsonAnalytical(Test):
                 sample_size=sample_size,
                 length=seq_length,
                 gene_conversion_rate=gc_rate[k],
-                gene_conversion_track_length=gc_length[k],
+                gene_conversion_tract_length=gc_length[k],
                 discrete_genome=True,
                 num_replicates=R,
             )


### PR DESCRIPTION
I changed the variable name and all other occurrences of a gene conversion "track" with "tract" as discussed in #1202.
However, I did not change any of the original code in data/msdir and data/msHOTdir where the variable "track_len" is used.

Fixes #1202 