### PR TITLE
Finalise sampling for sim_ancestry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,6 +39,9 @@
   ``simulate`` and ``mutate``. These sub-commands are provided by the ``tskit``
   CLI or the ``TreeSequence`` API in ``tskit``.
 
+- The ``msprime.Sample`` object is no longer an namedtuple, and therefore
+  references like ``population, time = sample`` will not work.
+
 **Deprecations**:
 
 - Deprecate module attributes that were moved to tskit.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,9 +39,6 @@
   ``simulate`` and ``mutate``. These sub-commands are provided by the ``tskit``
   CLI or the ``TreeSequence`` API in ``tskit``.
 
-- The ``msprime.Sample`` object is no longer an namedtuple, and therefore
-  references like ``population, time = sample`` will not work.
-
 **Deprecations**:
 
 - Deprecate module attributes that were moved to tskit.

--- a/docs/ancestry.rst
+++ b/docs/ancestry.rst
@@ -22,6 +22,7 @@ Models
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -179,6 +180,7 @@ Examples
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -426,6 +428,8 @@ Population size
     how this relates to ploidy. Should link to the demography page and
     model sections for more details.
 
+.. _sec_ancestry_samples:
+
 ******************
 Specifying samples
 ******************
@@ -437,25 +441,84 @@ Specifying samples
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 The ``samples`` argument to :func:`sim_ancestry` defines the number
 of sample individuals we simulate the history of. There are three different
-ways forms; the ``samples`` argument can be:
+forms; the ``samples`` argument can be:
 
-- an **integer**, interpreted as the number of samples to draw from this
-  population;
+- an **integer**, interpreted as the number of samples to draw in a single
+  population model;
 - a **dictionary** mapping population references (either integer IDs or
   names) to the number of samples for that population;
 - a list of :class:`.SampleSet` objects, which provide more flexibility
   in how groups of similar samples are drawn from populations.
 
 .. warning:: It is important to note that the number of samples
-    refers to the number of *individuals* not the number of *nodes*.
-    See the :ref:`sec_ancestry_samples_ploidy` section for details.
+    refers to the number of *individuals* not the number of *nodes*
+    (monoploid genomes). See the :ref:`sec_ancestry_samples_ploidy`
+    section for details.
 
-The :ref:`sec_ancestry_samples_advanced_sampling` section shows how
-to fully control how sample individuals and nodes are defined; however,
+Sample individuals and nodes are allocated sequentially in the order that
+they are specified. For example:
+
+.. jupyter-execute::
+
+    demography = msprime.Demography.island_model([10, 10], migration_rate=1)
+    ts = msprime.sim_ancestry(
+        samples=[
+            msprime.SampleSet(1, population=1),
+            msprime.SampleSet(2, population=0)],
+        demography=demography,
+        end_time=0)
+    print(ts.tables.individuals)
+    print(ts.tables.nodes)
+
+(Because we're only interested in the sampled nodes and individuals we
+stopped the simulation from actually doing anything by setting
+``end_time=0``.) Here we define three sample individuals,
+and we therefore have three rows in the individual table.
+Because these are diploid individuals, the node table contains
+six sample nodes. If we look at the ``individual`` column in the
+node table we can see that the first two nodes correspond to individual
+``0``, the next two nodes individual ``1``, etc. The sample configuration
+stated that the first sample should come from population ``1`` and
+the other two from population ``0``, and we can see this reflected
+in the ``population`` column of the node table. (Somewhat confusingly,
+population values are associated with nodes rather than individuals;
+this is mostly for historical reasons.)
+
+The :class:`.SampleSet` class has a number of attributes which default
+to ``None``. If these are set they will **override** the values
+which might be specified elsewhere. For example, we can specify
+mixed ploidy samples via the ``ploidy`` attribute of :class:`.SampleSet`:
+
+.. jupyter-execute::
+
+    ts = msprime.sim_ancestry(
+        samples=[
+            msprime.SampleSet(1, ploidy=3),
+            msprime.SampleSet(2)],
+        ploidy=1,
+        end_time=0)
+    print(ts.tables.individuals)
+    print(ts.tables.nodes)
+
+(Again, we stop the simulation immediately because we're only interested
+in the initial samples.) Here we have three sampled individuals again
+but in this they are mixed ploidy: the first individual is triploid
+and the other two are haploid.
+
+.. warning:: It is vital to note that setting the ``ploidy`` value
+    of :class:`.SampleSet` objects only affects sampling and does
+    not affect the actual simulation. In this case, the simulation
+    will be run on the haploid time scale. Some models may not
+    support mixing of ploidy at all.
+
+If you wish to set up the node and individual IDs in some other way,
+the :ref:`sec_ancestry_samples_advanced_sampling` section shows how
+to fully control how sample individuals and nodes are defined. However,
 this level of control should not be needed for the vast majority of
 applications.
 
