### PR TITLE
Seeds for replicates

### DIFF
--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -255,14 +255,19 @@ RandomGenerator_init(RandomGenerator *self, PyObject *args, PyObject *kwds)
 {
     int ret = -1;
     static char *kwlist[] = {"seed", NULL};
-    PyObject *py_seed;
+    PyObject *py_seed = NULL;
 
     self->rng = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &py_seed)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kwlist, &py_seed)) {
         goto out;
     }
     self->rng = gsl_rng_alloc(gsl_rng_default);
-    ret = RandomGenerator_parse_seed(self, py_seed);
+    if (py_seed != NULL) {
+        if (RandomGenerator_parse_seed(self, py_seed) != 0) {
+            goto out;
+        }
+    }
+    ret = 0;
 out:
     return ret;
 }

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -306,15 +306,31 @@ RandomGenerator_flat(RandomGenerator *self, PyObject *args)
 {
     PyObject *ret = NULL;
     double a, b;
+    long n = 1;
+    long j;
+    npy_intp size;
+    PyObject *array = NULL;
+    double *values;
 
     if (RandomGenerator_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTuple(args, "dd", &a, &b)) {
+    if (!PyArg_ParseTuple(args, "dd|l", &a, &b, &n)) {
         goto out;
     }
-    ret = Py_BuildValue("d", gsl_ran_flat(self->rng, a, b));
+    size = (npy_intp) n;
+    array = PyArray_SimpleNew(1, &size, NPY_FLOAT64);
+    if (array == NULL) {
+        goto out;
+    }
+    values = (double *) PyArray_DATA((PyArrayObject *) array);
+    for (j = 0; j < n; j++) {
+        values[j] = gsl_ran_flat(self->rng, a, b);
+    }
+    ret = array;
+    array = NULL;
 out:
+    Py_XDECREF(array);
     return ret;
 }
 
@@ -322,16 +338,32 @@ static PyObject *
 RandomGenerator_poisson(RandomGenerator *self, PyObject *args)
 {
     PyObject *ret = NULL;
+    long n = 1;
+    long j;
+    npy_intp size;
+    PyObject *array = NULL;
+    uint32_t *values;
     double mu;
 
     if (RandomGenerator_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTuple(args, "d", &mu)) {
+    if (!PyArg_ParseTuple(args, "d|l", &mu, &n)) {
         goto out;
     }
-    ret = Py_BuildValue("I", gsl_ran_poisson(self->rng, mu));
+    size = (npy_intp) n;
+    array = PyArray_SimpleNew(1, &size, NPY_UINT32);
+    if (array == NULL) {
+        goto out;
+    }
+    values = (uint32_t *) PyArray_DATA((PyArrayObject *) array);
+    for (j = 0; j < n; j++) {
+        values[j] = (uint32_t) gsl_ran_poisson(self->rng, mu);
+    }
+    ret = array;
+    array = NULL;
 out:
+    Py_XDECREF(array);
     return ret;
 }
 
@@ -339,16 +371,32 @@ static PyObject *
 RandomGenerator_uniform_int(RandomGenerator *self, PyObject *args)
 {
     PyObject *ret = NULL;
-    unsigned long n;
+    long n = 1;
+    long j;
+    npy_intp size;
+    PyObject *array = NULL;
+    uint32_t *values;
+    unsigned long max;
 
     if (RandomGenerator_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTuple(args, "k", &n)) {
+    if (!PyArg_ParseTuple(args, "k|l", &max, &n)) {
         goto out;
     }
-    ret = Py_BuildValue("k", gsl_rng_uniform_int(self->rng, n));
+    size = (npy_intp) n;
+    array = PyArray_SimpleNew(1, &size, NPY_UINT32);
+    if (array == NULL) {
+        goto out;
+    }
+    values = (uint32_t *) PyArray_DATA((PyArrayObject *) array);
+    for (j = 0; j < n; j++) {
+        values[j] = (uint32_t) gsl_rng_uniform_int(self->rng, max);
+    }
+    ret = array;
+    array = NULL;
 out:
+    Py_XDECREF(array);
     return ret;
 }
 

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1319,13 +1319,13 @@ class Simulator(_msprime.Simulator):
             self.run()
 
             if mutation_rate is not None:
-                seed = 1 + self.random_generator.uniform_int(2 ** 31 - 2)
+                # This is only called from simulate() or the ms interface,
+                # so does not need any further parameters.
                 mutations._simple_mutate(
-                    self.tables,
-                    int(seed),
+                    tables=self.tables,
+                    random_generator=self.random_generator,
                     sequence_length=self.sequence_length,
                     rate=mutation_rate,
-                    discrete_sites=self.discrete_genome,
                 )
             tables = tskit.TableCollection.fromdict(self.tables.asdict())
             replicate_provenance = None

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -29,7 +29,6 @@ import sys
 import tskit
 
 import msprime
-from . import _msprime
 from . import ancestry
 
 
@@ -227,8 +226,7 @@ class SimulationRunner:
         ms_seeds = random_seeds
         if random_seeds is None:
             ms_seeds = generate_seeds()
-        seed = get_single_seed(ms_seeds)
-        self._random_generator = _msprime.RandomGenerator(seed)
+        self._random_seed = get_single_seed(ms_seeds)
         self._ms_random_seeds = ms_seeds
 
         # If we have specified any population_configurations we don't want
@@ -248,7 +246,6 @@ class SimulationRunner:
             demographic_events=demographic_events,
             gene_conversion_rate=scaled_gene_conversion_rate,
             gene_conversion_tract_length=gene_conversion_tract_length,
-            random_generator=self._random_generator,
             discrete_genome=True,
         )
 
@@ -314,7 +311,10 @@ class SimulationRunner:
         # The first line of ms's output is the command line.
         print(" ".join(sys.argv), file=output)
         print(" ".join(str(s) for s in self._ms_random_seeds), file=output)
-        for ts in self._simulator.run_replicates(self._num_replicates):
+        replicates = self._simulator.run_replicates(
+            self._num_replicates, random_seed=self._random_seed
+        )
+        for ts in replicates:
             # This is a hack. We should have some sort of "mutator" argument
             # to run_replicates that passes in various args or something
             seed = 1 + self._simulator.random_generator.uniform_int(2 ** 31 - 2)

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -197,7 +197,7 @@ class SimulationRunner:
         mutation_rate=0,
         print_trees=False,
         precision=3,
-        random_seeds=None,
+        ms_random_seeds=None,
         gene_conversion_rate=0,
         gene_conversion_tract_length=1,
         hotspots=None,
@@ -216,11 +216,12 @@ class SimulationRunner:
             # This is just used for testing so values don't really matter.
             demography = msprime.Demography.simple_model(1)
 
-        ms_seeds = random_seeds
-        if random_seeds is None:
-            ms_seeds = generate_seeds()
-        self.random_seed = get_single_seed(ms_seeds)
-        self.ms_random_seeds = ms_seeds
+        self.ms_random_seeds = ms_random_seeds
+        if ms_random_seeds is None:
+            self.ms_random_seeds = generate_seeds()
+        # The ms command line requires three integers. We combine these into
+        # a single seed.
+        random_seed = get_single_seed(self.ms_random_seeds)
 
         # We need to get direct access to the simulator here because of the
         # "invisible" recombination breakpoints, so we can't run simulations
@@ -232,6 +233,7 @@ class SimulationRunner:
             gene_conversion_rate=gene_conversion_rate,
             gene_conversion_tract_length=gene_conversion_tract_length,
             ploidy=1,
+            random_seed=random_seed,
         )
 
     def _print_trees(self, tree_sequence, output):
@@ -268,7 +270,6 @@ class SimulationRunner:
         print(" ".join(str(s) for s in self.ms_random_seeds), file=output)
         replicates = self.simulator.run_replicates(
             self.num_replicates,
-            random_seed=self.random_seed,
             mutation_rate=self.mutation_rate,
         )
         for ts in replicates:
@@ -629,7 +630,7 @@ def create_simulation_runner(parser, arg_list):
         gene_conversion_tract_length=gc_tract_length,
         precision=args.precision,
         print_trees=args.trees,
-        random_seeds=args.random_seeds,
+        ms_random_seeds=args.random_seeds,
         hotspots=args.hotspots,
     )
     return runner

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -189,101 +189,73 @@ class SimulationRunner:
 
     def __init__(
         self,
-        samples,
+        num_samples,
         demography=None,
         num_loci=1,
-        scaled_recombination_rate=0,
+        recombination_rate=0,
         num_replicates=1,
-        scaled_mutation_rate=0,
+        mutation_rate=0,
         print_trees=False,
         precision=3,
         random_seeds=None,
-        scaled_gene_conversion_rate=0,
+        gene_conversion_rate=0,
         gene_conversion_tract_length=1,
         hotspots=None,
     ):
-        self._num_loci = num_loci
-        self._num_replicates = num_replicates
-        self._recombination_rate = scaled_recombination_rate
-        self._mutation_rate = scaled_mutation_rate
-        # For strict ms-compability we want to have m non-recombining loci
+        self.num_loci = num_loci
+        self.num_replicates = num_replicates
+        self.mutation_rate = mutation_rate
+        self.precision = precision
+        self.print_trees = print_trees
         if hotspots is None:
