### PR TITLE
Mutation updates

### DIFF
--- a/docs/v0/upgrading.md
+++ b/docs/v0/upgrading.md
@@ -86,6 +86,12 @@ function and is very similar. There are some important differences though:
 * There are now also many new mutation models supported by :func:.sim_mutations;
   see {ref}`sec_mutations` for details. These are *not* supported in the deprecated
   {func}`.mutate` function.
+* The simulated mutations now have a simulated ``time`` value, which specifies the 
+  precise time that the mutation occurred. Note that this value is also provided in the
+  returned tables for the deprecated ``simulate()`` and ``mutate()`` functions,
+  which may lead to some compatibility issues. (We considered removing the simulated
+  mutation times for these 0.x functions for strict compatibility, but this would
+  have broken any code using the ``keep`` option in mutate.)
 
 ## Utilities
 

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -78,7 +78,7 @@ def mutation_model_factory(model):
     }
 
     if model is None:
-        model_instance = BinaryMutationModel()
+        model_instance = JC69MutationModel()
     elif isinstance(model, str):
         lower_model = model.lower()
         if lower_model not in model_map:
@@ -1034,7 +1034,7 @@ NUCLEOTIDES = 1
 
 class InfiniteSites(MatrixMutationModel):
     # This mutation model is defined for backwards compatability, and is a remnant
-    # of an earlier design. We keep it to
+    # of an earlier design.
     def __init__(self, alphabet=BINARY):
         self.alphabet = alphabet
         models = {BINARY: BinaryMutationModel(), NUCLEOTIDES: JC69MutationModel()}
@@ -1137,6 +1137,9 @@ def mutate(
             "This is a legacy interface which does not support general "
             "mutation models. Please use the sim_ancestry function instead."
         )
+    # The legacy function simulates 0/1 alleles by default.
+    if model is None:
+        model = BinaryMutationModel()
     return sim_mutations(
         tree_sequence,
         rate=rate,

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -1944,3 +1944,25 @@ class TestModelClasses:
             str(m) == "Infinite alleles mutation model, beginning with"
             " allele 1\n    next allele: 1\n"
         )
+
+
+class TestDeprecatedApis:
+    def test_simulate_mutate_keep(self):
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
+        assert ts.num_sites > 0
+        mts = msprime.mutate(ts, rate=1, random_seed=3, keep=True)
+        assert set(mts.tables.sites.position) > set(ts.tables.sites.position)
+
+    def test_simulate_sim_mutations(self):
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=2)
+        assert ts.num_sites > 0
+        mts = msprime.sim_mutations(
+            ts, rate=1, random_seed=3, keep=True, discrete_genome=False
+        )
+        assert set(mts.tables.sites.position) > set(ts.tables.sites.position)
+
+    def test_sim_ancestry_mutate(self):
+        ts = msprime.sim_ancestry(10, random_seed=2)
+        assert ts.num_sites == 0
+        mts = msprime.mutate(ts, rate=1, random_seed=3)
+        assert mts.num_sites > 0

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -323,18 +323,18 @@ class TestBuildObjects:
         assert not decoded.parameters.keep
         assert (
             decoded.parameters.model["__class__"]
-            == "msprime.mutations.BinaryMutationModel"
+            == "msprime.mutations.JC69MutationModel"
         )
 
     def test_mutate_model(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.sim_mutations(ts, model="jc69")
+        ts = msprime.sim_mutations(ts, model="pam")
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
         assert decoded.parameters.command == "sim_mutations"
         assert (
             decoded.parameters.model["__class__"]
-            == "msprime.mutations.JC69MutationModel"
+            == "msprime.mutations.PAMMutationModel"
         )
 
     def test_mutate_map(self):


### PR DESCRIPTION
Some updates to the mutations API for the next 1.0 alpha.

- Sets the default models for sim_mutations to JC69. I really can't see a good reason for defaulting to 0/1 now when we have a chance to fix this. (#1403)
- ~More controversially, discards the mutations times for the deprecated APIs. (#1399).~

~There we some unexpected hiccups with this, where we mix the output msprime.simulate() with the ``keep`` option, which now requires that times be set. So, I *think* this means that old code that does ``msprime.simulate()``, ``msprime.mutate(keep=True)`` will break, which is much worse than the vaguely forseen compatibility problems we might get from having times assigned where there used to be none. So, likely the best thing to do is drop the last commit in this PR, and make some notes on potential compatibility problems.~

~It was a good exercise to go through anyway, I think.~

~@petrelharp, what do you think?~

[EDIT] I've updated this PR to drop the commit in question and tack in another one with some notes to the effect that we can't remove the ``time`` column, and moved it do it's own PR for the record (#1406). Ready for review and merge now I think.