### PR TITLE
add documentation for gene conversion

### DIFF
--- a/docs/ancestry.rst
+++ b/docs/ancestry.rst
@@ -722,23 +722,6 @@ recombination model and number of loci.
 Gene conversion
 +++++++++++++++
 
-.. todo:: This is old text taken from api.rst. Reuse as appropriate.
-    Note that some of this is specific to the Hudson model and so
-    should perhaps be moved in there.
-
-For gene conversion there are two parameters. The gene
-conversion rate determines the initiation
-and is again per unit of sequence length and per generation in ``msprime``.
-Thus, given the per generation gene conversion rate :math:`g`, the overall rate of
-gene conversion initiation between the ends of the sequence is :math:`\rho = 4 N_e g L` in
-coalescent time units. The second parameter :math:`tract\_len` is the expected tract length
-of a gene conversion. At each gene conversion initiation site the tract of the conversion
-extends to the right and the length of the tract is geometric distributed with parameter
-:math:`1/tract\_len`. Currently recombination maps for gene conversion are not supported.
-However, recombination (with or without recombination maps) and a constant gene conversion
-rate along the genome can be combined in ``msprime``.
-
-
 .. jupyter-kernel:: python3
 
 
@@ -748,10 +731,85 @@ rate along the genome can be combined in ``msprime``.
     import msprime
     from IPython.display import SVG
 
-.. todo:: Examples of small simulations using GC on its own
-    and mixed with recombination. Ideally we'd start with an
-    example with one GC event where we could explain what happened.
-    This might be tricky to finesse.
+Gene conversion events are defined by two parameters: the rate at which gene
+conversion events are initiated and the distribution of tract lengths.
+In the default case of discrete genome coordinates, tract lengths are drawn
+from a geometric distribution with mean gene_conversion_tract_length (which
+must be at least 1). Note that if we specify a tract length of 1, then all
+gene conversion tracts will have length exactly 1.
+In the following example one gene conversion event of length 1 has occured.
+
+
+.. jupyter-execute::
+
+    ts = msprime.sim_ancestry(
+        3, gene_conversion_rate=0.02, gene_conversion_tract_length=1,
+        sequence_length=10, random_seed=3)
+    ts.sequence_length
+    SVG(ts.draw_svg())
+
+.. jupyter-execute::
+    :hide-code:
+
+    assert 1 < ts.num_trees < 5
+    
+Continous genomes can also be used. In this case the parameters define
+the rate at which gene conversion events are initiated per unit of sequence
+length and the mean of the exponentially distributed gene conversion tract
+lengths. The following example shows the same simulation as above but for a
+continuous genome of length 1 and scaled gene conversion parameters.
+    
+.. jupyter-execute::
+
+    ts = msprime.sim_ancestry(
+        3, gene_conversion_rate=0.2, gene_conversion_tract_length=0.1,
+        sequence_length=1, random_seed=3, discrete_genome=False)
+    ts.sequence_length
+    SVG(ts.draw_svg())
+
+.. jupyter-execute::
+    :hide-code:
+
+    assert 1 < ts.num_trees < 5
+
+Recombination and gene conversion at constant rates can be simulated alongside.
+In the following example recombinations at site 60 and 97 have occured in addition
+to a gene conversion event covering the tract from site 76 to site 80.
+
+.. jupyter-execute::
+
+    ts = msprime.sim_ancestry(
+        3, sequence_length = 100, recombination_rate=0.003,
+        gene_conversion_rate=0.002, gene_conversion_tract_length=5,
+        random_seed=6)
+    ts.sequence_length
+    SVG(ts.draw_svg())
+
+.. jupyter-execute::
+    :hide-code:
+
+    assert 1 < ts.num_trees < 6
+    
+Variable recombination rates and constant gene conversion rates can be combined.
+In the next example we define a recombination map with a high recombination rate between
+site 10 and site 11 and a constant gene conversion rate with a mean tract length of 3.
+
+.. jupyter-execute::
+
+    rate_map = msprime.RateMap(
+        position=[0, 10, 11, 20],
+        rate=[0.01, 0.5, 0.01])
+    ts = msprime.sim_ancestry(
+        3, recombination_rate=rate_map,
+        gene_conversion_rate=0.01, gene_conversion_tract_length=3,
+        random_seed=8)
+    ts.sequence_length
+    SVG(ts.draw_svg())
+
+.. jupyter-execute::
+    :hide-code:
+
+    assert 1 < ts.num_trees < 5
 
 
 .. _sec_ancestry_multiple_chromosomes:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -170,12 +170,12 @@ added. We  currently support:
 
 - Basic functionality (sample size, replicates, tree and haplotype output);
 - Recombination (via the ``-r`` option);