-            self._recomb_map = msprime.RateMap.uniform(
-                num_loci, self._recombination_rate
-            )
+            recomb_map = msprime.RateMap.uniform(num_loci, recombination_rate)
         else:
-            self._recomb_map = hotspots_to_recomb_map(
-                hotspots, self._recombination_rate, num_loci
-            )
+            recomb_map = hotspots_to_recomb_map(hotspots, recombination_rate, num_loci)
 
-        # sort out the random seeds
+        if demography is None:
+            # This is just used for testing so values don't really matter.
+            demography = msprime.Demography.simple_model(1)
+
         ms_seeds = random_seeds
         if random_seeds is None:
             ms_seeds = generate_seeds()
-        self._random_seed = get_single_seed(ms_seeds)
-        self._ms_random_seeds = ms_seeds
+        self.random_seed = get_single_seed(ms_seeds)
+        self.ms_random_seeds = ms_seeds
 
-        self._simulator = ancestry._parse_sim_ancestry(
-            samples=samples,
+        # We need to get direct access to the simulator here because of the
+        # "invisible" recombination breakpoints, so we can't run simulations
+        # the usual way via sim_ancestry.
+        self.simulator = ancestry._parse_sim_ancestry(
+            samples=demography.sample(*num_samples),
             demography=demography,
-            recombination_rate=self._recomb_map,
-            gene_conversion_rate=scaled_gene_conversion_rate,
+            recombination_rate=recomb_map,
+            gene_conversion_rate=gene_conversion_rate,
             gene_conversion_tract_length=gene_conversion_tract_length,
             ploidy=1,
         )
 
-        self._precision = precision
-        self._print_trees = print_trees
-
-    def get_num_replicates(self):
-        """
-        Returns the number of replicates we are to run.
-        """
-        return self._num_replicates
-
-    def get_simulator(self):
-        """
-        Returns the simulator instance for this simulation runner.
-        """
-        return self._simulator
-
-    def get_mutation_rate(self):
-        """
-        Returns the per-base, per generation mutation rate used by
-        msprime.
-        """
-        return self._mutation_rate
-
-    def get_recomb_map(self):
-        """
-        Returns the RecombinationMap used by msprime.
-        """
-        return self._recomb_map
-
-    def print_trees(self, tree_sequence, output):
+    def _print_trees(self, tree_sequence, output):
         """
         Print out the trees in ms-format from the specified tree sequence.
         When 'invisible' recombinations occur ms prints out copies of the
         same tree. Therefore, we must keep track of all breakpoints from the
         simulation and write out a tree for each one.
         """
-        breakpoints = list(self._simulator.breakpoints) + [self._num_loci]
-        if self._num_loci == 1:
+        if self.num_loci == 1:
             tree = next(tree_sequence.trees())
-            newick = tree.newick(precision=self._precision)
+            newick = tree.newick(precision=self.precision)
             print(newick, file=output)
         else:
+            breakpoints = list(self.simulator.breakpoints) + [self.num_loci]
             j = 0
             for tree in tree_sequence.trees():
-                newick = tree.newick(precision=self._precision)
+                newick = tree.newick(precision=self.precision)
                 left, right = tree.interval
                 while j < len(breakpoints) and breakpoints[j] <= right:
-                    length = breakpoints[j] - left
+                    length = int(breakpoints[j] - left)
                     left = breakpoints[j]
                     j += 1
-                    # Print these seperately to avoid the cost of creating
-                    # another string.
-                    print("[{}]".format(int(length)), end="", file=output)
+                    print(f"[{length}]", end="", file=output)
                     print(newick, file=output)
 
     def run(self, output):
@@ -293,38 +265,27 @@ class SimulationRunner:
         """
         # The first line of ms's output is the command line.
         print(" ".join(sys.argv), file=output)
-        print(" ".join(str(s) for s in self._ms_random_seeds), file=output)
-        replicates = self._simulator.run_replicates(
-            self._num_replicates, random_seed=self._random_seed
+        print(" ".join(str(s) for s in self.ms_random_seeds), file=output)
+        replicates = self.simulator.run_replicates(
+            self.num_replicates,
+            random_seed=self.random_seed,
+            mutation_rate=self.mutation_rate,
         )
         for ts in replicates:
-            # This is a hack. We should have some sort of "mutator" argument
-            # to run_replicates that passes in various args or something
-            seed = 1 + self._simulator.random_generator.uniform_int(2 ** 31 - 2)
-            ts = msprime.mutate(
-                ts,
-                self._mutation_rate,
-                model=msprime.BinaryMutationModel(),
-                random_seed=seed,
-            )
             print(file=output)
             print("//", file=output)
-            if self._print_trees:
-                self.print_trees(ts, output)
-            if self._mutation_rate > 0:
+            if self.print_trees:
+                self._print_trees(ts, output)
+            if self.mutation_rate > 0:
                 assert ts.num_sites == ts.num_mutations
                 s = ts.num_sites
                 print("segsites:", s, file=output)
                 if s != 0:
                     print("positions: ", end="", file=output)
-                    positions = [
-                        mutation.position / self._num_loci
-                        for mutation in ts.mutations()
-                    ]
-                    positions.sort()
-                    for position in positions:
+                    for site in ts.sites():
+                        x = site.position / self.num_loci
                         print(
-                            "{0:.{1}f}".format(position, self._precision),
+                            "{0:.{1}f}".format(x, self.precision),
                             end=" ",
                             file=output,
                         )
@@ -449,26 +410,21 @@ def create_simulation_runner(parser, arg_list):
     else:
         gc_rate = r * gc_param
 
+    demography = msprime.Demography.simple_model(1)
     # Check the structure format.
     symmetric_migration_rate = 0.0
     num_populations = 1
-    num_samples = [args.sample_size]
-    population_configurations = [msprime.PopulationConfiguration(initial_size=1)]
     migration_matrix = [[0.0]]
+    num_samples = [args.sample_size]
     if args.structure is not None:
         num_populations = convert_int(args.structure[0], parser)
         # We must have at least num_population sample_configurations
         if len(args.structure) < num_populations + 1:
             parser.error("Must have num_populations sample sizes")
-        population_configurations = [None for j in range(num_populations)]
-        num_samples = [0 for _ in range(num_populations)]
+        demography = msprime.Demography.simple_model([1] * num_populations)
+        num_samples = [0] * num_populations
         for j in range(num_populations):
             num_samples[j] = convert_int(args.structure[j + 1], parser)
-            population_configurations[j] = msprime.PopulationConfiguration(0)
-            # convert_int(args.structure[j + 1], parser)
-            # convert_int(args.structure[j + 1], parser)
-            # )
-        # total = sum(conf.sample_size for conf in population_configurations)
         if sum(num_samples) != args.sample_size:
             parser.error("Population sample sizes must sum to sample_size")
         # We optionally have the overall migration_rate here
@@ -512,17 +468,17 @@ def create_simulation_runner(parser, arg_list):
         migration_matrix[pop_i][pop_j] = rate
 
     # Set the initial demography
-    demographic_events = []
     if args.growth_rate is not None:
-        for config in population_configurations:
-            config.growth_rate = args.growth_rate
+        for population in demography.populations:
+            population.growth_rate = args.growth_rate
     for population_id, growth_rate in args.population_growth_rate:
         pid = convert_population_id(parser, population_id, num_populations)
-        population_configurations[pid].growth_rate = growth_rate
+        demography.populations[pid].growth_rate = growth_rate
     for population_id, size in args.population_size:
         pid = convert_population_id(parser, population_id, num_populations)
-        population_configurations[pid].initial_size = size
+        demography.populations[pid].initial_size = size
 
+    demographic_events = []
     # First we look at population split events. We do this differently
     # to ms, as msprime requires a fixed number of population. Therefore,
     # modify the number of populations to take into account populations
@@ -543,9 +499,8 @@ def create_simulation_runner(parser, arg_list):
         for row in migration_matrix:
             row.append(0)
         migration_matrix.append([0 for j in range(num_populations)])
-        # Add another PopulationConfiguration object with a sample size
-        # of zero.
-        population_configurations.append(msprime.PopulationConfiguration(0))
+        demography.populations.append(msprime.Population(initial_size=1))
+        num_samples.append(0)
 
     # Add the demographic events
     for index, (t, alpha) in args.growth_rate_change:
@@ -645,40 +600,32 @@ def create_simulation_runner(parser, arg_list):
                     )
                     demographic_events.append((index, msp_event))
 
-    # We've created all the events and PopulationConfiguration objects. Because
-    # msprime uses absolute population sizes we need to rescale these relative
-    # to Ne, since this is what ms does.
-    for _, msp_event in demographic_events:
-        if isinstance(msp_event, msprime.PopulationParametersChange):
-            if msp_event.initial_size is not None:
-                msp_event.initial_size /= 2
-    for config in population_configurations:
-        if config.initial_size is not None:
-            config.initial_size /= 2
-
     demographic_events.sort(key=lambda x: (x[0], x[1].time))
     time_sorted = sorted(demographic_events, key=lambda x: x[1].time)
     if demographic_events != time_sorted:
         parser.error("Demographic events must be supplied in non-decreasing time order")
 
-    # TODO change this so we make a new-style demography directly
-    demography = msprime.Demography.from_old_style(
-        population_configurations=population_configurations,
-        migration_matrix=migration_matrix,
-        demographic_events=[event for _, event in demographic_events],
-    )
-    for population in demography.populations:
-        if population.initial_size is None:
-            population.initial_size = 0.5
-    samples = demography.sample(*num_samples)
+    demography.events = [event for _, event in demographic_events]
+    demography.migration_matrix = migration_matrix
+
+    # Adjust the population sizes so that the timescales agree. In principle
+    # we could correct this with a ploidy value=0.5, but what we have here
+    # seems less awful.
+    for msp_event in demography.events:
+        if isinstance(msp_event, msprime.PopulationParametersChange):
+            if msp_event.initial_size is not None:
+                msp_event.initial_size /= 2
+    for pop in demography.populations:
+        pop.initial_size /= 2
+
     runner = SimulationRunner(
-        samples,
+        num_samples,
         demography,
         num_loci=num_loci,
         num_replicates=args.num_replicates,
-        scaled_recombination_rate=r,
-        scaled_mutation_rate=mu,
-        scaled_gene_conversion_rate=gc_rate,
+        recombination_rate=r,
+        mutation_rate=mu,
+        gene_conversion_rate=gc_rate,
         gene_conversion_tract_length=gc_tract_length,
         precision=args.precision,
         print_trees=args.trees,
@@ -693,7 +640,7 @@ class IndexedAction(argparse._AppendAction):
     Argparse action class that allows us to find the overall ordering
     across several different options. We use this for the demographic
     events, as the order in which the events are applied matters for
-    ms compatability.
+    ms compatibility.
     """
 
     index = 0

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -236,15 +236,36 @@ class Demography:
             demography.events = demographic_events
         return demography
 
-    @staticmethod
-    def simple_model(population_size=1):
+    # TODO give this a better name and document it.
+    # What about "isolated" as it gives an easy way of describing isolated pops?
+    def simple_model(initial_size=1, growth_rate=None):
         """
         Returns a simple single-population model.
         """
-        check_population_size(population_size)
-        pop = Population(initial_size=population_size, name="pop_0")
-        model = Demography(populations=[pop])
-        return model
+        initial_size = np.array(initial_size, ndmin=1)
+        if len(initial_size.shape) != 1:
+            raise ValueError(
+                "The initial_size argument must be scalar value or an "
+                "1D array of population size values"
+            )
+        if growth_rate is None:
+            growth_rate = np.zeros_like(initial_size)
+        else:
+            growth_rate = np.array(growth_rate, ndmin=1)
+        if initial_size.shape != growth_rate.shape:
+            raise ValueError(
+                "If growth_rate is specified it must be a 1D array of the same "
+                "length as the population_size array"
+            )
+        populations = [
+            Population(
+                initial_size=initial_size[j],
+                growth_rate=growth_rate[j],
+                name=f"pop_{j}",
+            )
+            for j in range(len(initial_size))
+        ]
+        return Demography(populations=populations)
 
     @staticmethod
     def island_model(num_populations, migration_rate, Ne=1):

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1043,12 +1043,12 @@ class InfiniteSites(MatrixMutationModel):
 
 def _simple_mutate(
     tables,
-    rng,
+    random_seed,
     rate,
     sequence_length,
     discrete_sites=False,
-    kept_mutations_before_end_time=False,
 ):
+    rng = _msprime.RandomGenerator(random_seed)
     rate_map = intervals.RateMap.uniform(sequence_length, rate)
     _msprime.sim_mutations(
         tables,
@@ -1056,7 +1056,6 @@ def _simple_mutate(
         rate_map.asdict(),
         model=BinaryMutationModel(),
         discrete_sites=discrete_sites,
-        kept_mutations_before_end_time=kept_mutations_before_end_time,
     )
 
 

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1042,20 +1042,23 @@ class InfiniteSites(MatrixMutationModel):
 
 
 def _simple_mutate(
+    *,
     tables,
-    random_seed,
-    rate,
     sequence_length,
-    discrete_sites=False,
+    rate,
+    random_generator,
 ):
-    rng = _msprime.RandomGenerator(random_seed)
+    """
+    Generate mutations directly using the low-level interfaces. Only
+    for internal use with the ms and old-style simulate() interfaces.
+    """
     rate_map = intervals.RateMap.uniform(sequence_length, rate)
     _msprime.sim_mutations(
         tables,
-        rng,
+        random_generator,
         rate_map.asdict(),
         model=BinaryMutationModel(),
-        discrete_sites=discrete_sites,
+        discrete_sites=False,
     )
 
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -150,9 +150,9 @@ class TestAlgorithms:
         assert len(stderr) == 0
 
     def test_from_ts(self):
-        from_ts = msprime.simulate(
+        from_ts = msprime.sim_ancestry(
             10,
-            length=100,
+            sequence_length=100,
             discrete_genome=True,
             recombination_rate=2,
             random_seed=2,

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -392,7 +392,10 @@ class TestParseRandomSeed:
             assert rng.seed == int(seed)
 
     def test_bad_values(self):
-        for bad_seed in [-1, 0, -10000]:
+        for bad_seed in [-1, -10000, 2 ** 64]:
+            with pytest.raises(OverflowError):
+                ancestry._parse_random_seed(bad_seed)
+        for bad_seed in [0, 2 ** 32]:
             with pytest.raises(ValueError):
                 ancestry._parse_random_seed(bad_seed)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,20 +653,20 @@ class TestMspmsCreateSimulationRunner:
         for event in events:
             assert event.time == 1.0
         assert isinstance(events[0], msprime.PopulationParametersChange)
-        assert events[0].initial_size == 0.5
+        assert events[0].initial_size == 1
         assert events[0].growth_rate == 0
         assert isinstance(events[1], msprime.PopulationParametersChange)
         assert events[1].growth_rate == 3
         assert events[1].initial_size is None
         assert isinstance(events[2], msprime.PopulationParametersChange)
-        assert events[2].initial_size == 1
+        assert events[2].initial_size == 2
         assert events[2].growth_rate == 0
 
     def test_population_growth_rate(self):
         def f(args):
             sim = self.create_simulator(args)
             return [
-                (c.initial_size * 4, c.growth_rate) for c in sim.demography.populations
+                (c.initial_size * 2, c.growth_rate) for c in sim.demography.populations
             ]
 
         assert f("2 1 -T -I 3 2 0 0 -g 1 -1") == [(1, -1), (1, 0), (1, 0)]
@@ -685,7 +685,7 @@ class TestMspmsCreateSimulationRunner:
         def f(args):
             sim = self.create_simulator(args)
             return [
-                (c.initial_size * 4, c.growth_rate) for c in sim.demography.populations
+                (c.initial_size * 2, c.growth_rate) for c in sim.demography.populations
             ]
 
         assert f("2 1 -T -I 3 2 0 0 -n 1 2") == [(2, 0), (1, 0), (1, 0)]
@@ -729,19 +729,19 @@ class TestMspmsCreateSimulationRunner:
         events = f("2 1 -T -en 0.1 1 2")
         assert len(events) == 1
         assert isinstance(events[0], msprime.PopulationParametersChange)
-        assert events[0].initial_size == 2.0 / 4
+        assert events[0].initial_size == 2.0 / 2
         assert events[0].growth_rate == 0
         assert events[0].time == 0.1
         assert events[0].population == 0
         events = f("2 1 -T -I 2 1 1 -en 0.1 1 2 -en 0.2 2 3")
         assert len(events) == 2
         assert isinstance(events[0], msprime.PopulationParametersChange)
-        assert events[0].initial_size == 2.0 / 4
+        assert events[0].initial_size == 2.0 / 2
         assert events[0].growth_rate == 0
         assert events[0].time == 0.1
         assert events[0].population == 0
         assert isinstance(events[1], msprime.PopulationParametersChange)
-        assert events[1].initial_size == 3.0 / 4
+        assert events[1].initial_size == 3.0 / 2
         assert events[1].growth_rate == 0
         assert events[1].time == 0.2
         assert events[1].population == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -975,7 +975,7 @@ class TestMspmsOutput(TestCli):
             mutation_rate=mutation_rate,
             print_trees=print_trees,
             precision=precision,
-            random_seeds=random_seeds,
+            ms_random_seeds=random_seeds,
         )
         with open(self.temp_file, "w+") as f:
             sr.run(f)
@@ -1151,7 +1151,7 @@ class TestMspmsOutput(TestCli):
         sr = cli.SimulationRunner(
             [sample_size],
             mutation_rate=mutation_rate,
-            random_seeds=seeds,
+            ms_random_seeds=seeds,
         )
         with tempfile.TemporaryFile("w+") as f:
             sr.run(f)

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -3757,6 +3757,49 @@ class TestDemographyObject:
         with pytest.raises(ValueError):
             model.sample(0, A=1)
 
+    def test_simple_model(self):
+        demography = msprime.Demography.simple_model(2)
+        assert demography.num_populations == 1
+        assert demography.populations[0].initial_size == 2
+        assert demography.populations[0].growth_rate == 0
+
+        demography = msprime.Demography.simple_model(2, 3)
+        assert demography.num_populations == 1
+        assert demography.populations[0].initial_size == 2
+        assert demography.populations[0].growth_rate == 3
+
+        demography = msprime.Demography.simple_model([3])
+        assert demography.num_populations == 1
+        assert demography.populations[0].initial_size == 3
+        assert demography.populations[0].growth_rate == 0
+
+        demography = msprime.Demography.simple_model([3], [4])
+        assert demography.num_populations == 1
+        assert demography.populations[0].initial_size == 3
+        assert demography.populations[0].growth_rate == 4
+
+        demography = msprime.Demography.simple_model([5, 6])
+        assert demography.num_populations == 2
+        assert demography.populations[0].initial_size == 5
+        assert demography.populations[0].growth_rate == 0
+        assert demography.populations[1].initial_size == 6
+        assert demography.populations[1].growth_rate == 0
+
+        demography = msprime.Demography.simple_model([5, 6], [7, 8])
+        assert demography.num_populations == 2
+        assert demography.populations[0].initial_size == 5
+        assert demography.populations[0].growth_rate == 7
+        assert demography.populations[1].initial_size == 6
+        assert demography.populations[1].growth_rate == 8
+
+    def test_simple_model_errors(self):
+        with pytest.raises(ValueError):
+            msprime.Demography.simple_model([[], []])
+        with pytest.raises(ValueError):
+            msprime.Demography.simple_model([1], [[], []])
+        with pytest.raises(ValueError):
+            msprime.Demography.simple_model([1], [])
+
 
 class TestDemographyFromOldStyle:
     """

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -2576,6 +2576,22 @@ class HistoricalSamplingMixin:
     Tests to make sure historical sampling works correctly.
     """
 
+    def test_two_diploid_samples(self):
+        N = 100
+        sampling_time = 1.01 * N
+        ts = msprime.sim_ancestry(
+            population_size=N,
+            ploidy=2,
+            model=self.model,
+            samples=[msprime.Sample(0, 0), msprime.Sample(0, sampling_time)],
+            random_seed=3,
+        )
+        for t in ts.trees():
+            assert t.get_time(0) == 0
+            assert t.get_time(1) == 0
+            assert t.get_time(2) == sampling_time
+            assert t.get_time(3) == sampling_time
+
     def test_two_samples(self):
         N = 100
         sampling_time = 1.01 * N
@@ -2583,12 +2599,10 @@ class HistoricalSamplingMixin:
             ts = msprime.simulate(
                 Ne=N,
                 model=self.model,
-                recombination_map=msprime.RecombinationMap.uniform_map(
-                    length=1, rate=recombination_rate
-                ),
+                recombination_rate=recombination_rate,
+                length=1,
                 samples=[msprime.Sample(0, 0), msprime.Sample(0, sampling_time)],
                 random_seed=3,
-                discrete_genome=True,
             )
             for t in ts.trees():
                 assert t.get_time(0) == 0

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2041,8 +2041,12 @@ class TestRandomGenerator:
                 rng.flat(bad_type, 1)
             with pytest.raises(TypeError):
                 rng.flat(0, bad_type)
+            with pytest.raises(TypeError):
+                rng.flat(0, 1, bad_type)
+        with pytest.raises(ValueError):
+            rng.flat(0, 1, -1)
 
-    def test_flat(self):
+    def test_flat_single(self):
         rng3 = _msprime.RandomGenerator(1)
         for seed in [1, 2, 2 ** 32 - 1]:
             rng1 = _msprime.RandomGenerator(seed)
@@ -2051,8 +2055,23 @@ class TestRandomGenerator:
             values = [0, 1, 10, -10, 1e200, -1e200]
             for a, b in itertools.product(values, repeat=2):
                 x = rng1.flat(a, b)
+                assert x.shape == (1,)
                 assert x == rng2.flat(a, b)
                 assert x == rng3.flat(a, b)
+
+    def test_flat_array(self):
+        rng3 = _msprime.RandomGenerator(1)
+        for seed in [1, 2, 2 ** 32 - 1]:
+            rng1 = _msprime.RandomGenerator(seed)
+            rng2 = _msprime.RandomGenerator(seed)
+            rng3.seed = seed
+            for n in range(10):
+                x1 = rng1.flat(0, 1, n)
+                x2 = rng2.flat(0, 1, n)
+                x3 = rng3.flat(0, 1, n)
+                assert x1.shape == (n,)
+                assert np.array_equal(x1, x2)
+                assert np.array_equal(x1, x3)
 
     def test_poisson_errors(self):
         rng = _msprime.RandomGenerator(1)
@@ -2061,8 +2080,12 @@ class TestRandomGenerator:
         for bad_type in ["as", [], None]:
             with pytest.raises(TypeError):
                 rng.poisson(bad_type)
+            with pytest.raises(TypeError):
+                rng.poisson(1, bad_type)
+        with pytest.raises(ValueError):
+            rng.flat(0, 1, -1)
 
-    def test_poisson(self):
+    def test_poisson_single(self):
         rng3 = _msprime.RandomGenerator(1)
         for seed in [1, 2, 2 ** 32 - 1]:
             rng1 = _msprime.RandomGenerator(seed)
@@ -2071,8 +2094,23 @@ class TestRandomGenerator:
             values = [0.001, 1e-6, 0, 1, 10, -10, 100]
             for mu in values:
                 x = rng1.poisson(mu)
+                assert x.shape == (1,)
                 assert x == rng2.poisson(mu)
                 assert x == rng3.poisson(mu)
+
+    def test_poisson_array(self):
+        rng3 = _msprime.RandomGenerator(1)
+        for seed in [1, 2, 2 ** 32 - 1]:
+            rng1 = _msprime.RandomGenerator(seed)
+            rng2 = _msprime.RandomGenerator(seed)
+            rng3.seed = seed
+            for n in range(10):
+                x1 = rng1.poisson(100, n)
+                x2 = rng2.poisson(100, n)
+                x3 = rng3.poisson(100, n)
+                assert x1.shape == (n,)
+                assert np.array_equal(x1, x2)
+                assert np.array_equal(x1, x3)
 
     def test_uniform_int_errors(self):
         rng = _msprime.RandomGenerator(1)
@@ -2081,8 +2119,10 @@ class TestRandomGenerator:
         for bad_type in ["as", [], None]:
             with pytest.raises(TypeError):
                 rng.uniform_int(bad_type)
+            with pytest.raises(TypeError):
+                rng.uniform_int(1, bad_type)
 
-    def test_uniform_int(self):
+    def test_uniform_int_single(self):
         rng3 = _msprime.RandomGenerator(1)
         for seed in [1, 2, 2 ** 32 - 1]:
             rng1 = _msprime.RandomGenerator(seed)
@@ -2091,8 +2131,23 @@ class TestRandomGenerator:
             values = [-1, 0, 1, 2, 10, 100, 2 ** 31]
             for n in values:
                 x = rng1.uniform_int(n)
+                assert x.shape == (1,)
                 assert x == rng2.uniform_int(n)
                 assert x == rng3.uniform_int(n)
+
+    def test_uniform_int_array(self):
+        rng3 = _msprime.RandomGenerator(1)
+        for seed in [1, 2, 2 ** 32 - 1]:
+            rng1 = _msprime.RandomGenerator(seed)
+            rng2 = _msprime.RandomGenerator(seed)
+            rng3.seed = seed
+            for n in range(10):
+                x1 = rng1.uniform_int(100, n)
+                x2 = rng2.uniform_int(100, n)
+                x3 = rng3.uniform_int(100, n)
+                assert x1.shape == (n,)
+                assert np.array_equal(x1, x2)
+                assert np.array_equal(x1, x3)
 
 
 class TestMatrixMutationModel:

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1983,37 +1983,33 @@ class TestRandomGenerator:
     """
 
     def test_constructor(self):
-        with pytest.raises(TypeError):
-            _msprime.RandomGenerator()
+        rng = _msprime.RandomGenerator()
+        assert rng is not None
         for bad_type in ["x", 1.0, {}]:
             with pytest.raises(TypeError):
                 _msprime.RandomGenerator(bad_type)
 
     def test_seed_bounds(self):
         for bad_value in [0, 2 ** 32]:
-            with pytest.raises(ValueError):
-                _msprime.RandomGenerator(bad_value)
-            gen = _msprime.RandomGenerator(1)
+            gen = _msprime.RandomGenerator()
             with pytest.raises(ValueError):
                 gen.seed = bad_value
 
         for overflow in [-1, -2, 2 ** 64]:
-            with pytest.raises(OverflowError):
-                _msprime.RandomGenerator(overflow)
-            gen = _msprime.RandomGenerator(1)
+            gen = _msprime.RandomGenerator()
             with pytest.raises(OverflowError):
                 gen.seed = overflow
 
     def test_seed(self):
 
         for s in [1, 10, 2 ** 32 - 1]:
-            rng = _msprime.RandomGenerator(s)
-            assert rng.seed == s
-            rng = _msprime.RandomGenerator(1)
+            rng = _msprime.RandomGenerator()
             rng.seed = s
             assert rng.seed == s
+            rng = _msprime.RandomGenerator(s)
+            assert rng.seed == s
 
-        rng = _msprime.RandomGenerator(1)
+        rng = _msprime.RandomGenerator()
         with pytest.raises(TypeError):
             rng.seed = None
         with pytest.raises(AttributeError):
@@ -2031,7 +2027,7 @@ class TestRandomGenerator:
             uninitialised_rng.uniform_int()
 
     def test_flat_errors(self):
-        rng = _msprime.RandomGenerator(1)
+        rng = _msprime.RandomGenerator()
         with pytest.raises(TypeError):
             rng.flat()
         with pytest.raises(TypeError):
@@ -2047,7 +2043,7 @@ class TestRandomGenerator:
             rng.flat(0, 1, -1)
 
     def test_flat_single(self):
-        rng3 = _msprime.RandomGenerator(1)
+        rng3 = _msprime.RandomGenerator()
         for seed in [1, 2, 2 ** 32 - 1]:
             rng1 = _msprime.RandomGenerator(seed)
             rng2 = _msprime.RandomGenerator(seed)
@@ -2060,7 +2056,7 @@ class TestRandomGenerator:
                 assert x == rng3.flat(a, b)
 
     def test_flat_array(self):
-        rng3 = _msprime.RandomGenerator(1)
+        rng3 = _msprime.RandomGenerator()
         for seed in [1, 2, 2 ** 32 - 1]:
             rng1 = _msprime.RandomGenerator(seed)
             rng2 = _msprime.RandomGenerator(seed)
@@ -2086,7 +2082,7 @@ class TestRandomGenerator:
             rng.flat(0, 1, -1)
 
     def test_poisson_single(self):
-        rng3 = _msprime.RandomGenerator(1)
+        rng3 = _msprime.RandomGenerator()
         for seed in [1, 2, 2 ** 32 - 1]:
             rng1 = _msprime.RandomGenerator(seed)
             rng2 = _msprime.RandomGenerator(seed)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -302,7 +302,6 @@ class TestRejectedCommonAncestorEventCounts:
         sim = ancestry._parse_simulate(
             sample_size=10,
             recombination_rate=10,
-            random_generator=_msprime.RandomGenerator(2),
         )
         sim.run()
         assert sim.num_common_ancestor_events > threshold
@@ -313,7 +312,6 @@ class TestRejectedCommonAncestorEventCounts:
             sample_size=10,
             recombination_rate=10,
             model="hudson",
-            random_generator=_msprime.RandomGenerator(2),
         )
         sim2.run()
         assert sim2.num_common_ancestor_events == sim.num_common_ancestor_events

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -302,6 +302,7 @@ class TestRejectedCommonAncestorEventCounts:
         sim = ancestry._parse_simulate(
             sample_size=10,
             recombination_rate=10,
+            random_seed=32,
         )
         sim.run()
         assert sim.num_common_ancestor_events > threshold
@@ -312,6 +313,7 @@ class TestRejectedCommonAncestorEventCounts:
             sample_size=10,
             recombination_rate=10,
             model="hudson",
+            random_seed=32,
         )
         sim2.run()
         assert sim2.num_common_ancestor_events == sim.num_common_ancestor_events

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -494,13 +494,13 @@ class TestDtwf:
         assert ts.num_trees == 1
 
     def test_single_recombination(self):
-        recombination_map = msprime.RecombinationMap([0, 100, 101, 200], [0, 1, 0, 0])
-        ts = msprime.simulate(
+        recombination_map = msprime.RateMap([0, 100, 101, 200], [0, 1, 0])
+        ts = msprime.sim_ancestry(
             10,
-            Ne=10,
+            population_size=10,
             model="dtwf",
             random_seed=2,
-            recombination_map=recombination_map,
+            recombination_rate=recombination_map,
             discrete_genome=True,
         )
         assert ts.num_trees == 2

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1808,8 +1808,8 @@ class PythonMutationGenerator:
                 # Generate the mutations.
                 rate = self.rate_map.rate[index]
                 mu = rate * (site_right - site_left) * branch_length
-                for _ in range(self.rng.poisson(mu)):
-                    position = self.rng.flat(site_left, site_right)
+                for _ in range(self.rng.poisson(mu)[0]):
+                    position = self.rng.flat(site_left, site_right)[0]
                     if discrete:
                         position = np.floor(position)
                     assert edge.left <= position

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -860,7 +860,7 @@ class TestKeep:
 
     def test_random_metadata(self):
         ts = tsutil.add_random_metadata(
-            msprime.simulate(12, random_seed=3, mutation_rate=1)
+            msprime.simulate(12, random_seed=4, mutation_rate=1)
         )
         assert ts.num_sites > 5
         self.verify(ts, 3, random_seed=7)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -50,7 +50,6 @@ class TestProvenance:
         assert libs["tskit"] == {"version": tskit.__version__}
 
 
-@pytest.mark.skip("replicate index")
 class TestBuildProvenance:
     """
     Tests for the provenance dictionary building. This dictionary is used
@@ -112,7 +111,6 @@ class ValidateSchemas:
         assert prov["parameters"]["command"] == "simplify"
 
 
-@pytest.mark.skip("replicate index")
 class TestBuildObjects:
     """
     Check that we can build objects from the json schema as we'd expect.
@@ -290,6 +288,10 @@ class TestBuildObjects:
 
     def test_replicate_index(self):
         for i, ts in enumerate(msprime.simulate(5, num_replicates=3)):
+            decoded = self.decode(ts.provenance(0).record)
+            assert decoded.parameters["replicate_index"] == i
+
+        for i, ts in enumerate(msprime.sim_ancestry(5, num_replicates=3)):
             decoded = self.decode(ts.provenance(0).record)
             assert decoded.parameters["replicate_index"] == i
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -50,6 +50,7 @@ class TestProvenance:
         assert libs["tskit"] == {"version": tskit.__version__}
 
 
+@pytest.mark.skip("replicate index")
 class TestBuildProvenance:
     """
     Tests for the provenance dictionary building. This dictionary is used
@@ -111,6 +112,7 @@ class ValidateSchemas:
         assert prov["parameters"]["command"] == "simplify"
 
 
+@pytest.mark.skip("replicate index")
 class TestBuildObjects:
     """
     Check that we can build objects from the json schema as we'd expect.

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -88,12 +88,12 @@ class TestUncoalescedTreeSequenceProperties:
         self.verify(ts)
 
     def test_discrete_loci(self):
-        ts = msprime.simulate(
+        ts = msprime.sim_ancestry(
             10,
-            recombination_map=msprime.RecombinationMap.uniform_map(10, 1),
+            sequence_length=10,
+            recombination_rate=1,
             random_seed=1,
             end_time=0.5,
-            discrete_genome=True,
         )
         self.verify(ts)
 
@@ -193,10 +193,10 @@ class TestBasicFunctionality:
     def test_from_wf_nonoverlapping(self):
         m = 100
         from_ts = get_wf_base(6, 4, num_loci=m)
-        final_ts = msprime.simulate(
-            from_ts=from_ts,
+        final_ts = msprime.sim_ancestry(
+            initial_state=from_ts,
             random_seed=2,
-            recombination_map=msprime.RecombinationMap.uniform_map(m, 1),
+            recombination_rate=1,
             discrete_genome=True,
         )
         self.verify_from_tables(from_ts, final_ts)
@@ -205,10 +205,10 @@ class TestBasicFunctionality:
     def test_from_wf_overlapping(self):
         m = 100
         from_ts = get_wf_base(6, 14, survival=0.25, num_loci=m)
-        final_ts = msprime.simulate(
-            from_ts=from_ts,
+        final_ts = msprime.sim_ancestry(
+            initial_state=from_ts,
             random_seed=2,
-            recombination_map=msprime.RecombinationMap.uniform_map(m, 1),
+            recombination_rate=1,
             discrete_genome=True,
         )
         self.verify_from_tables(from_ts, final_ts)
@@ -896,17 +896,10 @@ class TestSlimOutput:
     """
 
     def finish_simulation(self, from_ts, recombination_rate=0, seed=1):
-        population_configurations = [
-            msprime.PopulationConfiguration() for _ in range(from_ts.num_populations)
-        ]
-        return msprime.simulate(
-            from_ts=from_ts,
+        return msprime.sim_ancestry(
+            initial_state=from_ts,
             start_time=1,
-            population_configurations=population_configurations,
-            recombination_map=msprime.RecombinationMap.uniform_map(
-                from_ts.sequence_length, recombination_rate
-            ),
-            discrete_genome=True,
+            recombination_rate=recombination_rate,
             random_seed=seed,
         )
 

--- a/verification.py
+++ b/verification.py
@@ -314,9 +314,9 @@ class MsTest(Test):
     def _run_mspms_coalescent_stats(self, args):
         logging.debug(f"mspms: {args}")
         runner = cli.get_mspms_runner(args.split())
-        sim = runner.get_simulator()
+        sim = runner.simulator
         num_populations = sim.num_populations
-        replicates = runner.get_num_replicates()
+        replicates = runner.num_replicates
         num_trees = [0 for j in range(replicates)]
         time = [0 for j in range(replicates)]
         ca_events = [0 for j in range(replicates)]

--- a/verification.py
+++ b/verification.py
@@ -725,13 +725,7 @@ class DiscoalTest(Test):
             if tokens[i] == "-r":
                 rho = float(tokens[i + 1])
         mod_list = [None]
-        # check we have what we need
-        if None in [alpha, sweep_site, sweep_mod_time]:
-            logging.warning(
-                "full parameterization of sweep model not given \
-                          running neutral simulation"
-            )
-        else:
+        if alpha is not None:
             # sweep model
             mod = msprime.SweepGenicSelection(
                 position=sweep_site,
@@ -752,7 +746,6 @@ class DiscoalTest(Test):
             sample_size,
             Ne=0.25,
             model=mod_list,
-            discrete_genome=True,
             recombination_map=recomb_map,
             mutation_rate=mu,
             num_replicates=nreps,
@@ -1367,7 +1360,7 @@ class DtwfVsCoalescent(Test):
 
             logging.debug(f"Running: {kwargs}")
             data = collections.defaultdict(list)
-            replicates = msprime.simulate(**kwargs)
+            replicates = msprime.sim_ancestry(**kwargs)
             for ts in replicates:
                 t_mrca = np.zeros(ts.num_trees)
                 t_intervals = []
@@ -1426,21 +1419,21 @@ class DtwfVsCoalescentSimple(DtwfVsCoalescent):
     """
 
     def test_dtwf_vs_coalescent_single_locus(self):
-        self._run(sample_size=10, Ne=1000, num_replicates=300)
+        self._run(samples=10, population_size=1000, num_replicates=300)
 
     def test_dtwf_vs_coalescent_recomb_discrete_hotspots(self):
         """
         Checks the DTWF against the standard coalescent with a
         discrete recombination map with variable rates.
         """
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, 100, 500, 900, 1200, 1500, 2000],
-            rates=[0.00001, 0, 0.0002, 0.00005, 0, 0.001, 0],
+        recombination_map = msprime.RateMap(
+            position=[0, 100, 500, 900, 1200, 1500, 2000],
+            rate=[0.00001, 0, 0.0002, 0.00005, 0, 0.001],
         )
         self._run(
-            sample_size=10,
-            Ne=1000,
-            recombination_map=recombination_map,
+            samples=10,
+            population_size=1000,
+            recombination_rate=recombination_map,
             num_replicates=300,
             discrete_genome=True,
         )
@@ -1450,125 +1443,106 @@ class DtwfVsCoalescentSimple(DtwfVsCoalescent):
         Checks the DTWF against the standard coalescent with a
         continuous recombination map with variable rates.
         """
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, 0.1, 0.5, 0.9, 1.2, 1.5, 2.0],
-            rates=[0.00001, 0, 0.0002, 0.00005, 0, 0.001, 0],
+        recombination_map = msprime.RateMap(
+            position=[0, 0.1, 0.5, 0.9, 1.2, 1.5, 2.0],
+            rate=[0.00001, 0, 0.0002, 0.00005, 0, 0.001],
         )
         self._run(
-            sample_size=10,
-            Ne=1000,
-            recombination_map=recombination_map,
+            samples=10,
+            population_size=1000,
+            recombination_rate=recombination_map,
             num_replicates=300,
             discrete_genome=False,
         )
 
     def test_dtwf_vs_coalescent_single_forced_recombination(self):
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, 100, 101, 201], rates=[0, 1, 0, 0]
-        )
+        recombination_map = msprime.RateMap(position=[0, 100, 101, 201], rate=[0, 1, 0])
         self._run(
-            sample_size=10,
-            Ne=10,
+            samples=10,
+            population_size=10,
             num_replicates=1,
             discrete_genome=True,
-            recombination_map=recombination_map,
+            recombination_rate=recombination_map,
         )
 
     def test_dtwf_vs_coalescent_low_recombination(self):
-        self._run(sample_size=10, Ne=1000, num_replicates=400, recombination_rate=0.01)
+        self._run(
+            samples=10,
+            population_size=1000,
+            num_replicates=400,
+            recombination_rate=0.01,
+            sequence_length=5,
+        )
 
     def test_dtwf_vs_coalescent_2_pops_massmigration(self):
-        population_configurations = [
-            msprime.PopulationConfiguration(sample_size=10, initial_size=1000),
-            msprime.PopulationConfiguration(sample_size=10, initial_size=1000),
-        ]
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, int(1e6)], rates=[1e-8, 0]
-        )
-        demographic_events = [
+        demography = msprime.Demography.simple_model([1000, 1000])
+        demography.events.append(
             msprime.MassMigration(time=300, source=1, destination=0, proportion=1.0)
-        ]
+        )
         self._run(
-            population_configurations=population_configurations,
-            demographic_events=demographic_events,
+            samples=demography.sample(10, 10),
+            demography=demography,
+            sequence_length=10 ** 6,
             num_replicates=300,
-            recombination_map=recombination_map,
+            recombination_rate=1e-8,
         )
 
