### PR TITLE
Updates to mutations API for 1.0

### DIFF
--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -2810,11 +2810,11 @@ msprime_sim_mutations(PyObject *self, PyObject *args, PyObject *kwds)
     PyArrayObject *rate_array = NULL;
     size_t size;
     mutation_model_t *model = NULL;
-    int discrete_sites = false;
+    int discrete_genome = false;
     int kept_mutations_before_end_time = false;
     static char *kwlist[] = {
         "tables", "random_generator", "rate_map", "model",
-        "discrete_sites", "keep", "kept_mutations_before_end_time",
+        "discrete_genome", "keep", "kept_mutations_before_end_time",
         "start_time", "end_time", NULL};
     mutgen_t mutgen;
     int err;
@@ -2824,7 +2824,7 @@ msprime_sim_mutations(PyObject *self, PyObject *args, PyObject *kwds)
             &LightweightTableCollectionType, &tables,
             &RandomGeneratorType, &random_generator,
             &PyDict_Type, &rate_map,
-            &py_model, &discrete_sites, &keep, &kept_mutations_before_end_time,
+            &py_model, &discrete_genome, &keep, &kept_mutations_before_end_time,
             &start_time, &end_time)) {
         goto out;
     }
@@ -2860,7 +2860,7 @@ msprime_sim_mutations(PyObject *self, PyObject *args, PyObject *kwds)
         handle_library_error(err);
         goto out;
     }