+- Gene-conversion (via the ``-c`` option);
 - Spatial structure with arbitrary migration matrices;
 - Support for :command:`ms` demographic events. (The implementation of the
   ``-es`` option is limited, and has restrictions on how it may be
   combined with other options.)
 
-Gene-conversion is not currently supported, but is planned for a future release.
 
 ++++++++++++++++
 Argument details

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1594,6 +1594,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
         handle_input_error("node_mapping_block_size", sim_ret);
         goto out;
     }
+    msp_set_discrete_genome(self->sim, discrete_genome);
     if (gene_conversion_rate != 0) {
         sim_ret = msp_set_gene_conversion_rate(self->sim, gene_conversion_rate);
         if (sim_ret != 0) {
@@ -1612,7 +1613,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             goto out;
         }
     }
-    msp_set_discrete_genome(self->sim, discrete_genome);
+
 
     sim_ret = msp_set_ploidy(self->sim, ploidy);
     if (sim_ret != 0) {

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1064,12 +1064,17 @@ def sim_ancestry(
         See :ref:`sec_ancestry_recombination` for usage examples
         for this parameter and how it interacts with other parameters.
     :param gene_conversion_rate: The rate of gene conversion along the sequence;
-        can be either a single value (specifying a single rate over the entire
-        sequence) or an instance of :class:`RateMap`. If provided, a value
-        for ``gene_conversion_tract_length`` must also be specified.
-        See :ref:`sec_ancestry_gene_conversion` for usage examples
+        can be a single value (specifying a single rate over the entire
+        sequence). Currently an instance of :class:`RateMap` is not supported.
+        If provided, a value for ``gene_conversion_tract_length`` must also be
+        specified. See :ref:`sec_ancestry_gene_conversion` for usage examples
         for this parameter and how it interacts with other parameters.
-    :param gene_conversion_tract_length: TODO
+    :param gene_conversion_tract_length: The mean length of the gene conversion
+        tracts. For discrete genomes the tract lengths are geometrically
+        distributed with mean ``gene_conversion_tract_length``, which must be
+        greater than or equal to 1. For continuous genomes the tract lengths are
+        exponentially distributed with mean ``gene_conversion_tract_length``,
+        which must be larger than 0.
     :param int random_seed: The random seed. If this is not specified or `None`,
         a high-quality random seed will be automatically generated. Valid random
         seeds must be between 1 and :math:`2^{32} - 1`.

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -55,7 +55,20 @@ mscompat_recombination_help = (
     "between the ends of the region being simulated; num_loci is the number "
     "of sites between which recombination can occur"
 )
-mscompat_gene_conversion_help = "TODO"
+mscompat_gene_conversion_help = (
+    "Gene conversion at rate gamma where gamma depends on the defined "
+    "recombination rate rho=4*N0*r. If rho > 0, gc_recomb_ratio defines the ratio "
+    "g/r, where r is the probability per generation of crossing-over and g the "
+    "corresponding gene conversion probability. Gene conversions are initiated at "
+    "rate gamma=rho*gc_recomb_ratio = 4*N0*r*gc_recomb_ratio. If rho = 0 the gene "
+    "conversion rate is given by gamma=gc_recomb_ratio=4*N0*c where c is the rate "
+    "of gene conversion initiation between the ends of the simulated region of "
+    "length num_loci. If the recombination rate is not specified, standard "
+    "parameters are used, i.e. rho = 0 and num_loci = 1. The length of the gene "
+    "conversion tracts is geometrically distributed with mean tract_length. "
+    "The mean tract_length needs to be larger than or equal to 1 for discrete "
+    "genomes and larger than 0 for continuous genomes."
+)
 mshotcompat_hotspot_help = (
     "Recombination hotspots defined according to the msHOT format. This is "
     "defined as a sequence: n (start stop scale)+ where n is the number of "


### PR DESCRIPTION
I have added a small documentation for gene conversion with a few illustrative examples.
Also: fixed a small bug as the discrete_genome feature has to be set before we set the gene conversion tract lengths in _msprimemodule.c.