-    def test_dtwf_vs_coalescent_2_pop_growth(self):
-        population_configurations = [
-            msprime.PopulationConfiguration(
-                sample_size=10, initial_size=1000, growth_rate=0.01
-            )
-        ]
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, int(5e7)], rates=[1e-8, 0]
-        )
+    def test_dtwf_vs_coalescent_1_pop_growth(self):
         self._run(
-            population_configurations=population_configurations,
-            recombination_map=recombination_map,
+            samples=10,
+            demography=msprime.Demography.simple_model(1000, growth_rate=0.01),
+            recombination_rate=1e-8,
+            sequence_length=5e7,
             num_replicates=300,
             discrete_genome=True,
         )
 
-    def test_dtwf_vs_coalescent_2_pop_shrink(self):
+    def test_dtwf_vs_coalescent_1_pop_shrink(self):
         initial_size = 1000
-        population_configurations = [
-            msprime.PopulationConfiguration(
-                sample_size=10, initial_size=initial_size, growth_rate=-0.01
-            )
-        ]
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, int(1e7)], rates=[1e-8, 0]
-        )
-        demographic_events = [
+        demography = msprime.Demography.simple_model(initial_size, growth_rate=-0.01)
+        demography.events.append(
             msprime.PopulationParametersChange(
-                time=200, initial_size=initial_size, growth_rate=0.01, population_id=0
+                time=200, initial_size=initial_size, growth_rate=0.01, population=0
             )
-        ]
+        )
         self._run(
-            population_configurations=population_configurations,
-            recombination_map=recombination_map,
-            demographic_events=demographic_events,
+            samples=10,
+            demography=demography,
+            recombination_rate=1e-8,
+            sequence_length=5e7,
             num_replicates=300,
             discrete_genome=True,
         )
 
     def test_dtwf_vs_coalescent_multiple_bottleneck(self):