@@ -465,13 +528,17 @@ applications.
 Ploidy
 ++++++
 
+.. todo:: This section is pretty much superseded by the previous discussion
+    and we don't actually discuss the important point about timescales
+    anywhere. We need to have a top-level section about this somewhere.
+
 The samples argument for :func:`sim_ancestry` is flexible, and allows us
 to provide samples in a number of different forms. In single-population
 models we can use the numeric form, which gives us :math:`n` samples:
 
 .. jupyter-execute::
 
-    ts = msprime.sim_ancestry(3, random_seed=42)
+    ts = msprime.sim_ancestry(3)
     SVG(ts.first().draw_svg())
 
 
@@ -484,7 +551,7 @@ six sample *nodes*.
 
 .. jupyter-execute::
 
-    ts = msprime.sim_ancestry(3, ploidy=1, random_seed=42)
+    ts = msprime.sim_ancestry(3, ploidy=1)
     SVG(ts.first().draw_svg())
 
 .. _sec_ancestry_samples_demography:
@@ -506,7 +573,9 @@ linear habitat.
 
     N = 10
     demography = msprime.Demography.stepping_stone_model(
-        [100] * N, migration_rate=0.1, boundaries=True)
+        [100] * N,
+        migration_rate=0.1,
+        boundaries=True)
     ts = msprime.sim_ancestry({0: 1, N - 1: 1}, demography=demography)
     ts
 
@@ -532,60 +601,31 @@ based on a species tree, and then draw samples using the species names.
 Sampling time
 +++++++++++++
 
-.. todo:: Translate this text taken from the old tutorial
-
-Simulating coalescent histories in which some of the samples are not
-from the present time is straightforward in ``msprime``.
-By using the ``samples`` argument to :meth:`msprime.simulate`
-we can specify the location and time at which all samples are made.
-
-.. code-block:: python
-
-    def historical_samples_example():
-        samples = [
-            msprime.Sample(population=0, time=0),
-            msprime.Sample(0, 0),  # Or, we can use positional arguments.
-            msprime.Sample(0, 1.0),
-            msprime.Sample(0, 1.0)
-        ]
-        tree_seq = msprime.simulate(samples=samples)
-        tree = tree_seq.first()
-        for u in tree.nodes():
-            print(u, tree.parent(u), tree.time(u), sep="\t")
-        print(tree.draw(format="unicode"))
-
-In this example we create four samples, two taken at the present time
-and two taken 1.0 generations in the past, as might represent one modern
-and one ancient diploid individual. There are a number of
-different ways in which we can describe the samples using the
-``msprime.Sample`` object (samples can be provided as plain tuples also
-if more convenient). Running this example, we get:
-
-.. code-block:: python
-
-    historical_samples_example()
-    # 6    -1    2.8240255501413247
-    # 4    6    0.0864109319103291
-    # 0    4    0.0
-    # 1    4    0.0
-    # 5    6    1.9249243960710336
-    # 2    5    1.0
-    # 3    5    1.0
-    #    6
-    #  ┏━┻━┓
-    #  ┃   5
-    #  ┃  ┏┻┓
-    #  ┃  2 3
-    #  ┃
-    #  4
-    # ┏┻┓
-    # 0 1
+By default the samples that we draw from a :class:`Population` are the
+population's ``sampling_time``. This is usually zero, representing the
+present, but in some demographic models representing (for example)
+with populations representing archaic individuals the default sampling
+time might be older. We can manually control the time at which samples
+are drawn using list of :class:`SampleSet` objects form for the
+samples argument.
 
 
-Because nodes ``0`` and ``1`` were sampled at time 0, their times in the tree
-are both 0. Nodes ``2`` and ``3`` were sampled at time 1.0, and so their times are recorded
-as 1.0 in the tree.
+.. jupyter-execute::
 
