### PR TITLE
Don't push docs for PRs with no doc changes, prevent doc push on forks.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,21 +43,29 @@ jobs:
         run: make -C docs
 
       - name: Checkout docs site
+        if: github.repository_owner == 'tskit-dev'
         uses: actions/checkout@v2
         with:
           repository: tskit-dev/msprime-docs
           token: ${{ secrets.ADMINBOT_DOCS_TOKEN }}
           path: msprime-docs
 
+      - name: Check for diff
+        if: github.repository_owner == 'tskit-dev'
+        id: diff
+        #The html contains commit hashes which we don't want to count as a change
+        run: |
+          diff -x .buildinfo -r msprime-docs/main docs/_build/html | grep "^[<>]" | grep -v "<title>\|VERSION:" | grep . && echo "::set-output name=change_detected::true" || echo "NO CHANGES"
+
       - name: Copy our docs to the PR specific location
-        if: github.event.pull_request
+        if: github.repository_owner == 'tskit-dev' && github.event.pull_request && steps.diff.outputs.change_detected
         run: |
           cd msprime-docs
           rm -rf ${{github.event.pull_request.number}}
           cp -r ../docs/_build/html ${{github.event.pull_request.number}}
 
       - name: Copy our docs to the tag specific location
-        if: (!github.event.pull_request)
+        if: github.repository_owner == 'tskit-dev' && !github.event.pull_request
         run: |
           cd msprime-docs
           export DEST=`echo ${GITHUB_REF} | sed -e "s/refs\/heads\///g" |  sed -e "s/refs\/tags\///g"`
@@ -65,6 +73,7 @@ jobs:
           cp -r ../docs/_build/html $DEST
 
       - name: Commit and push the docs
+        if: github.repository_owner == 'tskit-dev' && (steps.diff.outputs.change_detected || (!github.event.pull_request))
         run: |
           cd msprime-docs
           git config user.name Adminbot-tskit
@@ -74,7 +83,7 @@ jobs:
           git push
 
       - name: Comment on PR
-        if: github.event.pull_request
+        if: github.repository_owner == 'tskit-dev' && github.event.pull_request && steps.diff.outputs.change_detected
         uses: mshick/add-pr-comment@v1
         with:
           message: |


### PR DESCRIPTION
Diff the generated HTML to check if a doc preview is needed. Tags still always get built and deployed.