-        population_configurations = [
-            msprime.PopulationConfiguration(sample_size=5, initial_size=1000),
-            msprime.PopulationConfiguration(sample_size=5, initial_size=1000),
-        ]
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, int(1e6)], rates=[1e-8, 0]
-        )
-
-        demographic_events = [
+        demography = msprime.Demography.simple_model([1000, 1000])
+        demography.events = [
             msprime.PopulationParametersChange(
-                time=100, initial_size=100, growth_rate=-0.01, population_id=0
+                time=100, initial_size=100, growth_rate=-0.01, population=0
             ),
             msprime.PopulationParametersChange(
-                time=200, initial_size=100, growth_rate=-0.01, population_id=1
+                time=200, initial_size=100, growth_rate=-0.01, population=1
             ),
             msprime.PopulationParametersChange(
-                time=300, initial_size=1000, growth_rate=0.01, population_id=0
+                time=300, initial_size=1000, growth_rate=0.01, population=0
             ),
             msprime.PopulationParametersChange(
-                time=400, initial_size=1000, growth_rate=0.01, population_id=1
+                time=400, initial_size=1000, growth_rate=0.01, population=1
             ),
             msprime.PopulationParametersChange(
-                time=500, initial_size=100, growth_rate=0, population_id=0
+                time=500, initial_size=100, growth_rate=0, population=0
             ),
             msprime.PopulationParametersChange(
-                time=600, initial_size=100, growth_rate=0, population_id=1
+                time=600, initial_size=100, growth_rate=0, population=1
             ),
             msprime.MigrationRateChange(time=700, rate=0.1, matrix_index=(0, 1)),
         ]
         self._run(
-            population_configurations=population_configurations,
-            demographic_events=demographic_events,
+            samples=demography.sample(5, 5),
+            demography=demography,
             num_replicates=400,
-            recombination_map=recombination_map,
+            recombination_rate=1e-8,
+            sequence_length=5e7,
         )
 
 
@@ -1603,8 +1577,7 @@ class DtwfVsCoalescentHighLevel(DtwfVsCoalescent):
             default_growth_rate = 0.01
             growth_rates = [default_growth_rate] * num_pops
 
-        population_configurations = []
-        demographic_events = []
+        demography = msprime.Demography.simple_model(initial_sizes, growth_rates)
 
         for i in range(num_pops):
             if initial_sizes[i] > 100:
@@ -1613,28 +1586,15 @@ class DtwfVsCoalescentHighLevel(DtwfVsCoalescent):
                 de = msprime.PopulationParametersChange(
                     t_100, growth_rate=0, population=i
                 )
-                demographic_events.append(de)
+                demography.events.append(de)
 
-                growth_rate = growth_rates[i]
             else:
                 # Enforce zero growth rate for small populations
                 logging.warning(
                     f"Warning - setting growth rate to zero for small \
                     population of size {initial_sizes[i]}",
                 )
-                growth_rate = 0
-
-            population_configurations.append(
-                msprime.PopulationConfiguration(
-                    sample_size=sample_sizes[i],
-                    initial_size=initial_sizes[i],
-                    growth_rate=growth_rate,
-                )
-            )
-
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, num_loci], rates=[recombination_rate, 0]
-        )
+                demography.populations[i].growth_rate = 0
 
         if migration_matrix is None:
             default_mig_rate = 0.05
