### PR TITLE
added nose to developer reqs

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -21,7 +21,7 @@ sphinx==3.3.1
 sphinx-argparse
 sphinx-issues
 jupyter-book
-
+nose
 newick
 # We use JSON-schema to test out metadata handling.
 python_jsonschema_objects


### PR DESCRIPTION
i had to nuke my conda environment for tskit development and in recreating it i got tripped up by not having `nose`. i've added it to `requirements/development.txt` here