### PR TITLE
Fixes for compile problems on 32bit i686

### DIFF
--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -2421,7 +2421,7 @@ test_large_bottleneck_simulation(void)
         ret = msp_run(&msp, bottlenecks[j].time + 1e-6, ULONG_MAX);
         CU_ASSERT_EQUAL(ret, MSP_EXIT_MAX_TIME);
         CU_ASSERT_FALSE(msp_is_completed(&msp));
-        CU_ASSERT_EQUAL(msp.time, bottlenecks[j].time + 1e-6);
+        CU_ASSERT_DOUBLE_EQUAL(msp.time, bottlenecks[j].time + 1e-6, 1e-9);
         msp_verify(&msp, 0);
     }
     ret = msp_run(&msp, DBL_MAX, ULONG_MAX);

--- a/lib/tests/test_core.c
+++ b/lib/tests/test_core.c
@@ -101,7 +101,9 @@ test_probability_list_select(void)
     }
     {
         double probs[3] = { short_half, DBL_EPSILON / 8.0, 0.5 };
+#ifdef MSP_TEST_EXACT_FLOAT_COMPARISONS
         CU_TEST(1.0 == probs[0] + probs[1] + probs[2]);
+#endif
         CU_ASSERT_EQUAL(0, probability_list_select(0.0, 3, probs))
         CU_ASSERT_EQUAL(1, probability_list_select(short_half, 3, probs))
         CU_ASSERT_EQUAL(2, probability_list_select(0.5, 3, probs))
@@ -109,7 +111,9 @@ test_probability_list_select(void)
     }
     {
         double probs[3] = { short_half, DBL_EPSILON / 16.0, 0.5 };
+#ifdef MSP_TEST_EXACT_FLOAT_COMPARISONS
         CU_TEST(1.0 == probs[0] + probs[1] + probs[2]);
+#endif
         CU_ASSERT_EQUAL(0, probability_list_select(0.0, 3, probs))
         CU_ASSERT_EQUAL(2, probability_list_select(short_half, 3, probs))
         CU_ASSERT_EQUAL(2, probability_list_select(0.5, 3, probs))

--- a/lib/tests/testlib.h
+++ b/lib/tests/testlib.h
@@ -33,6 +33,13 @@
 #include <gsl/gsl_randist.h>
 #include <CUnit/Basic.h>
 
+#ifdef __SSE2__
+/* On CPUs lacking SSE2 instructions we can't do exact floating
+ * point comparisons. See https://gcc.gnu.org/wiki/FloatingPointMath
+ */
+#define MSP_TEST_EXACT_FLOAT_COMPARISONS
+#endif
+
 #define ALPHABET_BINARY 0
 #define ALPHABET_NUCLEOTIDE 1
 

--- a/lib/util.c
+++ b/lib/util.c
@@ -511,11 +511,6 @@ idx_1st_strict_upper_bound(const double *elements, size_t n_elements, double que
 #error "Base 2 floating point types required"
 #endif
 
-#if SIZE_MAX < ULLONG_MAX
-#error "size_t must be at least 64 bits"
-/* unsigned long long must be at least 64 bits */
-#endif
-
 static bool
 valid_sorted_nonempty_array(const double *array, size_t size)
 {
@@ -588,8 +583,7 @@ fast_search_alloc(fast_search_t *self, const double *elements, size_t n_elements
 {
     int ret = 0;
     double max_element;
-
-    const size_t max_input_size = 1LL << (DBL_MANT_DIG - 1); // 4096 terabytes
+    const uint64_t max_input_size = 1ULL << (DBL_MANT_DIG - 1); // 4096 terabytes
 
     memset(self, 0, sizeof(*self));
 
@@ -597,7 +591,7 @@ fast_search_alloc(fast_search_t *self, const double *elements, size_t n_elements
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }
-    if (elements[0] != 0.0 || n_elements >= max_input_size) {
+    if (elements[0] != 0.0 || (uint64_t) n_elements >= max_input_size) {
         ret = MSP_ERR_BAD_PARAM_VALUE;
         goto out;
     }


### PR DESCRIPTION
Most of these changes are inconsequential I think, except dropping the requirement that size_t is 64 bit. Was there a specific reason for doing this @castedo? It all seems to work fine on my 32 bit machine.