@@ -1644,12 +1604,14 @@ class DtwfVsCoalescentHighLevel(DtwfVsCoalescent):
                 row[i] = 0
                 migration_matrix.append(row)
 
+        demography.migration_matrix = migration_matrix
+
         super()._run(
-            population_configurations=population_configurations,
-            migration_matrix=migration_matrix,
+            samples=demography.sample(*sample_sizes),
+            demography=demography,
             num_replicates=num_replicates,
-            demographic_events=demographic_events,
-            recombination_map=recombination_map,
+            sequence_length=num_loci,
+            recombination_rate=recombination_rate,
             discrete_genome=True,
         )
 
@@ -1716,12 +1678,11 @@ class DtwfVsSlim(Test):
     """
 
     def run_dtwf_slim_comparison(self, slim_args, **kwargs):
-
         df = pd.DataFrame()
 
         kwargs["model"] = "dtwf"
         logging.debug(f"Running: {kwargs}")
-        replicates = msprime.simulate(**kwargs)
+        replicates = msprime.sim_ancestry(**kwargs)
         data = collections.defaultdict(list)
         for ts in replicates:
             t_mrca = np.zeros(ts.num_trees)
@@ -1730,6 +1691,7 @@ class DtwfVsSlim(Test):
             data["tmrca_mean"].append(np.mean(t_mrca))
             data["num_trees"].append(ts.num_trees)
             data["model"].append("dtwf")
+            msp_num_samples = ts.num_samples
 
         slim_script = self.output_dir / "slim_script.txt"
         outfile = self.output_dir / "slim.trees"
@@ -1741,6 +1703,7 @@ class DtwfVsSlim(Test):
             subprocess.check_output(cmd)
             ts = tskit.load(outfile)
             ts = subsample_simplify_slim_treesequence(ts, slim_args["sample_sizes"])
+            assert ts.num_samples == msp_num_samples
 
             t_mrca = np.zeros(ts.num_trees)
             for tree in ts.trees():
@@ -1790,24 +1753,19 @@ class DtwfVsSlim(Test):
         """
         assert len(sample_sizes) == len(initial_sizes)
 
