### PR TITLE
Link to underlying code

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -29,6 +29,7 @@ sphinx:
     - sphinx.ext.autodoc
     - sphinx.ext.autosummary
     - sphinx.ext.todo
+    - sphinx.ext.viewcode
     - sphinx.ext.intersphinx
     - sphinx_issues
     - sphinxarg.ext


### PR DESCRIPTION
This is pretty helpful when looking through the docs for stuff that need documenting. We do it in tskit. Is there any reason *not* to show the code in msprime?