### PR TITLE
Remove __len__ and size() from RateMap

### DIFF
--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1198,7 +1198,7 @@ class Simulator(_msprime.Simulator):
 
         # FIXME support arbitrary gene conversion maps.
         # https://github.com/tskit-dev/msprime/issues/1212
-        assert len(gene_conversion_map) == 1
+        assert len(gene_conversion_map.rate) == 1
         gene_conversion_rate = gene_conversion_map.rate[0]
 
         start_time = -1 if start_time is None else start_time

--- a/msprime/intervals.py
+++ b/msprime/intervals.py
@@ -97,9 +97,6 @@ class RateMap:
 
         # Make all of the internal arrays read-only, so they can't get out of sync
 
-    def __len__(self):  # TODO - remove this, as the length of a ratemap is not obvious
-        return len(self.rate)
-
     @property
     def position(self):
         """
@@ -181,10 +178,6 @@ class RateMap:
         # Since we insist that the rate up to start_position and past end_position is 0
         # we can just return the cumulative total.
         return self.cumulative_mass[-1]
-
-    @property
-    def size(self):  # TODO - should we remove this, for the same reason as for __len__
-        return self.rate.shape[0]
 
     @property
     def mean_rate(self):
@@ -437,7 +430,7 @@ class RecombinationMap:
         raise ValueError("num_loci is no longer supported")
 
     def get_size(self):
-        return self.map.size + 1
+        return len(self.map.position)
 
     def get_positions(self):
         return list(self.map.position)

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -598,7 +598,7 @@ class TestParseSimAncestry:
             assert sim.sequence_length == 10
             gc_map = sim.gene_conversion_map
             assert gc_map.sequence_length == 10
-            assert len(gc_map) == 1
+            assert len(gc_map.rate) == 1
             assert gc_map.rate[0] == 1234
             assert sim.gene_conversion_tract_length == 5
 


### PR DESCRIPTION
As [suggested](https://github.com/tskit-dev/msprime/pull/1185#issuecomment-737279602) by @grahamgower, because it is unclear if we mean the number of rates or the number of positions. This will force users to do len(rate_map.rate) or len(rate_map.position) as appropriate.

I'm assuming that len(ratemap) and ratemap.size() were never previously released - if so this should not affect backwards compatibility.