+        sample_sizes = np.array(sample_sizes)
         num_pops = len(sample_sizes)
         slim_args = {}
 
         if num_replicates is None:
             num_replicates = 200
 
-        slim_args["sample_sizes"] = sample_sizes
+        # These are *diploid* samples in msprime
+        slim_args["sample_sizes"] = 2 * sample_sizes
+        demography = msprime.Demography.simple_model(initial_sizes)
 
-        population_configurations = []
         slim_args["POP_STRS"] = ""
-        for i in range(len(sample_sizes)):
-            population_configurations.append(
-                msprime.PopulationConfiguration(
-                    sample_size=sample_sizes[i],
-                    initial_size=initial_sizes[i],
-                    growth_rate=0,
-                )
-            )
+        for i in range(num_pops):
             slim_args["POP_STRS"] += "sim.addSubpop('p{i}', {N});\n".format(
                 i=i, N=initial_sizes[i]
             )
@@ -1819,6 +1777,7 @@ class DtwfVsSlim(Test):
                 row = [default_mig_rate] * num_pops
                 row[i] = 0
                 migration_matrix.append(row)
+        demography.migration_matrix = migration_matrix
 
         # SLiM rates are 'immigration' forwards in time, which matches
         # DTWF backwards-time 'emmigration'
@@ -1838,24 +1797,24 @@ class DtwfVsSlim(Test):
                 )
                 slim_args["POP_STRS"] += mig_str
 