+    samples = [
+        msprime.SampleSet(1),
+        msprime.SampleSet(1, time=1.0)
+    ]
+    ts = msprime.sim_ancestry(samples)
+    print(ts.tables.nodes)
+    SVG(ts.draw_svg())
+
+In this example we create two diploid sample individuals, one at the present time
+and one taken 5 generations in the past, representing one modern
+and one ancient diploid individual. Running this example, we get:
+
+Because nodes ``0`` and ``1`` were sampled at time 0, their times in the
+node table are both 0; likewise, nodes ``2`` and ``3`` are at time 1.0.
 
 .. _sec_ancestry_samples_advanced_sampling:
 
@@ -631,6 +671,7 @@ Genome length
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 There are a number of different ways to specify the length of the
@@ -690,6 +731,7 @@ Discrete or continuous?
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -762,6 +804,7 @@ recombination model and number of loci.
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -795,6 +838,7 @@ Gene conversion
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 Gene conversion events are defined by two parameters: the rate at which gene
@@ -977,6 +1021,7 @@ Random seeds
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -1039,6 +1084,7 @@ Running replicate simulations
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -1096,6 +1142,7 @@ Ancestral recombination graph
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 In ``msprime`` we usually want to simulate the coalescent with recombination
@@ -1163,6 +1210,7 @@ Migration events
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -1239,6 +1287,7 @@ Stopping simulations early
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -1258,6 +1307,7 @@ Setting the start time
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 
@@ -1277,6 +1327,7 @@ Specifying the initial state
     :hide-code:
 
     import msprime
+    msprime.core.set_seed_rng_seed(42)
     from IPython.display import SVG
 
 

--- a/docs/ancestry.rst
+++ b/docs/ancestry.rst
@@ -439,6 +439,26 @@ Specifying samples
     import msprime
     from IPython.display import SVG
 
+The ``samples`` argument to :func:`sim_ancestry` defines the number
+of sample individuals we simulate the history of. There are three different
+ways forms; the ``samples`` argument can be:
+
+- an **integer**, interpreted as the number of samples to draw from this
+  population;
+- a **dictionary** mapping population references (either integer IDs or
+  names) to the number of samples for that population;
+- a list of :class:`.SampleSet` objects, which provide more flexibility
+  in how groups of similar samples are drawn from populations.
+
+.. warning:: It is important to note that the number of samples
+    refers to the number of *individuals* not the number of *nodes*.
+    See the :ref:`sec_ancestry_samples_ploidy` section for details.
+
+The :ref:`sec_ancestry_samples_advanced_sampling` section shows how
+to fully control how sample individuals and nodes are defined; however,
+this level of control should not be needed for the vast majority of
+applications.
+
 .. _sec_ancestry_samples_ploidy:
 
 ++++++
@@ -467,9 +487,50 @@ six sample *nodes*.
     ts = msprime.sim_ancestry(3, ploidy=1, random_seed=42)
     SVG(ts.first().draw_svg())
 
-+++++++++++++++
-Ancient genomes
-+++++++++++++++
+.. _sec_ancestry_samples_demography:
+
+++++++++++
+Demography
+++++++++++
+
+.. todo:: Some text here that refers to the demography section.
+
+
+The next example illustrates one usage of the dictionary form of the ``samples``
+argument. We first create a :class:`Demography` object representing
+a 10 deme linear stepping stone model. Then, we run the simulation
+with 1 diploid sample each drawn from the first and last demes in this
+linear habitat.
+
+.. jupyter-execute::
+
+    N = 10
+    demography = msprime.Demography.stepping_stone_model(
+        [100] * N, migration_rate=0.1, boundaries=True)
+    ts = msprime.sim_ancestry({0: 1, N - 1: 1}, demography=demography)
+    ts
+
+The keys in the dictionary can also be the string names of the
+population, which is useful when we are simulating from empirically
+estimated models. For example, here create a :class:`Demography` object
+based on a species tree, and then draw samples using the species names.
+
+.. jupyter-execute::
+
+    demography = msprime.Demography.from_species_tree(
+        "(((human:5.6,chimpanzee:5.6):3.0,gorilla:8.6):9.4,orangutan:18.0)",
+        branch_length_units="myr",
+        initial_size=10**4,
+        generation_time=20)
+    ts = msprime.sim_ancestry({"gorilla": 2, "human": 4}, demography=demography)
+    ts
+
+
+.. _sec_ancestry_samples_sampling_time:
+
++++++++++++++
+Sampling time
++++++++++++++
 
 .. todo:: Translate this text taken from the old tutorial
 
