### PR TITLE
Drop mutation times  for old apis

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -59,6 +59,7 @@
 #define MSP_KEEP_SITES (1 << 0)
 #define MSP_DISCRETE_SITES (1 << 1)
 #define MSP_KEPT_MUTATIONS_BEFORE_END_TIME (1 << 2)
+#define MSP_DISCARD_MUTATION_TIMES (1 << 3)
 
 /* Pedigree states */
 #define MSP_PED_STATE_UNCLIMBED 0

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -2830,20 +2830,21 @@ msprime_sim_mutations(PyObject *self, PyObject *args, PyObject *kwds)
     mutation_model_t *model = NULL;
     int discrete_genome = false;
     int kept_mutations_before_end_time = false;
+    int discard_times = false; /* for backwards compatibility */
     static char *kwlist[] = {
         "tables", "random_generator", "rate_map", "model",
         "discrete_genome", "keep", "kept_mutations_before_end_time",
-        "start_time", "end_time", NULL};
+        "start_time", "end_time", "discard_times", NULL};
     mutgen_t mutgen;
     int err;
 
     memset(&mutgen, 0, sizeof(mutgen));
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!O|iiidd", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O!O!O|iiiddi", kwlist,
             &LightweightTableCollectionType, &tables,
             &RandomGeneratorType, &random_generator,
             &PyDict_Type, &rate_map,
             &py_model, &discrete_genome, &keep, &kept_mutations_before_end_time,
-            &start_time, &end_time)) {
+            &start_time, &end_time, &discard_times)) {
         goto out;
     }
     if (LightweightTableCollection_check_state(tables) != 0
@@ -2886,6 +2887,9 @@ msprime_sim_mutations(PyObject *self, PyObject *args, PyObject *kwds)
     }
     if (kept_mutations_before_end_time) {
         flags |= MSP_KEPT_MUTATIONS_BEFORE_END_TIME;
+    }
+    if (discard_times) {
+        flags |= MSP_DISCARD_MUTATION_TIMES;
     }
     err = mutgen_generate(&mutgen, flags);
     if (err != 0) {

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -78,7 +78,7 @@ def mutation_model_factory(model):
     }
 
     if model is None:
-        model_instance = BinaryMutationModel()
+        model_instance = JC69MutationModel()
     elif isinstance(model, str):
         lower_model = model.lower()
         if lower_model not in model_map:
@@ -1034,7 +1034,7 @@ NUCLEOTIDES = 1
 
 class InfiniteSites(MatrixMutationModel):
     # This mutation model is defined for backwards compatability, and is a remnant
-    # of an earlier design. We keep it to
+    # of an earlier design.
     def __init__(self, alphabet=BINARY):
         self.alphabet = alphabet
         models = {BINARY: BinaryMutationModel(), NUCLEOTIDES: JC69MutationModel()}
@@ -1137,6 +1137,9 @@ def mutate(
             "This is a legacy interface which does not support general "
             "mutation models. Please use the sim_ancestry function instead."
         )
+    # The legacy function simulates 0/1 alleles by default.
+    if model is None:
+        model = BinaryMutationModel()
     return sim_mutations(
         tree_sequence,
         rate=rate,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1291,9 +1291,10 @@ class TestMspConversionOutput(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._tree_sequence = msprime.simulate(
-            10, length=10, recombination_rate=10, mutation_rate=10, random_seed=1
+        ts = msprime.sim_ancestry(
+            10, sequence_length=10, recombination_rate=10, random_seed=1
         )
+        cls._tree_sequence = msprime.sim_mutations(ts, rate=10, random_seed=1)
         fd, cls._tree_sequence_file = tempfile.mkstemp(
             prefix="msp_cli", suffix=".trees"
         )

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -309,7 +309,7 @@ class TestBuildObjects:
         )
 
     def test_sim_mutations(self):
-        ts = msprime.simulate(5, random_seed=1)
+        ts = msprime.sim_ancestry(5, random_seed=1)
         ts = msprime.sim_mutations(
             ts, rate=2, random_seed=1, start_time=0, end_time=100, keep=False
         )
@@ -323,18 +323,18 @@ class TestBuildObjects:
         assert not decoded.parameters.keep
         assert (
             decoded.parameters.model["__class__"]
-            == "msprime.mutations.BinaryMutationModel"
+            == "msprime.mutations.JC69MutationModel"
         )
 
     def test_mutate_model(self):
         ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.sim_mutations(ts, model="jc69")
+        ts = msprime.sim_mutations(ts, model="pam")
         decoded = self.decode(ts.provenance(1).record)
         assert decoded.schema_version == "1.0.0"
         assert decoded.parameters.command == "sim_mutations"
         assert (
             decoded.parameters.model["__class__"]
-            == "msprime.mutations.JC69MutationModel"
+            == "msprime.mutations.PAMMutationModel"
         )
 
     def test_mutate_map(self):
@@ -476,18 +476,18 @@ class TestSimulateRoundTrip(TestRoundTrip):
         self.verify(ts)
 
 
-class TestMutateRoundTrip(TestRoundTrip):
+class TestSimMutationsRoundTrip(TestRoundTrip):
     def test_mutate_round_trip(self):
-        ts = msprime.simulate(5, random_seed=1)
-        ts = msprime.mutate(
+        ts = msprime.sim_ancestry(5, random_seed=1)
+        ts = msprime.sim_mutations(
             ts, rate=2, random_seed=1, start_time=0, end_time=100, keep=False
         )
         self.verify(ts)
 
     def test_mutate_rate_map(self):
-        ts = msprime.simulate(5, random_seed=1)
+        ts = msprime.sim_ancestry(5, random_seed=1)
         rate_map = msprime.RateMap(position=[0, 0.5, 1], rate=[0, 1])
-        ts = msprime.mutate(ts, rate=rate_map)
+        ts = msprime.sim_mutations(ts, rate=rate_map)
         self.verify(ts)
 
 


### PR DESCRIPTION
Depends on #1405 

This is a PR to keep a record of what would be required to null out the mutation time columns as discussed in #1399.

Basically, we shouldn't do this because it will break old code using the ``keep`` option in mutate()