### PR TITLE
bugfix too long continuous tract length

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -1457,6 +1457,14 @@ class Simulator:
             ret = x, alpha
         return ret
 
+    def generate_gc_tract_length(self):
+        # generate tract length
+        if self.discrete_genome:
+            tl = np.random.geometric(1 / self.tract_length)
+        else:
+            tl = np.random.exponential(self.tract_length)
+        return tl
+
     def wiuf_gene_conversion_within_event(self, label):
         """
         Implements a gene conversion event that starts within a segment
@@ -1470,7 +1478,7 @@ class Simulator:
         )
         x = y.prev
         # generate tract_length
-        tl = np.random.geometric(1 / self.tract_length)
+        tl = self.generate_gc_tract_length()
         assert tl > 0
         right_breakpoint = left_breakpoint + tl
         if y.left >= right_breakpoint:
@@ -1589,7 +1597,7 @@ class Simulator:
         assert y is not None
 
         # generate tract_length
-        tl = np.random.geometric(1 / self.tract_length)
+        tl = self.generate_gc_tract_length()
 
         bp = y.left + tl
         while y is not None and y.right <= bp:

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -209,6 +209,8 @@ typedef struct _msp_t {
     size_t num_re_events;
     size_t num_ca_events;
     size_t num_gc_events;
+    size_t num_internal_gc_events;
+    double sum_internal_gc_tract_lengths;
     size_t num_rejected_ca_events;
     size_t *num_migration_events;
     size_t num_trapped_re_events;
@@ -455,6 +457,8 @@ size_t msp_get_num_common_ancestor_events(msp_t *self);
 size_t msp_get_num_rejected_common_ancestor_events(msp_t *self);
 size_t msp_get_num_recombination_events(msp_t *self);
 size_t msp_get_num_gene_conversion_events(msp_t *self);
+size_t msp_get_num_internal_gene_conversion_events(msp_t *self);
+double msp_get_sum_internal_gc_tract_lengths(msp_t *self);
 
 int matrix_mutation_model_factory(mutation_model_t *self, int model);
 int matrix_mutation_model_alloc(mutation_model_t *self, size_t num_alleles,

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -1483,7 +1483,9 @@ run_gc_simulation(double sequence_length, double gc_rate, double tract_length,
     int ret;
     uint32_t n = 10;
     long seed = 10;
-    size_t num_events, num_ca_events, num_re_events, num_gc_events;
+    size_t num_events, num_ca_events, num_re_events, num_gc_events,
+        num_internal_gc_events;
+    double sum_internal_gc_tract_lengths;
     bool single_locus = sequence_length == 1 && discrete_genome;
     tsk_table_collection_t tables;
     tsk_treeseq_t ts;
@@ -1523,6 +1525,12 @@ run_gc_simulation(double sequence_length, double gc_rate, double tract_length,
         CU_ASSERT_EQUAL(num_gc_events, 0);
     } else {
         CU_ASSERT_TRUE(num_gc_events > 0);
+    }
+    num_internal_gc_events = msp_get_num_internal_gene_conversion_events(&msp);
+    CU_ASSERT_TRUE(num_internal_gc_events >= num_gc_events);
+    sum_internal_gc_tract_lengths = msp_get_sum_internal_gc_tract_lengths(&msp);
+    if (discrete_genome) {
+        CU_ASSERT_TRUE(sum_internal_gc_tract_lengths >= num_internal_gc_events);
     }
     msp_free(&msp);
 
@@ -1564,10 +1572,10 @@ test_gc_zero_recombination(void)
 static void
 test_gc_rates(void)
 {
-    run_gc_simulation(1, 0.1, 0.5, 10.0, false);
-    run_gc_simulation(1, 10.0, 0.5, 0.1, false);
+    run_gc_simulation(10, 0.1, 1.5, 1.0, false);
+    run_gc_simulation(5, 5.0, 2.5, 0.01, false);
     run_gc_simulation(10, 1, 1, 1.0, false);
-    run_gc_simulation(30, 1.0, 6, 1.0, true);
+    run_gc_simulation(30, 1.0, 6.5, 1.0, true);
 }
 
 static void

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1976,6 +1976,32 @@ out:
 }
 
 static PyObject *
+Simulator_get_num_internal_gene_conversion_events(Simulator  *self, void *closure)
+{
+    PyObject *ret = NULL;
+    if (Simulator_check_sim(self) != 0) {
+        goto out;
+    }
+    ret = Py_BuildValue("n",
+        (Py_ssize_t) msp_get_num_internal_gene_conversion_events(self->sim));
+out:
+    return ret;
+}
+
+static PyObject *
+Simulator_get_sum_internal_gc_tract_lengths(Simulator  *self, void *closure)
+{
+    PyObject *ret = NULL;
+    if (Simulator_check_sim(self) != 0) {
+        goto out;
+    }
+    ret = Py_BuildValue("n",
+        (Py_ssize_t) msp_get_sum_internal_gc_tract_lengths(self->sim));
+out:
+    return ret;
+}
+
+static PyObject *
 Simulator_get_num_migration_events(Simulator  *self, void *closure)
 {
     PyObject *ret = NULL;
@@ -2632,6 +2658,12 @@ static PyGetSetDef Simulator_getsetters[] = {
     {"num_gene_conversion_events",
             (getter) Simulator_get_num_gene_conversion_events, NULL,
             "The number of gene_conversion_events" },
+    {"num_internal_gene_conversion_events",
+            (getter) Simulator_get_num_internal_gene_conversion_events, NULL,
+            "The number of internal_gene_conversion_events" },
+    {"sum_internal_gc_tract_lengths",
+            (getter) Simulator_get_sum_internal_gc_tract_lengths, NULL,
+            "The sum of all internal_gc_tract_lengths" },
     {"num_labels",
             (getter) Simulator_get_num_labels, NULL,
             "The number of labels." },

--- a/verification.py
+++ b/verification.py
@@ -3198,33 +3198,37 @@ class HudsonAnalytical(Test):
         n = 10
         gene_conversion_rate = 5
         gc_tract_lengths = np.append(np.arange(1, 5.25, 0.25), [10, 50])
-        data_to_plot = []
 
-        for k, l in enumerate(gc_tract_lengths):
-            num_gc_events = np.zeros(num_replicates)
-            num_internal_gc_events = np.zeros(num_replicates)
-            sum_internal_gc_tract_lengths = np.zeros(num_replicates)
+        for discrete_genome in [True, False]:
+            data_to_plot = []
 
-            sim = msprime.ancestry._parse_simulate(
-                sample_size=n,
-                length=100,
-                gene_conversion_rate=gene_conversion_rate,
-                gene_conversion_tract_length=gc_tract_lengths[k],
-                discrete_genome=True,
-            )
-            for j, _ts in enumerate(sim.run_replicates(num_replicates)):
-                num_gc_events[j] = sim.num_gene_conversion_events
-                num_internal_gc_events[j] = sim.num_internal_gene_conversion_events
-                sum_internal_gc_tract_lengths[j] = sim.sum_internal_gc_tract_lengths
-                sim.reset()
-            data_to_plot.append(
-                sum_internal_gc_tract_lengths / num_internal_gc_events / l
-            )
-        pyplot.boxplot(data_to_plot, labels=gc_tract_lengths)
-        pyplot.xlabel("tl: mean tract length specified")
-        pyplot.ylabel("average internal tract length / tl")
-        pyplot.savefig(self.output_dir / "mean_gc_tract_lengths.png")
-        pyplot.close("all")
+            for k, l in enumerate(gc_tract_lengths):
+                num_gc_events = np.zeros(num_replicates)
+                num_internal_gc_events = np.zeros(num_replicates)
+                sum_internal_gc_tract_lengths = np.zeros(num_replicates)
+
+                sim = msprime.ancestry._parse_sim_ancestry(
+                    samples=n,
+                    sequence_length=100,
+                    gene_conversion_rate=gene_conversion_rate,
+                    gene_conversion_tract_length=gc_tract_lengths[k],
+                    discrete_genome=discrete_genome,
+                    ploidy=1,
+                )
+                for j, _ts in enumerate(sim.run_replicates(num_replicates)):
+                    num_gc_events[j] = sim.num_gene_conversion_events
+                    num_internal_gc_events[j] = sim.num_internal_gene_conversion_events
+                    sum_internal_gc_tract_lengths[j] = sim.sum_internal_gc_tract_lengths
+                    sim.reset()
+                data_to_plot.append(
+                    sum_internal_gc_tract_lengths / num_internal_gc_events / l
+                )
+            pyplot.boxplot(data_to_plot, labels=gc_tract_lengths)
+            pyplot.xlabel("tl: mean tract length specified")
+            pyplot.ylabel("average internal tract length / tl")
+            filename = f"mean_gc_tract_lengths_discrete={int(discrete_genome)}.png"
+            pyplot.savefig(self.output_dir / filename)
+            pyplot.close("all")
 
     def get_tbl_distribution(self, n, R, executable):
         """