@@ -525,11 +586,16 @@ Because nodes ``0`` and ``1`` were sampled at time 0, their times in the tree
 are both 0. Nodes ``2`` and ``3`` were sampled at time 1.0, and so their times are recorded
 as 1.0 in the tree.
 
-++++++++++++++++++++
-Population structure
-++++++++++++++++++++
 
-.. todo examples of drawing samples from a demography.
+.. _sec_ancestry_samples_advanced_sampling:
+
++++++++++++++++++
+Advanced sampling
++++++++++++++++++
+
+.. todo:: This section should describe how to define samples directly in
+    terms of the ``initial_state`` tables and give an example of how to
+    use it.
 
 
 *****************
@@ -752,13 +818,13 @@ In the following example one gene conversion event of length 1 has occured.
     :hide-code:
 
     assert 1 < ts.num_trees < 5
-    
+
 Continous genomes can also be used. In this case the parameters define
 the rate at which gene conversion events are initiated per unit of sequence
 length and the mean of the exponentially distributed gene conversion tract
 lengths. The following example shows the same simulation as above but for a
 continuous genome of length 1 and scaled gene conversion parameters.
-    
+
 .. jupyter-execute::
 
     ts = msprime.sim_ancestry(
@@ -789,7 +855,7 @@ to a gene conversion event covering the tract from site 76 to site 80.
     :hide-code:
 
     assert 1 < ts.num_trees < 6
-    
+
 Variable recombination rates and constant gene conversion rates can be combined.
 In the next example we define a recombination map with a high recombination rate between
 site 10 and site 11 and a constant gene conversion rate with a mean tract length of 3.
@@ -1501,6 +1567,7 @@ API
 
 .. autofunction:: msprime.sim_ancestry
 
+.. autoclass:: msprime.SampleSet
 
 ++++++++++++++
 Deprecated API

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -356,7 +356,8 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
-    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    # currently 404ing.
+    # "numpy": ("http://docs.scipy.org/doc/numpy/", None),
     "tskit": ("https://tskit.readthedocs.io/en/stable", None),
     "stdpopsim": ("https://stdpopsim.readthedocs.io/en/stable", None),
 }

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -97,15 +97,12 @@ of a fixed size exists for all time. For most simulations this
 is an unrealistic assumption, and so msprime provides a way
 to describe more complex demographic histories.
 
-.. todo:: The demography.sample example here isn't a very good one
-    and the .sample function needs to updated.
-
 .. jupyter-execute::
 
     # Create a 1D stepping stone model of demograpy
     demography = msprime.Demography.stepping_stone_model([100] * 10, migration_rate=0.1)
