### PR TITLE
Add some toc separators.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,76 +2,40 @@
 Welcome to msprime's documentation!
 ===================================
 
-This is the documentation for ``msprime``, a reimplementation of Hudson's
-classical :command:`ms` simulator.
+Simulate genealogical trees and genomic sequence data using
+retrospective population genetic models.
 
-If you are looking for help on a specific issue or would like to ask a
-question to fellow ``msprime`` users, please send an email to the
-`mailing list <https://groups.google.com/group/msprime-users>`_. By asking
-questions on the mailing list, you can help to build a searchable knowledge
-base.
-
-=====================
-OLD Introduction text
-=====================
-
-.. todo:: refactor this to be more relevant for 1.0. In particular,
-    we don't need to talk about ms so much.
-
-The primary goal of ``msprime`` is to efficiently and conveniently
-generate coalescent trees for a sample under a range of evolutionary
-scenarios. The library is a reimplementation of Hudson's seminal
-``ms`` program, and aims to eventually reproduce all its functionality.
-``msprime`` differs from ``ms`` in some important ways:
-
-1. ``msprime`` is *much* more efficient than ``ms``, both in terms of
-   memory usage and simulation time. In fact, ``msprime`` is also
-   much more efficient than simulators based on approximations to the
-   coalescent with recombination model, especially for simulations
-   with very large sample sizes. ``msprime`` can easily simulate
-   chromosome sized regions for hundreds of thousands of samples.
-
-2. ``msprime`` is primarily designed to be used through its
-   :ref:`Python API <sec_api>` to simplify the workflow associated with
-   running and analysing simulations. (However, we do provide an
-   ``ms`` compatible :ref:`command line interface <sec_cli>` to
-   plug in to existing workflows.) For many simulations we first
-   write a script to generate the command line parameters we
-   want to run, then fork shell processes to run the simulations,
-   and then parse the results to obtain the genealogies in a form
-   we can use. With ``msprime`` all of this can be done directly
-   in Python, which is both simpler and far more efficient.
-
-3. ``msprime`` does not use Newick trees for interchange as they
-   are extremely inefficient in terms of storage space and the
-   time needed to generate and parse them. Instead, we use the
-   `tskit library <https://tskit.readthedocs.io/en/stable/index.html>`_
-   which allows us to store and process very large scale simulation
-   results efficiently.
-
-
-.. This TOC is a work in progress while we refactor the documentation for 1.0.
-   The idea is we refactor all the stuff that's currently in the tutorial and
-   API sections into the appropriate high-level sections.
-
-.. It would be nice to split the TOC into some sections, if we could.
-
-Contents:
-=========
+.. todo:: This way of splitting up the content is preliminary and
+    doesn't really make sense. Work in progress!
 
 .. toctree::
    :maxdepth: 2
+   :caption: Getting started
 
+   what_is
    quickstart
+   installation
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Running simulations
+
    ancestry
    mutations
    demography
    likelihoods
-
-   installation
-   quickref
    utilities
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API documentation
+
+   quickref
    cli
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Developers
 
    development
    CITATION
@@ -79,6 +43,7 @@ Contents:
 
    tutorial
    api
+
 
 Indices and tables
 ==================

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,6 +10,9 @@ Quickstart
 Installation
 *************
 
+.. todo:: This section is probably unnecessary now, can just link to the
+    installation page.
+
 If you have `conda <https://docs.conda.io/en/latest/>`_ installed::
 
     $ conda install -c conda-forge msprime

--- a/docs/what_is.rst
+++ b/docs/what_is.rst
@@ -1,0 +1,8 @@
+.. _sec_what_is:
+
+================
+What is msprime?
+================
+
+
+.. todo:: What **is** msprime??


### PR DESCRIPTION
Closes #1373

Doh! We can have multiple toc directives. This changes how we organise the docs quite fundamentally I think, opening up the possibility of *much* better ways of doing it. I'll need to play with things a big before I come up with a proposal. 

For now though, here's a preliminary pass which at least shows what's possible that we can deploy for alpha2 (hopefully I'll have an update to improve things later today, though).