-        num_loci = int(num_loci)
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, num_loci], rates=[recombination_rate, 0]
-        )
         slim_args["RHO"] = recombination_rate
-        slim_args["NUM_LOCI"] = num_loci
+        slim_args["NUM_LOCI"] = int(num_loci)
 
         self.run_dtwf_slim_comparison(
             slim_args,
-            population_configurations=population_configurations,
-            migration_matrix=migration_matrix,
+            samples=demography.sample(*sample_sizes),
+            demography=demography,
             num_replicates=num_replicates,
-            recombination_map=recombination_map,
+            sequence_length=num_loci,
+            recombination_rate=recombination_rate,
             discrete_genome=True,
         )
 
     def test_dtwf_vs_slim_single_locus(self):
-        self._run([10], [10], 1, 0)
+        self._run([100], [10], 1, 0)
+
+    def test_dtwf_vs_slim_single_locus_2_pops(self):
+        self._run([20, 20], [5, 5], 1, 0)
 
     def test_dtwf_vs_slim_short_region(self):
         self._run([100], [10], 1e7, 1e-8, num_replicates=200)
@@ -1871,30 +1830,24 @@ class DtwfVsCoalescentRandom(DtwfVsCoalescent):
 
     def _run(self, num_populations=1, num_replicates=200, num_demographic_events=0):
 
+        # Make this deterministic
+        np.random.seed(42)
+        random.seed(42)
+
         N = num_populations
         num_loci = np.random.randint(1e5, 1e7)
-        rho = 1e-8
-        recombination_map = msprime.RecombinationMap(
-            positions=[0, num_loci], rates=[rho, 0]
-        )
-
-        population_configurations = []
-        for _ in range(N):
-            population_configurations.append(
-                msprime.PopulationConfiguration(
-                    sample_size=np.random.randint(2, 10), initial_size=int(1000 / N)
-                )
-            )
+        num_samples = np.random.randint(2, 10, size=num_populations)
+        demography = msprime.Demography.simple_model([1000 / N] * num_populations)
 
         migration_matrix = []
         for i in range(N):
             migration_matrix.append(
                 [random.uniform(0.05, 0.25) * (j != i) for j in range(N)]
             )
+        demography.migration_matrix = migration_matrix
 
         # Add demographic events and some migration rate changes
         t_max = 1000
-        demographic_events = []
         times = sorted(np.random.randint(300, t_max, size=num_demographic_events))
         for t in times:
             initial_size = np.random.randint(500, 1000)
@@ -1902,7 +1855,7 @@ class DtwfVsCoalescentRandom(DtwfVsCoalescent):
             # growth_rates in the DTWF which don't result in N going to 0.
             growth_rate = 0
             pop_id = np.random.randint(N)
