### PR TITLE
Read hapmap reworking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -356,8 +356,7 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
-    # currently 404ing.
-    # "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
     "tskit": ("https://tskit.readthedocs.io/en/stable", None),
     "stdpopsim": ("https://stdpopsim.readthedocs.io/en/stable", None),
 }

--- a/tests/test_recombination_map.py
+++ b/tests/test_recombination_map.py
@@ -19,7 +19,6 @@
 """
 Tests for the legacy recombination map functionality.
 """
-import gzip
 import io
 import os
 import random
@@ -27,7 +26,6 @@ import tempfile
 import unittest
 import warnings
 
-import numpy as np
 import pytest
 
 import msprime
@@ -261,50 +259,6 @@ class TestReadHapmap:
     """
     Tests file reading code.
     """
-
-    def test_read_hapmap_simple(self, tmp_path):
-        hapfile = io.StringIO(
-            """\
-            HEADER
-            chr1 0 1
-            chr1 1 5 x
-            chr1 2 0 x x x"""
-        )
-        rm = msprime.read_hapmap(hapfile)
-        np.testing.assert_array_equal(rm.position, [0, 1, 2])
-        np.testing.assert_array_equal(rm.rate, [1e-8, 5e-8])
-
-    def test_read_hapmap_nonzero_rate_start(self):
-        hapfile = io.StringIO(
-            """\
-            HEADER
-            chr1 1 5 x
-            chr1 2 0 x x x"""
-        )
-        rm = msprime.read_hapmap(hapfile)
-        np.testing.assert_array_equal(rm.position, [0, 1, 2])
-        np.testing.assert_array_equal(rm.rate, [0, 5e-8])
-
-    def test_read_hapmap_nonzero_end(self):
-        hapfile = io.StringIO(
-            """\
-            HEADER
-            chr1 0 5 x
-            chr1 2 1 x x x"""
-        )
-        with pytest.raises(ValueError):
-            msprime.read_hapmap(hapfile)
-
-    def test_read_hapmap_gzipped(self, tmp_path):
-        hapfile = os.path.join(tmp_path, "hapmap.txt.gz")
-        with gzip.GzipFile(hapfile, "wb") as gzfile:
-            gzfile.write(b"HEADER\n")
-            gzfile.write(b"chr1 0 1\n")
-            gzfile.write(b"chr1 1 5.5\n")
-            gzfile.write(b"chr1 2 0\n")
-        rm = msprime.read_hapmap(hapfile)
-        np.testing.assert_array_equal(rm.position, [0, 1, 2])
-        np.testing.assert_array_equal(rm.rate, [1e-8, 5.5e-8])
 
     def test_read_hapmap_deprecation_warning(self):
         hapfile = io.StringIO(

--- a/tests/test_recombination_map.py
+++ b/tests/test_recombination_map.py
@@ -20,6 +20,7 @@
 Tests for the legacy recombination map functionality.
 """
 import gzip
+import io
 import os
 import random
 import tempfile
@@ -256,71 +257,66 @@ class TestCoordinateConversion(unittest.TestCase):
                     self.assertAlmostEqual(x, rm.genetic_to_physical(x))
 
 
-class TestReadHapmap(unittest.TestCase):
+class TestReadHapmap:
     """
     Tests file reading code.
     """
 
-    def setUp(self):
-        fd, self.temp_file = tempfile.mkstemp(suffix="msp_recomb_map")
-        os.close(fd)
-
-    def tearDown(self):
-        try:
-            os.unlink(self.temp_file)
-        except Exception:
-            pass
-
-    def test_read_hapmap_simple(self):
-        with open(self.temp_file, "w+") as f:
-            print("HEADER", file=f)
-            print("chr1 0 1", file=f)
-            print("chr1 1 5 x", file=f)
-            print("s    2 0 x x x", file=f)
-        rm = msprime.read_hapmap(self.temp_file)
+    def test_read_hapmap_simple(self, tmp_path):
+        hapfile = io.StringIO(
+            """\
+            HEADER
+            chr1 0 1
+            chr1 1 5 x
+            chr1 2 0 x x x"""
+        )
+        rm = msprime.read_hapmap(hapfile)
         np.testing.assert_array_equal(rm.position, [0, 1, 2])
         np.testing.assert_array_equal(rm.rate, [1e-8, 5e-8])
 
-    def test_read_hapmap_nonzero_start(self):
-        with open(self.temp_file, "w+") as f:
-            print("HEADER", file=f)
-            print("chr1 1 5 x", file=f)
-            print("s    2 0 x x x", file=f)
-        rm = msprime.read_hapmap(self.temp_file)
+    def test_read_hapmap_nonzero_rate_start(self):
+        hapfile = io.StringIO(
+            """\
+            HEADER
+            chr1 1 5 x
+            chr1 2 0 x x x"""
+        )
+        rm = msprime.read_hapmap(hapfile)
         np.testing.assert_array_equal(rm.position, [0, 1, 2])
         np.testing.assert_array_equal(rm.rate, [0, 5e-8])
 
     def test_read_hapmap_nonzero_end(self):
-        with open(self.temp_file, "w+") as f:
-            print("HEADER", file=f)
-            print("chr1 0 5 x", file=f)
-            print("s    2 1 x x x", file=f)
+        hapfile = io.StringIO(
+            """\
+            HEADER
+            chr1 0 5 x
+            chr1 2 1 x x x"""
+        )
         with pytest.raises(ValueError):
-            msprime.read_hapmap(self.temp_file)
+            msprime.read_hapmap(hapfile)
 
-    def test_read_hapmap_gzipped(self):
-        try:
-            filename = self.temp_file + ".gz"
-            with gzip.open(filename, "w+") as f:
-                f.write(b"HEADER\n")
-                f.write(b"chr1 0 1\n")
-                f.write(b"chr1 1 5.5\n")
-                f.write(b"s    2 0\n")
-            rm = msprime.read_hapmap(filename)
-            np.testing.assert_array_equal(rm.position, [0, 1, 2])
-            np.testing.assert_array_equal(rm.rate, [1e-8, 5.5e-8])
-        finally:
-            os.unlink(filename)
+    def test_read_hapmap_gzipped(self, tmp_path):
+        hapfile = os.path.join(tmp_path, "hapmap.txt.gz")
+        with gzip.GzipFile(hapfile, "wb") as gzfile:
+            gzfile.write(b"HEADER\n")
+            gzfile.write(b"chr1 0 1\n")
+            gzfile.write(b"chr1 1 5.5\n")
+            gzfile.write(b"chr1 2 0\n")
+        rm = msprime.read_hapmap(hapfile)
+        np.testing.assert_array_equal(rm.position, [0, 1, 2])
+        np.testing.assert_array_equal(rm.rate, [1e-8, 5.5e-8])
 
     def test_read_hapmap_deprecation_warning(self):
-        with open(self.temp_file, "w+") as f:
-            print("HEADER", file=f)
-            print("chr1 0 1", file=f)
-            print("chr1 1 5 x", file=f)
-            print("s    2 0 x x x", file=f)
+        hapfile = io.StringIO(
+            """\
+            HEADER
+            chr1 0 1
+            chr1 1 5 x
+            chr1 2 0 x x x"""
+        )
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            rm = msprime.RecombinationMap.read_hapmap(self.temp_file)
+            rm = msprime.RecombinationMap.read_hapmap(hapfile)
             assert len(w) == 1
         assert rm.get_positions() == [0, 1, 2]
         assert rm.get_rates() == [1e-8, 5e-8, 0]


### PR DESCRIPTION
This addresses the first part of https://github.com/tskit-dev/msprime/issues/1338 as suggested by @jeromekelleher, with the addition of reading in the 0th column as the name, if appropriate. I've covered a few other edge cases such as the user accidentally specifying the same pos & map cols. 

After this, the only remaining part to do is to implement `write_hapmap`, I think.