-    # Take one diploid sample each from the first two demes
-    samples = demography.sample(1, 1)
+    # Take one diploid sample each from the first and last demes
+    samples = {0: 1, 9: 1}
     # Simulate an ancestral history for this demography and sample.
     ts = msprime.sim_ancestry(samples=samples, demography=demography)
     ts.tables.nodes

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -845,7 +845,7 @@ def _parse_sim_ancestry(
 
     # Simple defaults.
     start_time = 0 if start_time is None else float(start_time)
-    end_time = sys.float_info.max if end_time is None else float(end_time)
+    end_time = math.inf if end_time is None else float(end_time)
     discrete_genome = core._parse_flag(discrete_genome, default=True)
     record_full_arg = core._parse_flag(record_full_arg, default=False)
     record_migrations = core._parse_flag(record_migrations, default=False)

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1020,16 +1020,20 @@ def sim_ancestry(
 ):
     """
     Simulates an ancestral process described by a given model, demography and
-    set of samples and return the output as a
-    :class:`tskit.TreeSequence` (or a sequence of replicate tree sequences).
+    samples, and return a :class:`tskit.TreeSequence` (or a sequence of
+    replicate tree sequences).
 
     :param samples: The sampled individuals as either an integer, specifying
-        the number of individuals to sample at time zero in a single-population
-        model; or a list of :class:`.Sample` objects explicitly specifying the
-        time and population of every sample individual. Each sampled individual
-        corresponds to :math:`k` sample *nodes* when ``ploidy`` = :math:`k`.
+        the number of individuals to sample in a single-population model;
+        or a list of :class:`.SampleSet` objects defining the properties of
+        groups of similar samples; or as a mapping in which the keys
+        are population identifiers (either an integer ID or string name)
+        and the values are the number of samples to take from the corresponding
+        population at its default sampling time. It is important to note that
+        samples correspond to *individuals* here, and each sampled individual
+        is usually associated with :math:`k` sample *nodes* (or genomes) when
+        ``ploidy`` = :math:`k`. See :ref:`sec_ancestry_samples` for further details.
         Either ``samples`` or ``initial_state`` must be specified.
-        See :ref:`sec_ancestry_samples_ploidy` for usage examples.
     :param int ploidy: The number of monoploid genomes per sample individual
         (Default=2). See :ref:`sec_ancestry_samples_ploidy` for usage examples.
     :param float sequence_length: The length of the genome sequence to simulate.

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2020 University of Oxford
+# Copyright (C) 2015-2021 University of Oxford
 #
 # This file is part of msprime.
 #
@@ -241,7 +241,7 @@ class SimulationRunner:
         # "invisible" recombination breakpoints, so we can't run simulations
         # the usual way via sim_ancestry.
         self.simulator = ancestry._parse_sim_ancestry(
-            samples=demography.sample(*num_samples),
+            samples=dict(enumerate(num_samples)),
             demography=demography,
             recombination_rate=recomb_map,
             gene_conversion_rate=gene_conversion_rate,

--- a/msprime/core.py
+++ b/msprime/core.py
@@ -19,6 +19,7 @@
 """
 Core functions and classes used throughout msprime.
 """
+import numbers
 import os
 import random
 
@@ -76,12 +77,9 @@ def isinteger(value):
     Returns True if the specified value can be converted losslessly to an
     integer.
     """
-    try:
-        int_val = int(value)
-        float_val = float(value)
-        return int_val == float_val
-    except (ValueError, TypeError):
-        return False
+    if isinstance(value, numbers.Number):
+        return int(value) == float(value)
+    return False
 
 
 def _parse_flag(value, *, default):

--- a/msprime/core.py
+++ b/msprime/core.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2015-2020 University of Oxford
+# Copyright (C) 2015-2021 University of Oxford
 #
 # This file is part of msprime.
 #
@@ -70,6 +70,18 @@ def get_random_seed():
         # be unique, even across different processes.
         _seed_rng_map[pid] = random.Random()
     return _seed_rng_map[pid].randint(1, 2 ** 32 - 1)
+
+
+def set_seed_rng_seed(seed):
+    """
+    Convenience method to let us make unseeded simulations deterministic
+    when generating documentation examples.
+
+    DO NOT USE THIS FUNCTION!!!
+    """
+    global _seed_rng_map
+    pid = os.getpid()
+    _seed_rng_map[pid] = random.Random(seed)
 
 
 def isinteger(value):

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -81,6 +81,26 @@ class Demography:
 
         # Sort demographic events by time.
         self.events.sort(key=lambda de: de.time)
+        self.__name_id_map = None
+
+    def name_to_id(self, name):
+        """
+        Returns the integer ID (i.e., its position in the list of populations)
+        of the population with the specified name. If the name does not exist,
+        raise a KeyError.
+
+        Note: this function will raise an error if called before the ``validate``
+        method is called.
+
+        :param str name: The name of the population we wish to look up.
+        :return: The integer ID of the population.
+        :rtype: int
+        """
+        if self.__name_id_map is None:
+            raise ValueError("Cannot call name_to_id before calling validate()")
+        if name not in self.__name_id_map:
+            raise KeyError(f"Population with name '{name}' not found in demography")
+        return self.__name_id_map[name]
 
     @property
     def num_populations(self):
@@ -109,8 +129,13 @@ class Demography:
                     "Demographic events must be a list of DemographicEvent "
                     "instances sorted in non-decreasing order of time."
                 )