--- a/verification.py
+++ b/verification.py
@@ -3190,6 +3190,42 @@ class HudsonAnalytical(Test):
         pyplot.savefig(self.output_dir / "prob_first_zoom.png")
         pyplot.close("all")
 
+    def test_gc_tract_length_expectation(self):
+        """
+        Runs the check for the mean length of gene conversion tracts.
+        """
+        num_replicates = 100
+        n = 10
+        gene_conversion_rate = 5
+        gc_tract_lengths = np.append(np.arange(1, 5.25, 0.25), [10, 50])
+        data_to_plot = []
+
+        for k, l in enumerate(gc_tract_lengths):
+            num_gc_events = np.zeros(num_replicates)
+            num_internal_gc_events = np.zeros(num_replicates)
+            sum_internal_gc_tract_lengths = np.zeros(num_replicates)
+
+            sim = msprime.ancestry._parse_simulate(
+                sample_size=n,
+                length=100,
+                gene_conversion_rate=gene_conversion_rate,
+                gene_conversion_tract_length=gc_tract_lengths[k],
+                discrete_genome=True,
+            )
+            for j, _ts in enumerate(sim.run_replicates(num_replicates)):
+                num_gc_events[j] = sim.num_gene_conversion_events
+                num_internal_gc_events[j] = sim.num_internal_gene_conversion_events
+                sum_internal_gc_tract_lengths[j] = sim.sum_internal_gc_tract_lengths
+                sim.reset()
+            data_to_plot.append(
+                sum_internal_gc_tract_lengths / num_internal_gc_events / l
+            )
+        pyplot.boxplot(data_to_plot, labels=gc_tract_lengths)
+        pyplot.xlabel("tl: mean tract length specified")
+        pyplot.ylabel("average internal tract length / tl")
+        pyplot.savefig(self.output_dir / "mean_gc_tract_lengths.png")
+        pyplot.close("all")
+
     def get_tbl_distribution(self, n, R, executable):
         """
         Returns an array of the R total branch length values from


### PR DESCRIPTION
This one fixes #1251.

We have unintentionally been simulating too long gene conversion tract lengths, when we switched to continuous coordinates. Tract lengths should be geometrically distributed with mean gc_tract_length. But since we are using continuous coordinates we are using the ceiling of an exponentially distributed random variable. So far we have been using an exponentially distributed variable with mean `gc_tract_length`. But the ceiling of this does not give the correct geometric distribution. This is most easily seen in the special case where `gc_tract_length` is 1. In this case, the discrete tract length should always be equal to 1, but the ceiing of the continuous tract length can be larger. Similary, a continuous mean tract length of 2 will lead to a discrete mean tract length of ~2.54.
The correct mean tract length in the continous case is given by 1/(log(tract_length) - log(tract_length - 1)).
I am defining this now as `self->continuous_gc_tract_length`.
In the special case where the discrete mean tract length is 1, I set `continuous_gc_tract_length` to a small enough number and do not generate any random tract lengths in the discrete case, as this is not necessary.