-    if (discrete_sites) {
+    if (discrete_genome) {
         flags |= MSP_DISCRETE_SITES;
     }
     if (keep) {

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -816,25 +816,6 @@ def _parse_samples(samples, ploidy, tables):
         )
 
 
-def _parse_flag(value, *, default):
-    """
-    Parses a boolean flag, which can be either True, False, or None.
-    If the input value is None, return the default. Otherwise,
-    check that the input value is a bool.
-
-    Note that we do *not* cast to a bool as this would accept
-    truthy values like the empty list, etc. In this case None
-    would be converted to False, potentially conflicting with
-    the default value.
-    """
-    assert isinstance(default, bool)
-    if value is None:
-        return default
-    if not isinstance(value, bool):
-        raise TypeError("Boolean flag must be True, False, or None (the default value)")
-    return value
-
-
 def _parse_sim_ancestry(
     samples=None,
     *,
@@ -865,9 +846,9 @@ def _parse_sim_ancestry(
     # Simple defaults.
     start_time = 0 if start_time is None else float(start_time)
     end_time = sys.float_info.max if end_time is None else float(end_time)
-    discrete_genome = _parse_flag(discrete_genome, default=True)
-    record_full_arg = _parse_flag(record_full_arg, default=False)
-    record_migrations = _parse_flag(record_migrations, default=False)
+    discrete_genome = core._parse_flag(discrete_genome, default=True)
+    record_full_arg = core._parse_flag(record_full_arg, default=False)
+    record_migrations = core._parse_flag(record_migrations, default=False)
 
     if initial_state is not None:
         if isinstance(initial_state, tskit.TreeSequence):

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -1018,7 +1018,7 @@ def run_simulate(args):
 
 def run_mutate(args):
     tree_sequence = tskit.load(args.tree_sequence)
-    tree_sequence = msprime.mutate(
+    tree_sequence = msprime.sim_mutations(
         tree_sequence=tree_sequence,
         rate=args.mutation_rate,
         random_seed=args.random_seed,

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -1025,7 +1025,7 @@ def run_mutate(args):
         keep=args.keep,
         start_time=args.start_time,
         end_time=args.end_time,
-        discrete=args.discrete,
+        discrete_genome=args.discrete_genome,
     )
     tree_sequence.dump(args.output_tree_sequence)
 
@@ -1063,7 +1063,7 @@ def add_mutate_subcommand(subparsers):
         help="Keep mutations in input tree sequence",
     )
     parser.add_argument(
-        "--discrete",
+        "--discrete-genome",
         action="store_true",
         default=False,
         help="Generate mutations at only integer positions along the genome. ",

--- a/msprime/core.py
+++ b/msprime/core.py
@@ -82,3 +82,22 @@ def isinteger(value):
         return int_val == float_val
     except (ValueError, TypeError):
         return False
+
+
+def _parse_flag(value, *, default):
+    """
+    Parses a boolean flag, which can be either True, False, or None.
+    If the input value is None, return the default. Otherwise,
+    check that the input value is a bool.
+
+    Note that we do *not* cast to a bool as this would accept
+    truthy values like the empty list, etc. In this case None
+    would be converted to False, potentially conflicting with
+    the default value.
+    """
+    assert isinstance(default, bool)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise TypeError("Boolean flag must be True, False, or None (the default value)")
+    return value

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1058,7 +1058,7 @@ def _simple_mutate(
         random_generator,
         rate_map.asdict(),
         model=BinaryMutationModel(),
-        discrete_sites=False,
+        discrete_genome=False,
     )
 
 
@@ -1070,7 +1070,7 @@ def mutate(
     keep=False,
     start_time=None,
     end_time=None,
-    discrete=False,
+    discrete_genome=False,
     kept_mutations_before_end_time=False,
 ):
     """
@@ -1095,7 +1095,7 @@ def mutate(
     mutations are simulated. Under the infinite sites mutation model, all new
     mutations generated will occur at distinct positions from each other and
     from any existing mutations (by rejection sampling). Furthermore, if sites
-    are discrete, trying to simulate mutations at time periods that are older
+    are discrete_genome, trying to simulate mutations at time periods that are older
     than mutations kept from the original tree sequence is an error, because
     this would create an extra transition (from the new allele to the old
     one below it) that may be incorrect according to the model of mutation.
@@ -1131,12 +1131,12 @@ def mutate(
         occur. (Default: no restriction.)
     :param float end_time: The maximum time ago at which a mutation can occur
         (Default: no restriction).
-    :param bool discrete: Whether to generate mutations at only integer positions
+    :param bool discrete_genome: Whether to generate mutations at only integer positions
         along the genome.  Default is False, which produces infinite-sites
         mutations at floating-point positions.
     :param bool kept_mutations_before_end_time: Whether to allow mutations to be added
         ancestrally to existing (kept) mutations. This flag has no effect
-        if either keep or discrete are False.
+        if either keep or discrete_genome are False.
     :return: The :class:`tskit.TreeSequence` object resulting from overlaying
         mutations on the input tree sequence.
     :rtype: :class:`tskit.TreeSequence`
@@ -1172,7 +1172,7 @@ def mutate(
     if start_time > end_time:
         raise ValueError("start_time must be <= end_time")
     keep = bool(keep)
-    discrete = bool(discrete)
+    discrete_genome = bool(discrete_genome)
     kept_mutations_before_end_time = bool(kept_mutations_before_end_time)
 
     model = mutation_model_factory(model)
@@ -1195,7 +1195,7 @@ def mutate(
         random_generator=rng,
         rate_map=rate_map.asdict(),
         model=model,
-        discrete_sites=discrete,
+        discrete_genome=discrete_genome,
         keep=keep,
         kept_mutations_before_end_time=kept_mutations_before_end_time,
         start_time=start_time,

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2411,7 +2411,7 @@ class TestSimMutations:
                     random_generator=rng,
                     rate_map=rate_map,
                     model=model,
-                    discrete_sites=bad_type,
+                    discrete_genome=bad_type,
                 )
         assert (
             _msprime.sim_mutations(
@@ -2435,7 +2435,7 @@ class TestSimMutations:
         generate()
         for bad_type in [[], None, "asdf"]:
             with pytest.raises(TypeError):
-                generate(discrete_sites=bad_type)
+                generate(discrete_genome=bad_type)
             with pytest.raises(TypeError):
                 generate(keep=bad_type)
             with pytest.raises(TypeError):

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -358,7 +358,6 @@ class TestBuildObjects:
             random_seed=np.array([1])[0],
             start_time=np.array([0])[0],
             end_time=np.array([100][0]),
-            keep=np.array([False][0]),
         )
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
@@ -367,7 +366,6 @@ class TestBuildObjects:
         assert decoded.parameters.rate == 2
         assert decoded.parameters.start_time == 0
         assert decoded.parameters.end_time == 100
-        assert not decoded.parameters.keep
 
 
 class TestParseProvenance:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -308,14 +308,14 @@ class TestBuildObjects:
             " record_provenance=False" in caplog.text
         )
 
-    def test_mutate(self):
+    def test_sim_mutations(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.mutate(
+        ts = msprime.sim_mutations(
             ts, rate=2, random_seed=1, start_time=0, end_time=100, keep=False
         )
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
-        assert decoded.parameters.command == "mutate"
+        assert decoded.parameters.command == "sim_mutations"
         assert decoded.parameters.random_seed == 1
         assert decoded.parameters.rate == 2
         assert decoded.parameters.start_time == 0
@@ -328,10 +328,10 @@ class TestBuildObjects:
 
     def test_mutate_model(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.mutate(ts, model="jc69")
+        ts = msprime.sim_mutations(ts, model="jc69")
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
-        assert decoded.parameters.command == "mutate"
+        assert decoded.parameters.command == "sim_mutations"
         assert (
             decoded.parameters.model["__class__"]
             == "msprime.mutations.JC69MutationModel"
@@ -340,10 +340,10 @@ class TestBuildObjects:
     def test_mutate_map(self):
         ts = msprime.simulate(5, random_seed=1)
         rate_map = msprime.RateMap(position=[0, 0.5, 1], rate=[0, 1])
-        ts = msprime.mutate(ts, rate=rate_map)
+        ts = msprime.sim_mutations(ts, rate=rate_map)
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
-        assert decoded.parameters.command == "mutate"
+        assert decoded.parameters.command == "sim_mutations"
         assert decoded.parameters.rate["__class__"] == "msprime.intervals.RateMap"
         assert decoded.parameters.rate["position"]["__ndarray__"] == list(
             rate_map.position
@@ -352,7 +352,7 @@ class TestBuildObjects:
 
     def test_mutate_numpy(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.mutate(
+        ts = msprime.sim_mutations(
             ts,
             rate=np.array([2])[0],
             random_seed=np.array([1])[0],
@@ -362,7 +362,7 @@ class TestBuildObjects:
         )
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
-        assert decoded.parameters.command == "mutate"
+        assert decoded.parameters.command == "sim_mutations"
         assert decoded.parameters.random_seed == 1
         assert decoded.parameters.rate == 2
         assert decoded.parameters.start_time == 0
@@ -385,10 +385,10 @@ class TestParseProvenance:
             )
 
     def test_current_ts(self):
-        ts1 = msprime.simulate(5, random_seed=1)
-        ts2 = msprime.mutate(ts1)
+        ts1 = msprime.sim_ancestry(5, random_seed=1)
+        ts2 = msprime.sim_mutations(ts1)
         command, prov = msprime.provenance.parse_provenance(ts2.provenance(1), ts1)
-        assert command == "mutate"
+        assert command == "sim_mutations"
         assert prov["tree_sequence"] == ts1
 
 

--- a/verification.py
+++ b/verification.py
@@ -4307,7 +4307,7 @@ class SeqGenTest(MutationTest):
                 ts,
                 rate=mutation_rate,
                 model=model_dict[model]["model_id"],
-                discrete=True,
+                discrete_genome=True,
             )
             num_sites = ts_mutated.num_sites
             t = ts_mutated.first()
@@ -4503,7 +4503,7 @@ class PyvolveTest(MutationTest):
                 ts,
                 rate=mutation_rate,
                 model=model_dict[model]["model_id"],
-                discrete=True,
+                discrete_genome=True,
             )
 
             num_sites = ts_mutated.num_sites

--- a/verification.py
+++ b/verification.py
@@ -2047,7 +2047,7 @@ class RecombinationMutationTest(Test):
             )
             ts = next(sim.run_replicates(1))
             empirical_rho.append(sim.num_breakpoints)
-            ts = msprime.mutate(ts, rate=m)
+            ts = msprime.sim_mutations(ts, rate=m)
             empirical_theta.append(ts.get_num_sites())
         empirical_rho.sort()
         empirical_theta.sort()
@@ -4303,7 +4303,7 @@ class SeqGenTest(MutationTest):
 
         for _ in range(num_replicates):
             ts = msprime.simulate(num_samples, Ne=Ne, length=length)
-            ts_mutated = msprime.mutate(
+            ts_mutated = msprime.sim_mutations(
                 ts,
                 rate=mutation_rate,
                 model=model_dict[model]["model_id"],
@@ -4499,7 +4499,7 @@ class PyvolveTest(MutationTest):
 
         for _ in range(num_replicates):
             ts = msprime.simulate(num_samples, Ne=1e4, length=length)
-            ts_mutated = msprime.mutate(
+            ts_mutated = msprime.sim_mutations(
                 ts,
                 rate=mutation_rate,
                 model=model_dict[model]["model_id"],


### PR DESCRIPTION
This PR brings together the various changes needed to the mutate/sim_mutations API for the 1.0 release.

Basically, we revert mutate() back to what it looked like as of 0.7.4, and document it as deprecated-but-supported-forever, and rename the ``discrete`` argument to ``discrete_genome``.

This isn't quite finished, so I've marked it as draft for now.

@petrelharp, do you agree with this approach?

(I've also updated the mutation tests to use ``sim_ancestry`` where it makes sense as a dogfooding exercise)