-        for population in self.populations:
+
+        self.__name_id_map = {}
+        for j, population in enumerate(self.populations):
             population.validate()
+            if population.name in self.__name_id_map:
+                raise ValueError(f"Duplicate population name: '{population.name}'")
+            self.__name_id_map[population.name] = j
 
     def insert_populations(self, tables):
         """

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -22,8 +22,8 @@ Test cases for basic ancestry simulation operations.
 import datetime
 import json
 import logging
+import math
 import random
-import sys
 import warnings
 
 import numpy as np
@@ -660,9 +660,9 @@ class TestParseSimAncestry:
             ancestry._parse_sim_ancestry(10, start_time=[])
 
     def test_end_time(self):
-        # default is DBL_MAX
+        # default is inf
         sim = ancestry._parse_sim_ancestry(10)
-        assert sim.end_time == sys.float_info.max
+        assert sim.end_time == math.inf
         for end_time in [1234, 1234.34, "1", "1.234"]:
             sim = ancestry._parse_sim_ancestry(10, end_time=end_time)
             assert sim.end_time == float(end_time)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -86,13 +86,10 @@ class TestIsInteger:
             -1,
             0,
             10 ** 6,
-            "1",
-            "100_000",
+            100_000,
             0x123,
             1.0,
             numpy_int_array[0],
-            numpy_int_array,
-            numpy_float_array,
             numpy_float_array[0],
         ]
         for good_value in good_values:
@@ -104,9 +101,12 @@ class TestIsInteger:
             [],
             None,
             {},
+            np.array([10], dtype=int),
             numpy_float_array,
             numpy_float_array[0],
             1.1,
+            "1",
+            "100_000",
             "1.1",
             1e-3,
         ]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,23 +54,28 @@ class TestDefaultRandomSeeds:
     def test_unique_multiple_processes_no_init(self):
         n = 100
         core.clear_seed_rng()
-        # Would use with block here, but not supported in Py < 3.3.
-        pool = multiprocessing.Pool(5)
-        seeds = pool.map(get_seed, range(n))
-        assert len(set(seeds)) == n
-        pool.terminate()
-        pool.join()
+        with multiprocessing.Pool(5) as pool:
+            seeds = pool.map(get_seed, range(n))
+            assert len(set(seeds)) == n
 
     def test_unique_multiple_processes_init(self):
         n = 100
         core.get_random_seed()
         assert core.get_seed_rng() is not None
-        # Would use with block here, but not supported in Py < 3.3.
-        pool = multiprocessing.Pool(5)
-        seeds = pool.map(get_seed, range(n))
-        assert len(set(seeds)) == n
-        pool.terminate()
-        pool.join()
+        with multiprocessing.Pool(5) as pool:
+            seeds = pool.map(get_seed, range(n))
+            assert len(set(seeds)) == n
+
+    def test_set_seed_rng_seed(self):
+        n = 10
+        core.set_seed_rng_seed(42)
+        seeds1 = [core.get_random_seed() for _ in range(n)]
+        core.set_seed_rng_seed(42)
+        seeds2 = [core.get_random_seed() for _ in range(n)]
+        assert seeds1 == seeds2
+        core.set_seed_rng_seed(1234)
+        seeds3 = [core.get_random_seed() for _ in range(n)]
+        assert seeds1 != seeds3
 
 
 class TestIsInteger:

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -3785,6 +3785,19 @@ class TestDemographyObject:
             msg = "A population name must be a valid Python identifier"
             assert msg in str(excinfo.value)
 
+    def test_population_name_map(self):
+        demography = msprime.Demography.isolated_model([1, 1])
+        assert demography.populations[0].name == "pop_0"
+        assert demography.populations[1].name == "pop_1"
+        # Looking up the name map before validate is
+        with pytest.raises(ValueError):
+            demography.name_to_id("pop_0")
+        demography.validate()
+        with pytest.raises(KeyError):
+            demography.name_to_id("x")
+        assert demography.name_to_id("pop_0") == 0
+        assert demography.name_to_id("pop_1") == 1
+
     def test_isolated_model(self):
         demography = msprime.Demography.isolated_model([2])
         assert demography.num_populations == 1

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018-2020 University of Oxford
+# Copyright (C) 2018-2021 University of Oxford
 #
 # This file is part of msprime.
 #
@@ -333,7 +333,7 @@ class TestSimMutations(MutateMixin):
     def test_populations(self):
         demography = msprime.Demography.island_model([1, 1], migration_rate=1)
         ts = msprime.sim_ancestry(
-            demography.sample(10, 10),
+            {0: 10, 1: 10},
             demography=demography,
             record_migrations=True,
             random_seed=1,

--- a/tests/test_species_tree_parsing.py
+++ b/tests/test_species_tree_parsing.py
@@ -600,7 +600,7 @@ class TestSpeciesTreeExamples:
 
         # Take one sample from each population
         ts = msprime.sim_ancestry(
-            samples=spec.sample(1, 1, 1, 1), demography=spec, ploidy=1
+            samples={j: 1 for j in range(4)}, demography=spec, ploidy=1
         )
 
         assert ts.num_trees == 1
@@ -619,21 +619,20 @@ class TestSpeciesTreeExamples:
         assert pops[6].metadata["name"] == "pop_6"
 
         # Use the population names to get the samples
-        samples = spec.sample(human=4, gorilla=2)
-        ts = msprime.simulate(samples=samples, demography=spec)
+        samples = dict(human=4, gorilla=2)
+        ts = msprime.sim_ancestry(samples=samples, demography=spec)
         assert ts.num_trees == 1
-        assert ts.num_samples == 6
+        assert ts.num_samples == 12
         for j, u in enumerate(ts.samples()):
-            pop = 0 if j < 4 else 2
+            pop = 0 if j < 8 else 2
             assert ts.node(u).population == pop
 
         # Order of keywords is respected
-        samples = spec.sample(gorilla=2, human=4)
-        ts = msprime.simulate(samples=samples, demography=spec)
+        ts = msprime.sim_ancestry(samples={"gorilla": 2, "human": 4}, demography=spec)
         assert ts.num_trees == 1
-        assert ts.num_samples == 6
+        assert ts.num_samples == 12
         for j, u in enumerate(ts.samples()):
-            pop = 2 if j < 2 else 0
+            pop = 2 if j < 4 else 0
             assert ts.node(u).population == pop
 
 


### PR DESCRIPTION
This is a proposal to finalise how we draw samples in the ``sim_ancestry`` function. The standard ``msprime.sim_ancestry(n)`` form will still work. More elaborate examples follow.

The ``samples`` parameter can be interpreted as a mapping, in which the keys are populations and the values are the number of samples to draw from the population
```python
demography = msprime.Demography.island_model([100, 100], migration_rate=0.1)
# Take 10 haploid samples from each population
ts = msprime.sim_ancestry({0: 10, 1: 10}, demography=demography, ploidy=1)
```

The keys can also be population ids:
```python
demography = msprime.Demography.from_species_tree(
    "(((human:5.6,chimpanzee:5.6):3.0,gorilla:8.6):9.4,orangutan:18.0)",
    branch_length_units="myr",
    initial_size=10**4,
    generation_time=20)
ts = msprime.sim_ancestry(samples={"gorilla": 2, "human": 4}, demography=demography)
```

~We can also specify a list of Samples in the same way as before so we can control. the sampling time and node IDs, like~
We can specify a list of SampleSets (a bit like the old Samples object, but more efficient/simpler/more flexible) so that we have more control:
```python
N = 100
ts = msprime.sim_ancestry(
    demography=msprime.Demography.island_model([N, N], migration_rate=1),
    samples=[msprime.SampleSet(1, population=0), msprime.SampleSet(1, population=1, time=N)],
)
```

I think this is a good combination of making the things people commonly want to do (sampling N individuals from a given population) easy and efficient, and also providing full flexibility for those who want to do more esoteric things. If we think this general approach is good, I have some ideas for adding more attributes to the Sample object that will give us more control of how sampling is done (e.g., add a ``num_nodes`` argument which lets us override the default behaviour of adding ``ploidy`` sample nodes for each sample).

There's also a bunch of things to finish up here, so don't bother doing a full review at this point.