### PR TITLE
Update API for kept mutations in sim_mutations.

### DIFF
--- a/lib/mutgen.c
+++ b/lib/mutgen.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2015-2020 University of Oxford
+** Copyright (C) 2015-2021 University of Oxford
 **
 ** This file is part of msprime.
 **
@@ -1069,6 +1069,13 @@ mutgen_populate_tables(mutgen_t *self)
                     parent_id = TSK_NULL;
                 } else {
                     parent_id = m->parent->id;
+                    if (m->derived_state_length == m->parent->derived_state_length
+                        && memcmp(m->derived_state, m->parent->derived_state,
+                               m->derived_state_length)
+                               == 0) {
+                        ret = MSP_ERR_BAD_ANCESTRAL_MUTATION;
+                        goto out;
+                    }
                     tsk_bug_assert(parent_id != TSK_NULL);
                 }
                 mutation_id = tsk_mutation_table_add_row(mutations, site_id, m->node,

--- a/lib/tests/test_mutations.c
+++ b/lib/tests/test_mutations.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2016-2020 University of Oxford
+** Copyright (C) 2016-2021 University of Oxford
 **
 ** This file is part of msprime.
 **
@@ -508,7 +508,6 @@ static void
 test_single_tree_mutgen_keep_sites_many_mutations(void)
 {
     int ret = 0;
-    int j;
     gsl_rng *rng = gsl_rng_alloc(gsl_rng_default);
     tsk_table_collection_t tables;
     mutgen_t mutgen;
@@ -520,23 +519,17 @@ test_single_tree_mutgen_keep_sites_many_mutations(void)
     ret = matrix_mutation_model_factory(&mut_model, ALPHABET_NUCLEOTIDE);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    for (j = 0; j < 8192; j++) {
-        ret = tsk_mutation_table_add_row(
-            &tables.mutations, 0, 0, -1, 0.0, "C", 1, NULL, 0);
-        CU_ASSERT_EQUAL_FATAL(ret, j + 1);
-    }
-
     gsl_rng_set(rng, 2);
     ret = mutgen_alloc(&mutgen, rng, &tables, &mut_model, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = mutgen_set_rate(&mutgen, 10);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = mutgen_generate(&mutgen, MSP_DISCRETE_SITES);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    for (j = 0; j < 10; j++) {
-        ret = mutgen_generate(&mutgen, MSP_KEEP_SITES);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-    }
-    CU_ASSERT_TRUE(tables.sites.num_rows > 2);
+    ret = mutgen_generate(&mutgen,
+        MSP_DISCRETE_SITES | MSP_KEEP_SITES | MSP_KEPT_MUTATIONS_BEFORE_END_TIME);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_BAD_ANCESTRAL_MUTATION);
 
     mutgen_free(&mutgen);
     mutation_model_free(&mut_model);

--- a/lib/util.c
+++ b/lib/util.c
@@ -200,6 +200,12 @@ msp_strerror_internal(int err)
                   "existing mutations: finite site mutations must be generated on "
                   "older time periods first.";
             break;
+        case MSP_ERR_BAD_ANCESTRAL_MUTATION:
+            ret = "The ancestral mutations added resulted in a silent transition "
+                  "(e.g. A -> A) which is not permitted by tskit. Please open an "
+                  "issue at https://github.com/tskit-dev/msprime/issues if you "
+                  "encounter this problem.";
+            break;
         case MSP_ERR_INSUFFICIENT_ALLELES:
             ret = "Must have at least two alleles.";
             break;

--- a/lib/util.h
+++ b/lib/util.h
@@ -113,6 +113,7 @@
 #define MSP_ERR_BAD_ANCIENT_SAMPLE_NODE                             -69
 #define MSP_ERR_UNKNOWN_TIME_NOT_SUPPORTED                          -70
 #define MSP_ERR_DTWF_DIPLOID_ONLY                                   -71
+#define MSP_ERR_BAD_ANCESTRAL_MUTATION                              -72
 
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1201,11 +1201,17 @@ def sim_mutations(
     keep=True)` might insert an X->Z mutation above the existing mutation, thus
     implying the impossible chain X->Y->Z.)  For this reason, if this method
     attempts to add a new mutation ancestral to any existing mutation, an error
-    will occur, unless ``add_ancestral=True``. The ``add_ancestral`` parameter
-    has no effect if ``keep=False``. In summary, to add more mutations to a
-    tree sequence with existing mutations, you need to either ensure that no
-    new mutations are ancestral to existing ones (e.g., using the ``end_time``
-    parameter), or set ``add_ancestral=True``.
+    will occur, unless ``add_ancestral=True``. Furthermore, even if
+    ``add_ancestral`` is True, this will throw an error if there are any
+    mutations that result in a silent transition (e.g., placing a mutation to A
+    above an existing mutation to A), since silent transitions are not allowed
+    in tskit. The ``add_ancestral`` parameter has no effect if ``keep=False``.
+
+    In summary, to add more mutations to a tree sequence with existing
+    mutations, you need to either ensure that no new mutations are ancestral to
+    existing ones (e.g., using the ``end_time`` parameter), or set
+    ``add_ancestral=True`` and be prepared for ocassional errors when silent
+    mutations arise.
 
     :param tskit.TreeSequence tree_sequence: The tree sequence onto which we
         wish to throw mutations.

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1148,6 +1148,7 @@ def mutate(
         keep=keep,
         start_time=start_time,
         end_time=end_time,
+        add_ancestral=True,
         discrete_genome=False,
     )
 
@@ -1158,11 +1159,11 @@ def sim_mutations(
     *,
     random_seed=None,
     model=None,
-    keep=None,
     start_time=None,
     end_time=None,
     discrete_genome=None,
-    kept_mutations_before_end_time=None,
+    keep=None,
+    add_ancestral=None,
 ):
     """
     Simulates mutations on the specified ancestry and returns the resulting
@@ -1183,25 +1184,28 @@ def sim_mutations(
     then the same mutations will be generated. If no random seed is specified
     then one is generated automatically.
 
-    By default, sites and mutations in the input tree sequence are
-    discarded. If the ``keep`` parameter is true, however, *additional*
-    mutations are simulated. Under the infinite sites mutation model, all new
-    mutations generated will occur at distinct positions from each other and
-    from any existing mutations (by rejection sampling). Furthermore, if sites
-    are discrete, trying to simulate mutations at time periods that are older
-    than mutations kept from the original tree sequence is an error, because
-    this would create an extra transition (from the new allele to the old
-    one below it) that may be incorrect according to the model of mutation.
-    Under a state-independent mutation model, however (e.g., Jukes-Cantor),
-    there is no problem, and ``kept_mutations_before_end_time=True`` may be
-    set to allow adding new mutations around or above existing ones.
-
     The time interval over which mutations can occur may be controlled
     using the ``start_time`` and ``end_time`` parameters. The ``start_time``
     defines the lower bound (in time-ago) on this interval and ``max_time``
     the upper bound. Note that we may have mutations associated with
     nodes with time <= ``start_time`` since mutations store the node at the
     bottom (i.e., towards the leaves) of the branch that they occur on.
+
+    If the tree sequence already has mutations, these are by default retained,
+    but can be discarded by passing ``keep=False``. However, adding new
+    mutations to a tree sequence with existing mutations must be done with
+    caution, since it can lead to incorrect or nonsensical results if mutation
+    probabilities differ by ancestral state. (As an extreme example, suppose
+    that X->Y and X->Z are allowable transitions, but Y->Z is not. If a branch
+    already has an X->Y mutation on it, then calling `sim_mutations(...,
+    keep=True)` might insert an X->Z mutation above the existing mutation, thus
+    implying the impossible chain X->Y->Z.)  For this reason, if this method
+    attempts to add a new mutation ancestral to any existing mutation, an error
+    will occur, unless ``add_ancestral=True``. The ``add_ancestral`` parameter
+    has no effect if ``keep=False``. In summary, to add more mutations to a
+    tree sequence with existing mutations, you need to either ensure that no
+    new mutations are ancestral to existing ones (e.g., using the ``end_time``
+    parameter), or set ``add_ancestral=True``.
 
     :param tskit.TreeSequence tree_sequence: The tree sequence onto which we
         wish to throw mutations.
@@ -1219,16 +1223,15 @@ def sim_mutations(
         mutation model is used. Please see the
         :ref:`sec_mutations_models` section for more details
         on specifying mutation models.
-    :param bool keep: Whether to keep existing mutations (default: False).
     :param float start_time: The minimum time ago at which a mutation can
         occur. (Default: no restriction.)
     :param float end_time: The maximum time ago at which a mutation can occur
         (Default: no restriction).
     :param bool discrete_genome: Whether to generate mutations at only integer positions
         along the genome (Default=True).
-    :param bool kept_mutations_before_end_time: Whether to allow mutations to be added
-        ancestrally to existing (kept) mutations. This flag has no effect
-        if either keep or discrete_genome are False.
+    :param bool keep: Whether to keep existing mutations. (default: True)
+    :param bool add_ancestral: Whether to allow the addition of new mutations
+        ancestral to existing ones. (default: False)
     :return: The :class:`tskit.TreeSequence` object resulting from overlaying
         mutations on the input tree sequence.
     :rtype: :class:`tskit.TreeSequence`
@@ -1258,10 +1261,8 @@ def sim_mutations(
     if start_time > end_time:
         raise ValueError("start_time must be <= end_time")
     discrete_genome = core._parse_flag(discrete_genome, default=True)
-    keep = core._parse_flag(keep, default=False)
-    kept_mutations_before_end_time = core._parse_flag(
-        kept_mutations_before_end_time, default=False
-    )
+    keep = core._parse_flag(keep, default=True)
+    add_ancestral = core._parse_flag(add_ancestral, default=False)
 
     model = mutation_model_factory(model)
 
@@ -1285,7 +1286,7 @@ def sim_mutations(
         model=model,
         discrete_genome=discrete_genome,
         keep=keep,
-        kept_mutations_before_end_time=kept_mutations_before_end_time,
+        kept_mutations_before_end_time=add_ancestral,
         start_time=start_time,
         end_time=end_time,
     )

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -2562,8 +2562,9 @@ class TestSimMutations:
         tables = tskit.TableCollection(1)
         tables.nodes.add_row(0)
         tables.sites.add_row(0, "a")
-        for _ in range(8192):
+        for _ in range(4096):
             tables.mutations.add_row(0, node=0, time=0, derived_state="b")
+            tables.mutations.add_row(0, node=0, time=0, derived_state="c")
         tables.build_index()
         tables.compute_mutation_parents()
         self.verify_block_size(tables)


### PR DESCRIPTION
Closes #1206

This threw up a problem I hadn't previously considered: what happens when we generate mutations when ``add_ancestral`` is True that won't decode in tskit? It feels like we should be able to rejection sample (or something) so that we don't do this, but I haven't thought hard about it. We should at least detect the problem and raise an error before the users calls ``variants()`` anyway.

@petrelharp, what do you think? 