-            demographic_events.append(
+            demography.events.append(
                 msprime.PopulationParametersChange(
                     time=t,
                     initial_size=initial_size,
@@ -1916,29 +1869,29 @@ class DtwfVsCoalescentRandom(DtwfVsCoalescent):
                 index = tuple(
                     np.random.choice(range(num_populations), size=2, replace=False)
                 )
-                demographic_events.append(
+                demography.events.append(
                     msprime.MigrationRateChange(time=t, rate=rate, matrix_index=index)
                 )
 
         # Collect all pops together to control coalescence times for DTWF
         for i in range(1, N):
-            demographic_events.append(
+            demography.events.append(
                 msprime.MassMigration(
                     time=t_max, source=i, destination=0, proportion=1.0
                 )
             )
 
-        demographic_events.append(
+        demography.events.append(
             msprime.PopulationParametersChange(
                 time=t_max, initial_size=100, growth_rate=0, population_id=0
             )
         )
         super()._run(
-            migration_matrix=migration_matrix,
-            population_configurations=population_configurations,
-            demographic_events=demographic_events,
+            samples=demography.sample(*num_samples),
+            demography=demography,
             num_replicates=num_replicates,
-            recombination_map=recombination_map,
+            sequence_length=num_loci,
+            recombination_rate=1e-8,
             discrete_genome=True,
         )
 
@@ -1964,25 +1917,16 @@ class RecombinationBreakpointTest(Test):
     def verify_breakpoint_distribution(
         self, name, sample_size, Ne, r, L, ploidy, model, growth_rate=0
     ):
-        sim = msprime.ancestry._parse_simulate(
-            Ne=Ne,
-            recombination_rate=r,
-            length=L,
-            population_configurations=[
-                msprime.PopulationConfiguration(
-                    sample_size=sample_size, initial_size=Ne, growth_rate=growth_rate
-                )
-            ],
+        ts = msprime.sim_ancestry(
+            samples=sample_size,
+            demography=msprime.Demography.simple_model(Ne, growth_rate),
             ploidy=ploidy,
+            sequence_length=L,
+            recombination_rate=r,
             model=model,
         )
-        ts = next(sim.run_replicates(1))
-        empirical = []
-        for tree in ts.trees():
-            area = tree.total_branch_length * tree.span
-            empirical.append(area)
-
-        scipy.stats.probplot(empirical, dist=scipy.stats.expon(Ne * r), plot=pyplot)
+        area = [tree.total_branch_length * tree.span for tree in ts.trees()]
+        scipy.stats.probplot(area, dist=scipy.stats.expon(Ne * r), plot=pyplot)
         path = self.output_dir / f"{name}_growth={growth_rate}_ploidy={ploidy}.png"
         logging.debug(f"Writing {path}")
         pyplot.savefig(path)
@@ -2255,8 +2199,19 @@ class KnownSFS(Test):
         data = collections.defaultdict(list)
         tbl_sum = [0] * (sample_size - 1)
         tot_bl_sum = [0]
-        sim = msprime.ancestry._parse_simulate(sample_size, ploidy=ploidy, model=model)
-        replicates = sim.run_replicates(num_replicates)
+        # Because we have input cases which sample_size % ploidy != 0 we can't
+        # use the standard approach for specifying the samples. Sidestep this
+        # by setting the initial state directly.
+        tables = tskit.TableCollection(1)
+        tables.populations.add_row()
+        for _ in range(sample_size):
+            tables.nodes.add_row(tskit.NODE_IS_SAMPLE, time=0, population=0)
+        replicates = msprime.sim_ancestry(
+            initial_state=tables,
+            ploidy=ploidy,
+            model=model,
+            num_replicates=num_replicates,
+        )
         for ts in replicates:
             for tree in ts.trees():
                 tot_bl = 0.0
@@ -2303,7 +2258,7 @@ class DiracSFS(KnownSFS):
         and compares to the expected SFS.
         """
         logging.debug(f"running SFS for {sample_size} {psi} {c}")
-        model = (msprime.DiracCoalescent(psi=psi, c=c),)
+        model = msprime.DiracCoalescent(psi=psi, c=c)
         name = f"n={sample_size}_psi={psi}_c={c}_ploidy={ploidy}"
         self.compare_sfs(sample_size, ploidy, model, num_replicates, sfs, name)
 
@@ -2615,7 +2570,7 @@ class BetaSFS(KnownSFS):
         Runs simulations of the xi beta model and compares to the expected SFS.
         """
         logging.debug(f"running Beta SFS for {sample_size} {alpha}")
-        model = (msprime.BetaCoalescent(alpha=alpha),)
+        model = msprime.BetaCoalescent(alpha=alpha)
         name = f"n={sample_size}_alpha={alpha}_ploidy={ploidy}"
         self.compare_sfs(sample_size, ploidy, model, num_replicates, sfs, name)
 
@@ -2777,16 +2732,17 @@ class XiGrowth(Test):
     def compare_tmrca(
         self, pop_size, growth_rate, model, num_replicates, a, b, ploidy, name
     ):
-        sim = msprime.ancestry._parse_simulate(
-            population_configurations=[
-                msprime.PopulationConfiguration(
-                    sample_size=2, initial_size=pop_size, growth_rate=growth_rate
-                )
-            ],
+        demography = msprime.Demography.simple_model(
+            initial_size=pop_size, growth_rate=growth_rate
+        )
+
+        replicates = msprime.ancestry.sim_ancestry(
+            2,
+            demography=demography,
             model=model,
             ploidy=ploidy,
+            num_replicates=num_replicates,
         )
-        replicates = sim.run_replicates(num_replicates)
         T1 = np.array([ts.first().tmrca(0, 1) for ts in replicates])
         sm.graphics.qqplot(
             T1, dist=scipy.stats.gompertz, distargs=(a / b,), scale=1 / b, line="45"
@@ -2875,11 +2831,11 @@ class ContinuousVsDiscreteRecombination(Test):
             replicates = kwargs["num_replicates"]
             num_trees = [0 for i in range(replicates)]
             breakpoints = [0 for i in range(replicates)]
-            for i, ts in enumerate(msprime.simulate(**kwargs)):
+            for i, ts in enumerate(msprime.sim_ancestry(**kwargs)):
                 num_trees[i] = ts.num_trees
                 breakpoints[i] = list(ts.breakpoints())
         else:
-            ts = msprime.simulate(**kwargs)
+            ts = msprime.sim_ancestry(**kwargs)
             num_trees = [ts.num_trees]
             breakpoints = [list(ts.breakpoints)]
 
@@ -2890,18 +2846,21 @@ class ContinuousVsDiscreteRecombination(Test):
     def run_cont_discrete_comparison(self, model, recomb_map):
         sample_size = 10
         num_replicates = 400
+        N = 100
         df_discrete = self._run_msprime_coalescent_stats(
             num_replicates=num_replicates,
-            sample_size=sample_size,
+            samples=sample_size,
+            population_size=N,
             model=model,
-            recombination_map=recomb_map,
+            recombination_rate=recomb_map,
             discrete_genome=True,
         )
         df_cont = self._run_msprime_coalescent_stats(
             num_replicates=num_replicates,
-            sample_size=sample_size,
+            samples=sample_size,
             model=model,
-            recombination_map=recomb_map,
+            population_size=N,
+            recombination_rate=recomb_map,
             discrete_genome=False,
         )
         self._plot_stats(
@@ -2915,7 +2874,7 @@ class ContinuousVsDiscreteRecombination(Test):
 
 class UniformRecombination(ContinuousVsDiscreteRecombination):
     def _run(self, model):
-        recomb_map = msprime.RecombinationMap.uniform_map(2000000, 1e-5)
+        recomb_map = msprime.RateMap.uniform(2000000, 1e-6)
         self.run_cont_discrete_comparison(model, recomb_map)
 
     def test_hudson_cont_discrete_uniform(self):
@@ -2927,11 +2886,11 @@ class UniformRecombination(ContinuousVsDiscreteRecombination):
 
 class VariableRecombination(ContinuousVsDiscreteRecombination):
     def _run(self, model):
-        r = 1e-5
+        r = 1e-6
         positions = [0, 10000, 50000, 150000, 200000]
-        rates = [0.0, r, 5 * r, r / 2, 0.0]
+        rates = [0.0, r, 5 * r, r / 2]
 
-        recomb_map = msprime.RecombinationMap(positions, rates)
+        recomb_map = msprime.RateMap(positions, rates)
 
         self.run_cont_discrete_comparison(model, recomb_map)
 
@@ -3116,7 +3075,7 @@ class HudsonAnalytical(Test):
         analytical predictions.
         """
         R = 1000
-        sample_size = 2
+        sample_size = 1  # 2 diploids
         gc_length_rate_ratio = np.array([0.05, 0.5, 5.0])
         gc_length = np.array([100, 50, 20])
         gc_rate = 0.25 / (gc_length_rate_ratio * gc_length)
@@ -3136,12 +3095,11 @@ class HudsonAnalytical(Test):
             same_root_count_first = np.zeros(seq_length)
             same_root_count_mid = np.zeros(seq_length)
             same_root_count_last = np.zeros(seq_length)
-            replicates = msprime.simulate(
-                sample_size=sample_size,
-                length=seq_length,
+            replicates = msprime.sim_ancestry(
+                samples=sample_size,
+                sequence_length=seq_length,
                 gene_conversion_rate=gc_rate[k],
                 gene_conversion_tract_length=gc_length[k],
-                discrete_genome=True,
                 num_replicates=R,
             )
             for ts in replicates:
@@ -3797,19 +3755,18 @@ class SimulateFrom(Test):
 
     def test_simulate_from_multi_locus(self):
         num_replicates = 1000
-        n = 100
+        n = 50
 
         for m in [10, 50, 100, 1000]:
             logging.debug(f"running for m = {m}")
             T1 = np.zeros(num_replicates)
             num_trees1 = np.zeros(num_replicates)
             recomb_rate = 1 / m
-            reps = msprime.simulate(
+            reps = msprime.sim_ancestry(
                 n,
                 recombination_rate=recomb_rate,
-                length=m,
+                sequence_length=m,
                 num_replicates=num_replicates,
-                discrete_genome=True,
             )
             for j, ts in enumerate(reps):
                 T1[j] = np.max(ts.tables.nodes.time)
@@ -3818,20 +3775,17 @@ class SimulateFrom(Test):
             for t in [0.5, 1, 1.5, 5]:
                 T2 = np.zeros(num_replicates)
                 num_trees2 = np.zeros(num_replicates)
-                reps = msprime.simulate(
+                reps = msprime.sim_ancestry(
                     n,
                     num_replicates=num_replicates,
                     recombination_rate=recomb_rate,
-                    length=m,
+                    sequence_length=m,
                     end_time=t,
-                    discrete_genome=True,
                 )
                 for j, ts in enumerate(reps):
-                    final_ts = msprime.simulate(
-                        from_ts=ts,
+                    final_ts = msprime.sim_ancestry(
+                        initial_state=ts,
                         recombination_rate=recomb_rate,
-                        length=m,
-                        discrete_genome=True,
                         start_time=np.max(ts.tables.nodes.time),
                     )
                     final_ts = final_ts.simplify()


### PR DESCRIPTION
Closes #1257 

The idea here is a use an instance of the GSL random generator to generate a random seed for each replicate. Currently, we use a single random generator for *all* the replicates. This was done in the first instance partly for performance reasons but mainly through paranoia about introducing some weird bias.

I think it must be OK,  though, right? That is,
```
rng = Random(seed)
replicates = [random_process(rng) for _ in range(num_replicates)]
```
should be equivalent in distribution to
```
rng = Random(seed)
seeds = [rng.uniform_int(1, 2**31 - 1) for _ in range(num_replicates)]
replicates = [random_process(Random(seeds[j]) for j in range(num_replicates)]
```

Right? So, I guess the assumption is that choosing seeds uniformly from the range of the RNG is the same thing as running the RNG for a long time.

@molpopgen, @petrelharp, am I doing something stupid here?

We can simplify things quite a bit and start offering meaningful APIs for doing simulations in parallel if we do it this way, so I think it's a good idea to make this change pre 1.0.


ps. Most of the code in here is for numpyifying the GSL random generator interface. We'll probably want this at some point if we do present APIs for doing simulations in parallel.