### PR TITLE
More demography tidyups

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -10,8 +10,10 @@ REPORTDIR=_build/html/reports
 jupyter-book build -W --keep-going .
 RETVAL=$?
 if [ $RETVAL -ne 0 ]; then
-    echo "Error occured; showing saved reports"
-    cat $REPORTDIR/*
+    if [ -e $REPORTDIR ]; then
+      echo "Error occured; showing saved reports"
+      cat $REPORTDIR/*
+    fi
 else
     # Clear out any old reports
     rm -f $REPORTDIR/*

--- a/lib/dev-tools/dev-cli.c
+++ b/lib/dev-tools/dev-cli.c
@@ -391,7 +391,7 @@ read_population_configuration(msp_t *msp, config_t *config)
             fatal_error("initial_size not specified");
         }
         initial_size = config_setting_get_float(t);
-        ret = msp_set_population_configuration(msp, j, initial_size, growth_rate);
+        ret = msp_set_population_configuration(msp, j, initial_size, growth_rate, true);
         if (ret != 0) {
             fatal_msprime_error(ret, __LINE__);
         }

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -514,6 +514,7 @@ msp_alloc_populations(msp_t *self)
         self->initial_populations[j].growth_rate = 0.0;
         self->initial_populations[j].initial_size = 1.0;
         self->initial_populations[j].start_time = 0.0;
+        self->initial_populations[j].state = MSP_POP_STATE_ACTIVE;
     }
 out:
     return ret;
@@ -559,8 +560,8 @@ out:
 }
 
 int
-msp_set_population_configuration(
-    msp_t *self, int population_id, double initial_size, double growth_rate)
+msp_set_population_configuration(msp_t *self, int population_id, double initial_size,
+    double growth_rate, bool initially_active)
 {
     int ret = MSP_ERR_BAD_POPULATION_CONFIGURATION;
 
@@ -574,6 +575,8 @@ msp_set_population_configuration(
     }
     self->initial_populations[population_id].initial_size = initial_size;
     self->initial_populations[population_id].growth_rate = growth_rate;
+    self->initial_populations[population_id].state
+        = initially_active ? MSP_POP_STATE_ACTIVE : MSP_POP_STATE_INACTIVE;
     ret = 0;
 out:
     return ret;
@@ -1626,6 +1629,7 @@ msp_print_state(msp_t *self, FILE *out)
     fprintf(out, "]\n");
     for (j = 0; j < self->num_populations; j++) {
         fprintf(out, "pop[%d]:\n", (int) j);
+        fprintf(out, "\tstate        = %d\n", self->populations[j].state);
         fprintf(out, "\tstart_time   = %.14g\n", self->populations[j].start_time);
         fprintf(out, "\tinitial_size = %.14g\n", self->populations[j].initial_size);
         fprintf(out, "\tgrowth_rate  = %.14g\n", self->populations[j].growth_rate);
@@ -1858,6 +1862,11 @@ msp_move_individual(msp_t *self, avl_node_t *node, avl_tree_t *source,
     int ret = 0;
     segment_t *ind, *x, *y, *new_ind;
     double recomb_mass, gc_mass;
+
+    if (self->populations[dest_pop].state != MSP_POP_STATE_ACTIVE) {
+        ret = MSP_ERR_POPULATION_INACTIVE_MOVE;
+        goto out;
+    }
 
     ind = (segment_t *) node->item;
     avl_unlink_node(source, node);
@@ -3418,9 +3427,15 @@ msp_insert_sample(msp_t *self, tsk_id_t node)
 {
     int ret = 0;
     segment_t *root_seg;
+    population_t pop;
 
     root_seg = self->root_segments[node];
-    if (self->populations[root_seg->population].initial_size == 0) {
+    pop = self->populations[root_seg->population];
+    if (pop.state != MSP_POP_STATE_ACTIVE) {
+        ret = MSP_ERR_POPULATION_INACTIVE_SAMPLE;
+        goto out;
+    }
+    if (pop.initial_size == 0) {
         ret = MSP_ERR_BAD_SAMPLES;
         goto out;
     }
@@ -3642,10 +3657,11 @@ msp_reset(msp_t *self)
     for (population_id = 0; population_id < (population_id_t) N; population_id++) {
         pop = self->populations + population_id;
         /* Set the initial population parameters */
-        initial_pop = self->initial_populations + population_id;
+        initial_pop = &self->initial_populations[population_id];
         pop->growth_rate = initial_pop->growth_rate;
         pop->initial_size = initial_pop->initial_size;
         pop->start_time = self->time;
+        pop->state = initial_pop->state;
     }
     /* Reset the tables to their correct position for replication */
     ret = tsk_table_collection_truncate(self->tables, &self->input_position);
@@ -3713,9 +3729,14 @@ msp_initialise_simulation_state(msp_t *self)
             min_root_time = GSL_MIN(node_time[root], min_root_time);
         }
     }
-    /* Make sure that the start-time is no less than the time of the
-     * youngest root */
-    self->start_time = GSL_MAX(self->start_time, min_root_time);
+    if (self->input_position.nodes == 0) {
+        /* When we're initialising for debugging we provide no samples. */
+        self->start_time = 0;
+    } else {
+        /* Make sure that the start-time is no less than the time of the
+         * youngest root */
+        self->start_time = GSL_MAX(self->start_time, min_root_time);
+    }
 
     /* Anything that has min_root_time is an initial sample, otherwise we
      * register them as sampling events */
@@ -5467,8 +5488,8 @@ msp_get_num_migration_events(msp_t *self, size_t *num_migration_events)
 }
 
 int MSP_WARN_UNUSED
-msp_get_population_configuration(
-    msp_t *self, size_t population_id, double *initial_size, double *growth_rate)
+msp_get_population_configuration(msp_t *self, size_t population_id, double *initial_size,
+    double *growth_rate, int *state)
 {
     int ret = 0;
     population_t *pop;
@@ -5480,6 +5501,7 @@ msp_get_population_configuration(
     pop = &self->populations[population_id];
     *initial_size = pop->initial_size;
     *growth_rate = pop->growth_rate;
+    *state = pop->state;
 out:
     return ret;
 }
@@ -5823,6 +5845,43 @@ out:
     return ret;
 }
 
+static void
+msp_deactivate_population(msp_t *self, int population_id)
+{
+    population_t *pop = &self->populations[population_id];
+
+    tsk_bug_assert(pop->state == MSP_POP_STATE_ACTIVE);
+    tsk_bug_assert(msp_get_num_population_ancestors(self, population_id) == 0);
+    pop->state = MSP_POP_STATE_PREVIOUSLY_ACTIVE;
+    /* Set these to zero for tidyness sake */
+    pop->initial_size = 0;
+    pop->growth_rate = 0;
+}
+
+static int
+msp_activate_population(msp_t *self, int population_id)
+{
+    int ret = 0;
+    population_t *pop = &self->populations[population_id];
+
+    /* It's not currently possible to do this because we're only calling
+     * msp_activate_population from population split, where we only activate
+     * if it's not already active. But, leaving this here as a reminder
+     * in case we ever do call activate from somewhere else.
+     */
+    /* if (pop->state == MSP_POP_STATE_ACTIVE) { */
+    /*     ret = MSP_ERR_POPULATION_CURRENTLY_ACTIVE; */
+    /*     goto out; */
+    /* } */
+    if (pop->state == MSP_POP_STATE_PREVIOUSLY_ACTIVE) {
+        ret = MSP_ERR_POPULATION_PREVIOUSLY_ACTIVE;
+        goto out;
+    }
+    pop->state = MSP_POP_STATE_ACTIVE;
+out:
+    return ret;
+}
+
 /* Population split */
 
 static int
@@ -5833,14 +5892,28 @@ msp_population_split(msp_t *self, demographic_event_t *event)
     population_id_t ancestral = event->params.population_split.ancestral;
     size_t num_populations = event->params.population_split.num_derived;
     demographic_event_t mass_migration;
+    population_t *pop = &self->populations[ancestral];
     size_t j, k;
     size_t N = self->num_populations;
+
+    if (pop->state != MSP_POP_STATE_ACTIVE) {
+        ret = msp_activate_population(self, ancestral);
+        if (ret != 0) {
+            goto out;
+        }
+    }
 
     /* The mass migration moves lineages into the ancestral population */
     mass_migration.params.mass_migration.destination = ancestral;
     mass_migration.params.mass_migration.proportion = 1.0;
 
     for (j = 0; j < num_populations; j++) {
+        pop = &self->populations[derived[j]];
+        if (pop->state != MSP_POP_STATE_ACTIVE) {
+            ret = MSP_ERR_SPLIT_DERIVED_NOT_ACTIVE;
+            goto out;
+        }
+
         /* Turn off all migration to and from derived[j] */
         for (k = 0; k < self->num_populations; k++) {
             self->migration_matrix[((size_t) derived[j] * N) + k] = 0;
@@ -5852,6 +5925,7 @@ msp_population_split(msp_t *self, demographic_event_t *event)
         if (ret != 0) {
             goto out;
         }
+        msp_deactivate_population(self, derived[j]);
     }
 out:
     return ret;
@@ -5874,6 +5948,48 @@ msp_print_population_split(
     fprintf(out, "] -> %d \n", event->params.population_split.ancestral);
 }
 
+static int MSP_WARN_UNUSED
+msp_check_event_populations(
+    msp_t *self, size_t num_populations, int32_t *populations, int different_population)
+{
+    int ret = 0;
+    int N = (int) self->num_populations;
+    size_t j;
+    bool *population_used = calloc(self->num_populations, sizeof(*population_used));
+
+    if (population_used == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
+
+    if (num_populations >= MSP_MAX_EVENT_POPULATIONS) {
+        ret = MSP_ERR_TOO_MANY_EVENT_POPULATIONS;
+        goto out;
+    }
+    if (different_population < 0 || different_population >= N) {
+        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
+        goto out;
+    }
+    for (j = 0; j < num_populations; j++) {
+        if (populations[j] < 0 || populations[j] >= N) {
+            ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
+            goto out;
+        }
+        if (populations[j] == different_population) {
+            ret = MSP_ERR_SOURCE_DEST_EQUAL;
+            goto out;
+        }
+        if (population_used[populations[j]]) {
+            ret = MSP_ERR_DUPLICATE_POPULATION;
+            goto out;
+        }
+        population_used[populations[j]] = true;
+    }
+out:
+    msp_safe_free(population_used);
+    return ret;
+}
+
 /* Adds a population split event.
  * Note: we use the int32_t type here so we can be sure we're passing in
  * arrays of the correct type from numpy where we have to specify the size.
@@ -5885,36 +6001,10 @@ msp_add_population_split(
     int ret = 0;
     size_t j;
     demographic_event_t *de;
-    int N = (int) self->num_populations;
-    bool *population_used = calloc(self->num_populations, sizeof(*population_used));
 
-    if (population_used == NULL) {
-        ret = MSP_ERR_NO_MEMORY;
+    ret = msp_check_event_populations(self, num_derived, derived, ancestral);
+    if (ret != 0) {
         goto out;
-    }
-
-    if (num_derived >= MSP_MAX_SPLIT_POPULATIONS) {
-        ret = MSP_ERR_TOO_MANY_SPLIT_POPULATIONS;
-        goto out;
-    }
-    if (ancestral < 0 || ancestral >= N) {
-        ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
-        goto out;
-    }
-    for (j = 0; j < num_derived; j++) {
-        if (derived[j] < 0 || derived[j] >= N) {
-            ret = MSP_ERR_POPULATION_OUT_OF_BOUNDS;
-            goto out;
-        }
-        if (derived[j] == ancestral) {
-            ret = MSP_ERR_SOURCE_DEST_EQUAL;
-            goto out;
-        }
-        if (population_used[derived[j]]) {
-            ret = MSP_ERR_DUPLICATE_POPULATION;
-            goto out;
-        }
-        population_used[derived[j]] = true;
     }
 
     ret = msp_add_demographic_event(self, time, &de);
@@ -5930,7 +6020,117 @@ msp_add_population_split(
     de->print_state = msp_print_population_split;
     ret = 0;
 out:
-    msp_safe_free(population_used);
+    return ret;
+}
+
+/* Admixture */
+
+static int
+msp_admixture(msp_t *self, demographic_event_t *event)
+{
+    int ret = 0;
+    population_id_t *ancestral = event->params.admixture.ancestral;
+    double *proportion = event->params.admixture.proportion;
+    population_id_t derived = event->params.admixture.derived;
+    population_t *pop;
+    size_t num_ancestral = event->params.admixture.num_ancestral;
+    size_t index;
+    avl_tree_t *source;
+    avl_node_t *node, *next;
+    double u;
+    label_id_t label = 0; /* For now only support label 0 */
+
+    pop = &self->populations[derived];
+    if (pop->state != MSP_POP_STATE_ACTIVE) {
+        ret = MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE;
+        goto out;
+    }
+    for (index = 0; index < num_ancestral; index++) {
+        pop = &self->populations[ancestral[index]];
+        if (pop->state != MSP_POP_STATE_ACTIVE) {
+            ret = MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE;
+            goto out;
+        }
+    }
+
+    /*
+     * Move lineages from derived to ancestral[j] with probability
+     * proportion[j].
+     */
+    source = &self->populations[derived].ancestors[label];
+    node = source->head;
+    while (node != NULL) {
+        next = node->next;
+        u = gsl_rng_uniform(self->rng);
+        index = probability_list_select(u, num_ancestral, proportion);
+        ret = msp_move_individual(self, node, source, ancestral[index], label);
+        if (ret != 0) {
+            goto out;
+        }
+        node = next;
+    }
+    msp_deactivate_population(self, derived);
+out:
+    return ret;
+}
+
+static void
+msp_print_admixture(msp_t *MSP_UNUSED(self), demographic_event_t *event, FILE *out)
+{
+    size_t num_populations = event->params.admixture.num_ancestral;
+    size_t j;
+
+    fprintf(out, "%f\tadmixture: %d -> [", event->time, event->params.admixture.derived);
+    for (j = 0; j < num_populations; j++) {
+        fprintf(out, "(%d, p=%f)", event->params.admixture.ancestral[j],
+            event->params.admixture.proportion[j]);
+        if (j < num_populations - 1) {
+            fprintf(out, ", ");
+        }
+    }
+    fprintf(out, "]\n");
+}
+
+/* Adds an admixture event.
+ * Note: we use the int32_t type here so we can be sure we're passing in
+ * arrays of the correct type from numpy where we have to specify the size.
+ */
+int MSP_WARN_UNUSED
+msp_add_admixture(msp_t *self, double time, int derived, size_t num_ancestral,
+    int32_t *ancestral, double *proportion)
+{
+    int ret = 0;
+    size_t j;
+    demographic_event_t *de;
+
+    ret = msp_check_event_populations(self, num_ancestral, ancestral, derived);
+    if (ret != 0) {
+        goto out;
+    }
+
+    for (j = 0; j < num_ancestral; j++) {
+        /* We don't bother checking if the proportions sum to 1 as this
+         * is better done at higher levels, and the code is fairly robust
+         * to this type of misspecification. */
+        if (proportion[j] < 0 || proportion[j] > 1.0) {
+            ret = MSP_ERR_BAD_PROPORTION;
+            goto out;
+        }
+    }
+
+    ret = msp_add_demographic_event(self, time, &de);
+    if (ret != 0) {
+        goto out;
+    }
+    for (j = 0; j < num_ancestral; j++) {
+        de->params.admixture.ancestral[j] = ancestral[j];
+        de->params.admixture.proportion[j] = proportion[j];
+    }
+    de->params.admixture.derived = derived;
+    de->params.admixture.num_ancestral = num_ancestral;
+    de->change_state = msp_admixture;
+    de->print_state = msp_print_admixture;
+out:
     return ret;
 }
 

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -84,10 +84,18 @@ typedef struct {
     tsk_size_t value;
 } node_mapping_t;
 
+#define MSP_POP_STATE_INACTIVE 0
+#define MSP_POP_STATE_ACTIVE 1
+#define MSP_POP_STATE_PREVIOUSLY_ACTIVE 2
+
 typedef struct {
+    /* The starting size and time for the current epoch for this population. */
     double initial_size;
-    double growth_rate;
     double start_time;
+    double growth_rate;
+    /* The lifecycle state machine. States go strictly from
+     * inactive -> active -> previously_active */
+    int state;
     avl_tree_t *ancestors;
     tsk_size_t num_potential_destinations;
     tsk_id_t *potential_destinations;
@@ -277,13 +285,20 @@ typedef struct {
 /* Arbitrary limit, saves us having to put in complex malloc/free
  * logic in the demographic_events. Can easily be changed if
  * needs be. */
-#define MSP_MAX_SPLIT_POPULATIONS 100
+#define MSP_MAX_EVENT_POPULATIONS 100
 
 typedef struct {
-    population_id_t derived[MSP_MAX_SPLIT_POPULATIONS];
+    population_id_t derived[MSP_MAX_EVENT_POPULATIONS];
     population_id_t ancestral;
     size_t num_derived;
 } population_split_t;
+
+typedef struct {
+    population_id_t derived;
+    population_id_t ancestral[MSP_MAX_EVENT_POPULATIONS];
+    double proportion[MSP_MAX_EVENT_POPULATIONS];
+    size_t num_ancestral;
+} admixture_t;
 
 typedef struct {
     population_id_t population;
@@ -304,6 +319,7 @@ typedef struct demographic_event_t_t {
         instantaneous_bottleneck_t instantaneous_bottleneck;
         mass_migration_t mass_migration;
         population_split_t population_split;
+        admixture_t admixture;
         migration_rate_change_t migration_rate_change;
         population_parameters_change_t population_parameters_change;
     } params;
@@ -415,8 +431,8 @@ int msp_set_node_mapping_block_size(msp_t *self, size_t block_size);
 int msp_set_segment_block_size(msp_t *self, size_t block_size);
 int msp_set_avl_node_block_size(msp_t *self, size_t block_size);
 int msp_set_migration_matrix(msp_t *self, size_t size, double *migration_matrix);
-int msp_set_population_configuration(
-    msp_t *self, int population_id, double initial_size, double growth_rate);
+int msp_set_population_configuration(msp_t *self, int population_id, double initial_size,
+    double growth_rate, bool initially_active);
 
 int msp_add_population_parameters_change(
     msp_t *self, double time, int population_id, double size, double growth_rate);
@@ -426,6 +442,8 @@ int msp_add_mass_migration(
     msp_t *self, double time, int source, int dest, double proportion);
 int msp_add_population_split(
     msp_t *self, double time, size_t num_derived, int32_t *derived, int ancestral);
+int msp_add_admixture(msp_t *self, double time, int derived, size_t num_ancestral,
+    int32_t *ancestral, double *proportions);
 int msp_add_simple_bottleneck(
     msp_t *self, double time, int population_id, double intensity);
 int msp_add_instantaneous_bottleneck(
@@ -445,8 +463,8 @@ int msp_get_ancestors(msp_t *self, segment_t **ancestors);
 int msp_get_breakpoints(msp_t *self, size_t *breakpoints);
 int msp_get_migration_matrix(msp_t *self, double *migration_matrix);
 int msp_get_num_migration_events(msp_t *self, size_t *num_migration_events);
-int msp_get_population_configuration(
-    msp_t *self, size_t population_id, double *initial_size, double *growth_rate);
+int msp_get_population_configuration(msp_t *self, size_t population_id,
+    double *initial_size, double *growth_rate, int *state);
 int msp_compute_population_size(
     msp_t *self, size_t population_id, double time, double *pop_size);
 int msp_is_completed(msp_t *self);

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -37,9 +37,9 @@ test_single_locus_simulation(void)
 
     memset(samples, 0, n * sizeof(sample_t));
     ret = build_sim(&msp, &tables, rng, 1, 1, samples, n);
-    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_initialise(&msp);
-    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     /* For the single locus sim we should have exactly n - 1 events */
     for (j = 0; j < n - 2; j++) {
@@ -250,7 +250,7 @@ test_single_locus_historical_sample(void)
             ret = msp_set_simulation_model_dtwf(&msp);
             CU_ASSERT_EQUAL(ret, 0);
         }
-        ret = msp_set_population_configuration(&msp, 0, 100, 0);
+        ret = msp_set_population_configuration(&msp, 0, 100, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(&msp);
         CU_ASSERT_EQUAL(ret, 0);
@@ -309,7 +309,7 @@ test_single_locus_all_historical(void)
             ret = msp_set_simulation_model_dtwf(&msp);
             CU_ASSERT_EQUAL(ret, 0);
         }
-        ret = msp_set_population_configuration(&msp, 0, 100, 0);
+        ret = msp_set_population_configuration(&msp, 0, 100, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(&msp);
         CU_ASSERT_EQUAL(ret, 0);
@@ -417,7 +417,7 @@ test_single_locus_historical_sample_start_time(void)
                 ret = msp_set_simulation_model_dtwf(&msp);
                 CU_ASSERT_EQUAL(ret, 0);
             }
-            ret = msp_set_population_configuration(&msp, 0, 100, 0);
+            ret = msp_set_population_configuration(&msp, 0, 100, 0, true);
             CU_ASSERT_EQUAL(ret, 0);
             ret = msp_set_start_time(&msp, start_times[j]);
             CU_ASSERT_EQUAL(ret, 0);
@@ -480,7 +480,7 @@ test_single_locus_historical_sample_end_time(void)
             ret = msp_set_simulation_model_dtwf(&msp);
             CU_ASSERT_EQUAL(ret, 0);
         }
-        ret = msp_set_population_configuration(&msp, 0, 100, 0);
+        ret = msp_set_population_configuration(&msp, 0, 100, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(&msp);
         CU_ASSERT_EQUAL(ret, 0);
@@ -734,7 +734,7 @@ test_dtwf_multi_locus_simulation(void)
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 0.1), 0);
-    ret = msp_set_population_configuration(&msp, 0, n, 0);
+    ret = msp_set_population_configuration(&msp, 0, n, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_migration_matrix(&msp, 4, migration_matrix);
     CU_ASSERT_EQUAL(ret, 0);
@@ -763,7 +763,7 @@ test_dtwf_multi_locus_simulation(void)
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 0.1), 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, n, 0);
+    ret = msp_set_population_configuration(&msp, 0, n, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_migration_matrix(&msp, 4, migration_matrix);
     ret = msp_initialise(&msp);
@@ -806,7 +806,7 @@ test_dtwf_deterministic(void)
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_recombination_rate(&msp, 1);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_set_population_configuration(&msp, 0, n, 0);
+        ret = msp_set_population_configuration(&msp, 0, n, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_initialise(&msp);
         CU_ASSERT_EQUAL(ret, 0);
@@ -847,7 +847,7 @@ test_dtwf_simultaneous_historical_samples(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, 100, 0);
+    ret = msp_set_population_configuration(&msp, 0, 100, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
 
     ret = msp_initialise(&msp);
@@ -887,7 +887,7 @@ test_dtwf_low_recombination(void)
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 1e-9), 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, n, 0);
+    ret = msp_set_population_configuration(&msp, 0, n, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -927,9 +927,9 @@ test_dtwf_events_between_generations(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_recombination_rate(&msp, 1);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, 10, 0);
+    ret = msp_set_population_configuration(&msp, 0, 10, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 1, 10, 0);
+    ret = msp_set_population_configuration(&msp, 1, 10, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_migration_matrix(&msp, 4, migration_matrix);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1031,7 +1031,7 @@ test_dtwf_zero_pop_size(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, 0.4, 0);
+    ret = msp_set_population_configuration(&msp, 0, 0.4, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1047,7 +1047,7 @@ test_dtwf_zero_pop_size(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, 10, 100);
+    ret = msp_set_population_configuration(&msp, 0, 10, 100, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1076,9 +1076,9 @@ test_dtwf_migration_matrix_not_stochastic(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_simulation_model_dtwf(&msp);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 1, 10, 0);
+    ret = msp_set_population_configuration(&msp, 1, 10, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 2, 10, 0);
+    ret = msp_set_population_configuration(&msp, 2, 10, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_migration_matrix(&msp, 9, migration_matrix);
     CU_ASSERT_EQUAL(ret, 0);
@@ -1337,6 +1337,7 @@ test_mixed_hudson_dtwf(void)
     double N = 100;
     int model;
     double initial_size, growth_rate;
+    int state;
     const char *model_name;
     tsk_table_collection_t tables;
     tsk_treeseq_t ts;
@@ -1352,11 +1353,11 @@ test_mixed_hudson_dtwf(void)
     CU_ASSERT_EQUAL(ret, 0);
     /* Set the populations to 1, 2, and 3N. We don't simulate them,
      * but they should be equal at the end */
-    ret = msp_set_population_configuration(&msp, 0, N, 0);
+    ret = msp_set_population_configuration(&msp, 0, N, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 1, 2 * N, g);
+    ret = msp_set_population_configuration(&msp, 1, 2 * N, g, true);
     CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 2, 3 * N, 2 * g);
+    ret = msp_set_population_configuration(&msp, 2, 3 * N, 2 * g, true);
     CU_ASSERT_EQUAL(ret, 0);
 
     ret = msp_initialise(&msp);
@@ -1368,10 +1369,12 @@ test_mixed_hudson_dtwf(void)
         msp_verify(&msp, 0);
         /* Check that our populations and growth rates are still correct */
         for (k = 0; k < 3; k++) {
-            ret = msp_get_population_configuration(&msp, k, &initial_size, &growth_rate);
+            ret = msp_get_population_configuration(
+                &msp, k, &initial_size, &growth_rate, &state);
             CU_ASSERT_EQUAL(ret, 0);
             CU_ASSERT_EQUAL(initial_size, (k + 1) * N);
             CU_ASSERT_EQUAL_FATAL(growth_rate, k * g);
+            CU_ASSERT_EQUAL(state, MSP_POP_STATE_ACTIVE);
         }
         CU_ASSERT_FALSE(msp_is_completed(&msp));
         if (j % 2 == 1) {
@@ -1672,7 +1675,7 @@ test_multiple_mergers_growth_rate(void)
             msp_set_ploidy(&msp, k);
 
             /* Set to a nonzero growth_rate */
-            ret = msp_set_population_configuration(&msp, 0, 1, -0.01);
+            ret = msp_set_population_configuration(&msp, 0, 1, -0.01, true);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             ret = msp_initialise(&msp);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1756,6 +1759,7 @@ test_simulator_getters_setters(void)
     gsl_rng *rng = safe_rng_alloc();
     double migration_matrix[] = { 0, 0, 0, 0 };
     double matrix[4], growth_rate, initial_size;
+    int state;
     double Ne = 4;
     size_t migration_events[4];
     size_t breakpoints[m];
@@ -1800,9 +1804,9 @@ test_simulator_getters_setters(void)
     CU_ASSERT_EQUAL(msp_set_node_mapping_block_size(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_segment_block_size(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
     CU_ASSERT_EQUAL(msp_set_avl_node_block_size(&msp, 0), MSP_ERR_BAD_PARAM_VALUE);
-    CU_ASSERT_EQUAL(msp_set_population_configuration(&msp, -1, 0, 0),
+    CU_ASSERT_EQUAL(msp_set_population_configuration(&msp, -1, 0, 0, true),
         MSP_ERR_POPULATION_OUT_OF_BOUNDS);
-    CU_ASSERT_EQUAL(msp_set_population_configuration(&msp, 3, 0, 0),
+    CU_ASSERT_EQUAL(msp_set_population_configuration(&msp, 3, 0, 0, true),
         MSP_ERR_POPULATION_OUT_OF_BOUNDS);
     CU_ASSERT_EQUAL(msp_set_recombination_rate(&msp, -1), MSP_ERR_BAD_RATE_VALUE);
     CU_ASSERT_EQUAL(
@@ -1822,12 +1826,12 @@ test_simulator_getters_setters(void)
 
     ret = msp_set_simulation_model_hudson(&msp);
     CU_ASSERT_EQUAL(msp_get_model(&msp)->type, MSP_MODEL_HUDSON);
-    ret = msp_set_population_configuration(&msp, 0, Ne, 0);
+    ret = msp_set_population_configuration(&msp, 0, Ne, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
 
-    CU_ASSERT_EQUAL(msp_get_population_configuration(&msp, 3, NULL, NULL),
+    CU_ASSERT_EQUAL(msp_get_population_configuration(&msp, 3, NULL, NULL, NULL),
         MSP_ERR_POPULATION_OUT_OF_BOUNDS);
-    ret = msp_set_population_configuration(&msp, 0, 2 * Ne, 0.5);
+    ret = msp_set_population_configuration(&msp, 0, 2 * Ne, 0.5, true);
     CU_ASSERT_EQUAL(ret, 0);
 
     CU_ASSERT_EQUAL(
@@ -1853,10 +1857,11 @@ test_simulator_getters_setters(void)
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
 
-    ret = msp_get_population_configuration(&msp, 0, &initial_size, &growth_rate);
+    ret = msp_get_population_configuration(&msp, 0, &initial_size, &growth_rate, &state);
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL(initial_size, 2 * Ne);
     CU_ASSERT_EQUAL(growth_rate, 0.5);
+    CU_ASSERT_EQUAL(state, MSP_POP_STATE_ACTIVE);
 
     CU_ASSERT_TRUE(msp_get_store_migrations(&msp));
     CU_ASSERT_EQUAL(msp_get_num_avl_node_blocks(&msp), 1);
@@ -1904,7 +1909,8 @@ test_demographic_events(void)
     gsl_rng *rng = safe_rng_alloc();
     double migration_matrix[] = { 0, 0.1, 0.1, 0 };
     double last_time, time, pop_size;
-    int source[2];
+    int pops[2];
+    double probs[2] = { 0, 1 };
     tsk_table_collection_t tables;
     msp_t msp;
 
@@ -1921,12 +1927,12 @@ test_demographic_events(void)
         CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 1), 0);
 
         /* Negative population sizes are not allowed */
-        ret = msp_set_population_configuration(&msp, 0, -1, 0);
+        ret = msp_set_population_configuration(&msp, 0, -1, 0, true);
         CU_ASSERT_EQUAL(ret, MSP_ERR_BAD_PARAM_VALUE);
 
-        ret = msp_set_population_configuration(&msp, 0, 1, 0.001);
+        ret = msp_set_population_configuration(&msp, 0, 1, 0.001, true);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_set_population_configuration(&msp, 1, 2, 0.002);
+        ret = msp_set_population_configuration(&msp, 1, 2, 0.002, true);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_set_migration_matrix(&msp, 4, migration_matrix);
         CU_ASSERT_EQUAL(ret, 0);
@@ -1939,9 +1945,9 @@ test_demographic_events(void)
             CU_ASSERT_EQUAL(ret, 0);
         }
 
-        ret = msp_set_population_configuration(&msp, 0, 0, 0);
+        ret = msp_set_population_configuration(&msp, 0, 0, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_set_population_configuration(&msp, 0, 100, 0);
+        ret = msp_set_population_configuration(&msp, 0, 100, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
 
         CU_ASSERT_EQUAL(msp_add_mass_migration(&msp, 10, -1, 0, 1),
@@ -1953,20 +1959,51 @@ test_demographic_events(void)
         CU_ASSERT_EQUAL(
             msp_add_mass_migration(&msp, 10, 0, 1, -5), MSP_ERR_BAD_PROPORTION);
 
-        source[0] = 0;
-        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 100, source, 1),
-            MSP_ERR_TOO_MANY_SPLIT_POPULATIONS);
-        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 1, source, 2),
+        pops[0] = 0;
+        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 100, pops, 1),
+            MSP_ERR_TOO_MANY_EVENT_POPULATIONS);
+        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 1, pops, 2),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
         CU_ASSERT_EQUAL_FATAL(
-            msp_add_population_split(&msp, 10, 1, source, 0), MSP_ERR_SOURCE_DEST_EQUAL);
-        source[0] = -1;
-        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 1, source, 0),
+            msp_add_population_split(&msp, 10, 1, pops, 0), MSP_ERR_SOURCE_DEST_EQUAL);
+        pops[0] = -1;
+        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 1, pops, 0),
             MSP_ERR_POPULATION_OUT_OF_BOUNDS);
-        source[0] = 0;
-        source[1] = 0;
-        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 2, source, 1),
+        pops[0] = 0;
+        pops[1] = 0;
+        CU_ASSERT_EQUAL(msp_add_population_split(&msp, 10, 2, pops, 1),
             MSP_ERR_DUPLICATE_POPULATION);
+        CU_ASSERT_EQUAL(
+            msp_add_population_split(&msp, -1, 1, pops, 1), MSP_ERR_BAD_PARAM_VALUE);
+
+        pops[0] = 0;
+        CU_ASSERT_EQUAL(msp_add_admixture(&msp, 10.0, 1, 100, pops, probs),
+            MSP_ERR_TOO_MANY_EVENT_POPULATIONS);
+        CU_ASSERT_EQUAL(msp_add_admixture(&msp, 10.0, 2, 1, pops, probs),
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+        CU_ASSERT_EQUAL(msp_add_admixture(&msp, 10.0, -1, 1, pops, probs),
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+        CU_ASSERT_EQUAL_FATAL(
+            msp_add_admixture(&msp, 10, 0, 1, pops, probs), MSP_ERR_SOURCE_DEST_EQUAL);
+        pops[0] = -1;
+        CU_ASSERT_EQUAL_FATAL(msp_add_admixture(&msp, 10, 0, 1, pops, probs),
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+        pops[0] = 2;
+        CU_ASSERT_EQUAL_FATAL(msp_add_admixture(&msp, 10, 0, 1, pops, probs),
+            MSP_ERR_POPULATION_OUT_OF_BOUNDS);
+        pops[0] = 1;
+        pops[1] = 1;
+        CU_ASSERT_EQUAL_FATAL(msp_add_admixture(&msp, 10, 0, 2, pops, probs),
+            MSP_ERR_DUPLICATE_POPULATION);
+        probs[0] = -1;
+        CU_ASSERT_EQUAL_FATAL(
+            msp_add_admixture(&msp, 10, 0, 1, pops, probs), MSP_ERR_BAD_PROPORTION);
+        probs[0] = 1.1;
+        CU_ASSERT_EQUAL_FATAL(
+            msp_add_admixture(&msp, 10, 0, 1, pops, probs), MSP_ERR_BAD_PROPORTION);
+        probs[0] = 1;
+        CU_ASSERT_EQUAL_FATAL(
+            msp_add_admixture(&msp, -1, 0, 1, pops, probs), MSP_ERR_BAD_PARAM_VALUE);
 
         CU_ASSERT_EQUAL(msp_add_migration_rate_change(&msp, 10, -1, 0, 0.2),
             MSP_ERR_BAD_MIGRATION_MATRIX_INDEX);
@@ -2046,13 +2083,6 @@ test_demographic_events(void)
             ret = msp_add_mass_migration(&msp, 2.5, 1, 0, 0.6);
             CU_ASSERT_EQUAL(ret, 0);
         }
-
-        source[0] = 0;
-        /* Zero source populations have no effect */
-        ret = msp_add_population_split(&msp, 10.6, 0, source, 1);
-        CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_add_population_split(&msp, 10.6, 1, source, 1);
-        CU_ASSERT_EQUAL(ret, 0);
 
         CU_ASSERT_EQUAL(msp_add_mass_migration(&msp, 0.1, 0, 1, 0.5),
             MSP_ERR_UNSORTED_DEMOGRAPHIC_EVENTS);
@@ -2180,15 +2210,490 @@ test_population_split(void)
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
 
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_ACTIVE);
+
     ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
     CU_ASSERT_EQUAL(ret, 0);
     msp_verify(&msp, 0);
     msp_print_state(&msp, _devnull);
 
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_ACTIVE);
+
     ret = msp_free(&msp);
     CU_ASSERT_EQUAL(ret, 0);
     gsl_rng_free(rng);
     tsk_table_collection_free(&tables);
+}
+
+static void
+test_population_split_debug(void)
+{
+    int ret;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    tsk_table_collection_t tables;
+    int32_t derived[2];
+    double time;
+    /*
+            6
+          ┏━┻━┓
+          ┃   5
+          ┃ ┏━┻┓
+          ┃ ┃  4
+          ┃ ┃ ┏┻┓
+          0 1 2 3
+    */
+    ret = build_sim(&msp, &tables, rng, 1, 7, NULL, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    derived[0] = 2;
+    derived[1] = 3;
+    ret = msp_add_population_split(&msp, 4, 2, derived, 4);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 4, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    derived[0] = 1;
+    derived[1] = 4;
+    ret = msp_add_population_split(&msp, 5, 2, derived, 5);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 5, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    derived[0] = 0;
+    derived[1] = 5;
+    ret = msp_add_population_split(&msp, 6, 2, derived, 6);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 6, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_INACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[5].state, MSP_POP_STATE_INACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[6].state, MSP_POP_STATE_INACTIVE);
+
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 4);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_INACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[5].state, MSP_POP_STATE_INACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[6].state, MSP_POP_STATE_INACTIVE);
+
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 5);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[5].state, MSP_POP_STATE_INACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[6].state, MSP_POP_STATE_INACTIVE);
+
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 6);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[5].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[6].state, MSP_POP_STATE_INACTIVE);
+
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_TRUE(isinf(time));
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[5].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[6].state, MSP_POP_STATE_ACTIVE);
+
+    ret = msp_free(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_population_split_replicates(void)
+{
+    int ret;
+    int j;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    tsk_table_collection_t tables;
+    int32_t derived[] = { 0, 1 };
+    sample_t samples[]
+        = { { .time = 0, .population = 0 }, { .time = 0, .population = 1 } };
+    /*
+        2
+       ┏┻┓
+       0 1
+    */
+    /* Nominal case. */
+    ret = build_sim(&msp, &tables, rng, 1, 3, samples, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 2, 2, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 2, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    for (j = 0; j < 10; j++) {
+        ret = msp_reset(&msp);
+        CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+        CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+        CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_INACTIVE);
+
+        ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+        CU_ASSERT_EQUAL(ret, 0);
+        CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+        CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+        CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    }
+
+    ret = msp_free(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_inactive_populations(void)
+{
+    int ret;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    tsk_table_collection_t tables;
+    int32_t derived[] = { 0, 1 };
+    sample_t samples[]
+        = { { .time = 0, .population = 0 }, { .time = 0, .population = 1 } };
+    /*
+        2
+       ┏┻┓
+       0 1
+    */
+    /* Nominal case. */
+    ret = build_sim(&msp, &tables, rng, 1, 3, samples, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 2, 2, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 2, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, 0);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* Sample from inactive at time zero. */
+    samples[0].population = 2;
+    ret = build_sim(&msp, &tables, rng, 1, 3, samples, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 2, 2, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 2, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_INACTIVE_SAMPLE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* Sample from inactive as event. */
+    samples[0].population = 2;
+    samples[0].time = 1;
+    ret = build_sim(&msp, &tables, rng, 1, 3, samples, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 2, 2, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 2, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_INACTIVE_SAMPLE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* Migrate into inactive via mass migration */
+    samples[0].population = 0;
+    samples[0].time = 0;
+    ret = build_sim(&msp, &tables, rng, 1, 3, samples, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 2, 2, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_mass_migration(&msp, 2.0001, 2, 1, 1.0);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_INACTIVE_MOVE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* Migrate into inactive via continuous migration */
+    ret = build_sim(&msp, &tables, rng, 1, 3, samples, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 2, 2, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_migration_rate_change(&msp, 2.0001, 2, 1, 10.0);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, MSP_ERR_POPULATION_INACTIVE_MOVE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    gsl_rng_free(rng);
+}
+
+static void
+test_admixture(void)
+{
+    int ret;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    sample_t samples[] = {
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+    };
+    int admix_source[] = { 0, 1, 2 };
+    double probs[] = { 0.25, 0.25, 0.5 };
+    tsk_table_collection_t tables;
+
+    /* Build a 5 pop model, where 3 is admixed from 0, 1, 2, and then
+     * 0, 1, 2 all split from 4. */
+    ret = build_sim(&msp, &tables, rng, 1, 5, samples, 6);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_admixture(&msp, 0.5, 3, 3, admix_source, probs);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_population_split(&msp, 1.5, 3, admix_source, 4);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 4, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_INACTIVE);
+
+    ret = msp_run(&msp, 0.51, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, MSP_EXIT_MAX_TIME);
+    msp_verify(&msp, 0);
+    msp_print_state(&msp, _devnull);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_INACTIVE);
+
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, 0);
+    msp_verify(&msp, 0);
+    msp_print_state(&msp, _devnull);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[4].state, MSP_POP_STATE_ACTIVE);
+
+    ret = msp_free(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_admixture_excess_probability(void)
+{
+    int ret;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    sample_t samples[] = {
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 3 },
+        { .time = 0, .population = 1 },
+    };
+    int admix_source[] = { 0, 1, 2 };
+    /* Put all the weight on population 1, but don't make the total sum = 1 */
+    double probs[] = { 0.00001, 1, 0.5 };
+    tsk_table_collection_t tables;
+
+    /* Build a 4 pop model, where 3 is admixed from 0, 1, 2. Since all
+     * the probability is from pop 1, the lineages should all migrate there
+     * and coalesce */
+    ret = build_sim(&msp, &tables, rng, 1, 4, samples, 6);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_add_admixture(&msp, 0.5, 3, 3, admix_source, probs);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_ACTIVE);
+
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, 0);
+    msp_verify(&msp, 0);
+    msp_print_state(&msp, _devnull);
+
+    CU_ASSERT_EQUAL(msp.populations[0].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[1].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[2].state, MSP_POP_STATE_ACTIVE);
+    CU_ASSERT_EQUAL(msp.populations[3].state, MSP_POP_STATE_PREVIOUSLY_ACTIVE);
+
+    ret = msp_free(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    tsk_table_collection_free(&tables);
+}
+
+static void
+test_population_state_machine_errors(void)
+{
+    int ret;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    tsk_table_collection_t tables;
+    double time;
+    double proba[] = { 1 };
+    int32_t derived[] = { 0 };
+    int32_t ancestral[] = { 0 };
+
+    /* PREVIOUSLY_ACTIVE -> ACTIVE */
+    ret = build_sim(&msp, &tables, rng, 1, 3, NULL, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 0 -> 1 */
+    derived[0] = 0;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 1);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 1 -> 2 */
+    derived[0] = 1;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 2);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 2 -> 1 */
+    derived[0] = 2;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 1);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 2);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_POPULATION_PREVIOUSLY_ACTIVE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* Inactive population as admixture derived.*/
+    ret = build_sim(&msp, &tables, rng, 1, 2, NULL, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 0 -> 1 */
+    ancestral[0] = 1;
+    ret = msp_add_admixture(&msp, 2, 0, 1, ancestral, proba);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 1 -> 0 */
+    derived[0] = 1;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 0, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 2);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* Inactive population as admix ancestral.*/
+    ret = build_sim(&msp, &tables, rng, 1, 2, NULL, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 1 -> 0 */
+    ancestral[0] = 0;
+    ret = msp_add_admixture(&msp, 2, 1, 1, ancestral, proba);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 1 -> 0 */
+    derived[0] = 1;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 0, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 2);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    /* derived not active in split */
+    ret = build_sim(&msp, &tables, rng, 1, 2, NULL, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 0 -> 1 */
+    derived[0] = 0;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 1);
+    CU_ASSERT_EQUAL(ret, 0);
+    /* 1 -> 0 */
+    derived[0] = 1;
+    ret = msp_add_population_split(&msp, 2, 1, derived, 0);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 0, 1, 0, false);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(time, 2);
+    ret = msp_debug_demography(&msp, &time);
+    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_SPLIT_DERIVED_NOT_ACTIVE);
+    msp_free(&msp);
+    tsk_table_collection_free(&tables);
+
+    gsl_rng_free(rng);
 }
 
 static void
@@ -2271,7 +2776,7 @@ test_floating_point_extremes(void)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, DBL_MAX), 0);
     CU_ASSERT_EQUAL_FATAL(msp_set_discrete_genome(&msp, false), 0);
-    ret = msp_set_population_configuration(&msp, 0, DBL_MAX, 0);
+    ret = msp_set_population_configuration(&msp, 0, DBL_MAX, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -2478,7 +2983,7 @@ test_large_bottleneck_simulation(void)
             &msp, bottlenecks[j].time, 0, bottlenecks[j].parameter);
         CU_ASSERT_EQUAL(ret, 0);
     }
-    ret = msp_set_population_configuration(&msp, 0, 0.25, 0);
+    ret = msp_set_population_configuration(&msp, 0, 0.25, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
@@ -2537,7 +3042,7 @@ verify_simulate_from(int model, rate_map_t *recomb_map,
         ret = msp_set_simulation_model_dtwf(&msp);
         CU_ASSERT_EQUAL(ret, 0);
     }
-    ret = msp_set_population_configuration(&msp, 0, 10, 0);
+    ret = msp_set_population_configuration(&msp, 0, 10, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
     /* TODO add dirac and other models */
     ret = msp_initialise(&msp);
@@ -2925,11 +3430,11 @@ check_zero_population_size(
             CU_ASSERT_EQUAL(ret, 0);
         }
 
-        ret = msp_set_population_configuration(&msp, 0, 0, 0);
+        ret = msp_set_population_configuration(&msp, 0, 0, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_set_population_configuration(&msp, 1, N, 0);
+        ret = msp_set_population_configuration(&msp, 1, N, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
-        ret = msp_set_population_configuration(&msp, 2, N, 0);
+        ret = msp_set_population_configuration(&msp, 2, N, 0, true);
         CU_ASSERT_EQUAL(ret, 0);
         ret = msp_add_mass_migration(&msp, T, 1, 0, 1.0);
         CU_ASSERT_EQUAL(ret, 0);
@@ -3032,6 +3537,12 @@ main(int argc, char **argv)
         { "test_demographic_events", test_demographic_events },
         { "test_demographic_events_start_time", test_demographic_events_start_time },
         { "test_population_split", test_population_split },
+        { "test_population_split_debug", test_population_split_debug },
+        { "test_population_split_replicates", test_population_split_replicates },
+        { "test_inactive_populations", test_inactive_populations },
+        { "test_admixture", test_admixture },
+        { "test_admixture_excess_probability", test_admixture_excess_probability },
+        { "test_population_state_machine_errors", test_population_state_machine_errors },
         { "test_census_event", test_census_event },
         { "test_time_travel_error", test_time_travel_error },
         { "test_floating_point_extremes", test_floating_point_extremes },

--- a/lib/util.c
+++ b/lib/util.c
@@ -275,13 +275,31 @@ msp_strerror_internal(int err)
         case MSP_ERR_DTWF_DIPLOID_ONLY:
             ret = "The DTWF model only supports ploidy = 2";
             break;
-        case MSP_ERR_TOO_MANY_SPLIT_POPULATIONS:
-            ret = "Cannot have more than 100 populations splitting at once. "
+        case MSP_ERR_TOO_MANY_EVENT_POPULATIONS:
+            ret = "Cannot have more than 100 populations in one event. "
                   "If this is something that you need to do, please open an issue "
                   "on GitHub";
             break;
         case MSP_ERR_DUPLICATE_POPULATION:
             ret = "Population IDs must be unique";
+            break;
+        case MSP_ERR_POPULATION_INACTIVE_MOVE:
+            ret = "Attempt to move a lineage into an inactive population";
+            break;
+        case MSP_ERR_POPULATION_INACTIVE_SAMPLE:
+            ret = "Attempt to sample a lineage from an inactive population";
+            break;
+        case MSP_ERR_POPULATION_PREVIOUSLY_ACTIVE:
+            ret = "Attempt to set a previously active population to active";
+            break;
+        case MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE:
+            ret = "All ancestral populations in admixture must already be active";
+            break;
+        case MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE:
+            ret = "The derived population in an admixture must be active";
+            break;
+        case MSP_ERR_SPLIT_DERIVED_NOT_ACTIVE:
+            ret = "The derived population in a population split must be active";
             break;
         default:
             ret = "Error occurred generating error string. Please file a bug "

--- a/lib/util.h
+++ b/lib/util.h
@@ -114,8 +114,14 @@
 #define MSP_ERR_UNKNOWN_TIME_NOT_SUPPORTED                          -70
 #define MSP_ERR_DTWF_DIPLOID_ONLY                                   -71
 #define MSP_ERR_BAD_ANCESTRAL_MUTATION                              -72
-#define MSP_ERR_TOO_MANY_SPLIT_POPULATIONS                          -73
+#define MSP_ERR_TOO_MANY_EVENT_POPULATIONS                          -73
 #define MSP_ERR_DUPLICATE_POPULATION                                -74
+#define MSP_ERR_POPULATION_INACTIVE_MOVE                            -75
+#define MSP_ERR_POPULATION_INACTIVE_SAMPLE                          -76
+#define MSP_ERR_POPULATION_PREVIOUSLY_ACTIVE                        -77
+#define MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE                          -78
+#define MSP_ERR_SPLIT_DERIVED_NOT_ACTIVE                            -79
+#define MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE                            -80
 
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -514,7 +514,7 @@ def create_simulation_runner(parser, arg_list):
         for row in migration_matrix:
             row.append(0)
         migration_matrix.append([0 for j in range(num_populations)])
-        demography.add_population(msprime.Population(initial_size=1))
+        demography.add_population(initial_size=1)
         num_samples.append(0)
 
     # Add the demographic events
@@ -619,9 +619,9 @@ def create_simulation_runner(parser, arg_list):
     time_sorted = sorted(demographic_events, key=lambda x: x[1].time)
     if demographic_events != time_sorted:
         parser.error("Demographic events must be supplied in non-decreasing time order")
-
-    demography.events = [event for _, event in demographic_events]
-    demography.migration_matrix = migration_matrix
+    for _, event in demographic_events:
+        demography.add_event(event)
+    demography.migration_matrix[:] = migration_matrix
 
     # Adjust the population sizes so that the timescales agree. In principle
     # we could correct this with a ploidy value=0.5, but what we have here
@@ -630,9 +630,8 @@ def create_simulation_runner(parser, arg_list):
         if isinstance(msp_event, msprime.PopulationParametersChange):
             if msp_event.initial_size is not None:
                 msp_event.initial_size /= 2
-    for j, pop in enumerate(demography.populations):
+    for pop in demography.populations:
         pop.initial_size /= 2
-        pop.name = f"pop_{j}"
 
     runner = SimulationRunner(
         num_samples,

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import collections
 import copy
 import dataclasses
+import enum
 import inspect
 import itertools
 import logging
@@ -33,6 +34,7 @@ import textwrap
 import warnings
 from typing import Any
 from typing import ClassVar
+from typing import Dict
 from typing import List
 from typing import Union
 
@@ -98,12 +100,13 @@ class Population:
     :vartype id: int
     """
 
-    initial_size: float
+    initial_size: float = 0.0
     growth_rate: float = 0.0
     name: Union[str, None] = None
     description: str = ""
     extra_metadata: dict = dataclasses.field(default_factory=dict)
-    sampling_time: float = 0
+    sampling_time: Union[float, None] = None
+    initially_active: Union[bool, None] = None
 
     # Keeping this as something we can init because this stops us
     # doing things like round-tripping through repr. The warning
@@ -112,32 +115,6 @@ class Population:
 
     def asdict(self):
         return dataclasses.asdict(self)
-
-    @staticmethod
-    def from_old_style(pop_config, Ne=1):
-        """
-        Returns a Population object derived from the specified old-style
-        PopulationConfiguration. The Ne value is used as the ``initial_size``
-        if this is not provided in the PopulationConfiguration.
-
-        :meta private:
-        """
-        initial_size = (
-            Ne if pop_config.initial_size is None else pop_config.initial_size
-        )
-        population = Population(
-            initial_size=initial_size,
-            growth_rate=pop_config.growth_rate,
-        )
-        metadata = pop_config.metadata
-        if metadata is not None and isinstance(metadata, collections.abc.Mapping):
-            metadata = metadata.copy()
-            if "name" in metadata:
-                population.name = metadata.pop("name")
-            if "description" in metadata:
-                population.description = metadata.pop("description")
-        population.extra_metadata = metadata
-        return population
 
     def validate(self):
         # TODO more checks
@@ -169,10 +146,6 @@ class Demography:
             N = self.num_populations
             self.migration_matrix = np.zeros((N, N))
 
-        # Sort demographic events by time. Sorting is stable so the relative
-        # order of events at the same time will be preserved.
-        self.events.sort(key=lambda de: de.time)
-
         # People might get cryptic errors from passing in copies of the same
         # population, so check for it.
         if len({id(pop) for pop in self.populations}) != len(self.populations):
@@ -190,29 +163,67 @@ class Demography:
                 population.name = f"pop_{j}"
         self._validate_populations()
 
-    def add_population(self, population: Population):
+    def add_population(
+        self,
+        *,
+        initial_size=None,
+        growth_rate=None,
+        name=None,
+        description=None,
+        extra_metadata=None,
+        sampling_time=None,
+        initially_active=None,
+    ) -> Population:
         """
-        Adds the specified :class:`.Population` to this Demography,
-        setting default attributes appropriately. Note that this method
-        uses the input object and will update its state.
-
-        :param Population population: The Population object to insert.
+        TODO document
         """
-        if not isinstance(population, Population):
-            raise TypeError("Input must be an instance of Population")
-        if population.id is not None:
-            raise ValueError(
-                "Population ID should not be set before adding to a demography"
-            )
         N = self.num_populations
+        population = Population()
         population.id = N
-        if population.name is None:
-            population.name = f"pop_{population.id}"
+        population.growth_rate = 0 if growth_rate is None else growth_rate
+        population.initial_size = 1 if initial_size is None else initial_size
+        population.name = f"pop_{population.id}" if name is None else name
+        population.description = "" if description is None else description
+        population.extra_metadata = {} if extra_metadata is None else extra_metadata
+        population.sampling_time = sampling_time
+        population.initially_active = initially_active
         self.populations.append(population)
         M = self.migration_matrix
         self.migration_matrix = np.zeros((N + 1, N + 1))
         self.migration_matrix[:N, :N] = M
         self._validate_populations()
+        return population
+
+    def _add_population_from_old_style(
+        self, pop_config: PopulationConfiguration, name: Union[str, None] = None
+    ) -> Population:
+        population = self.add_population(
+            name=name,
+            initial_size=pop_config.initial_size,
+            growth_rate=pop_config.growth_rate,
+        )
+        metadata = pop_config.metadata
+        if metadata is not None and isinstance(metadata, collections.abc.Mapping):
+            metadata = metadata.copy()
+            if "name" in metadata:
+                population.name = metadata.pop("name")
+                if name is not None and name != population.name:
+                    # Maybe this should be a warning, or just ignored entirely?
+                    raise ValueError(
+                        "Population name already set in old-style metadata and doesn't "
+                        "match supplied name"
+                    )
+            if "description" in metadata:
+                population.description = metadata.pop("description")
+        population.extra_metadata = metadata
+        return population
+
+    def add_event(self, event: DemographicEvent) -> DemographicEvent:
+        if not isinstance(event, DemographicEvent):
+            raise TypeError("Events must be instances of DemographicEvent")
+        event.demography = self
+        self.events.append(event)
+        return event
 
     def set_migration_rate(
         self, source: Union[str, int], dest: Union[str, int], rate: float
@@ -243,7 +254,9 @@ class Demography:
         self.migration_matrix[source, dest] = rate  # type: ignore
 
     def set_symmetric_migration_rate(
-        self, populations: List[Union[str, int]], rate: float
+        self,
+        populations: List[Union[str, int]],
+        rate: float,
     ):
         """
         Sets the symmetric migration rate between all pairs of populations in
@@ -269,6 +282,222 @@ class Demography:
             self.migration_matrix[pop_j, pop_k] = rate  # type: ignore
             self.migration_matrix[pop_k, pop_j] = rate  # type: ignore
 
+    # Demographic events.
+
+    def add_population_split(
+        self, time: float, *, derived: List[Union[str, int]], ancestral: Union[str, int]
+    ) -> PopulationSplit:
+        """
+        Adds a population split event at the specified time. In a population
+        split event all lineages from the (more recent) derived populations
+        move to the (more ancient) ancestral population. Forwards in time,
+        this corresponds to the ancestral population splitting into the
+        derived populations.
+
+        .. todo:: Add some links here, to the documentation and to the
+            other types of events we might want to support.
+
+        In addition to moving lineages from the derived population(s) into the
+        ancestral population, a population split has the following additional
+        effects:
+
+        - All migration rates to and from the derived populations are set to 0.
+        - Population sizes and growth rates for the derived populations are set
+          to 0.
+        - The ``sampling_time`` of the ``ancestral`` :class:`.Population` is set
+          to the time of this event, **if** the ``sampling_time`` for the
+          ancestral population has not already been set.
+
+        :param float time: The time at which this event occurs in generations.
+        :param list(str, int) derived: The derived populations.
+        :param str, int ancestral: The ancestral population.
+        """
+        pop = self[ancestral]
+        if pop.initially_active is None:
+            pop.initially_active = False
+            if pop.sampling_time is None:
+                pop.sampling_time = time
+        return self.add_event(
+            PopulationSplit(time=time, derived=derived, ancestral=ancestral)
+        )
+
+    def add_admixture(
+        self,
+        time: float,
+        *,
+        derived: Union[str, int],
+        ancestral: List[Union[str, int]],
+        proportions: List[float],
+    ) -> Admixture:
+        """
+        Adds an admixture event at the specified time. In an admixture
+        event all lineages from a (more recent) ``derived`` population
+        move to a list of (more ancient) ``ancestral`` populations according
+        to a list of ``proportions``, such that a given lineage has a
+        probability ``proportions[j]`` of being moved to the population
+        ``ancestral[j]``. This movement of lineages backwards in time
+        corresponds to the initial state of the admixed derived population
+        the specified ``time`` being composed of individuals from the
+        specified ``ancestral`` populations in the specified ``proportions``.
+
+        .. todo:: Add some links here, to the documentation and to the
+            other types of events we might want to support.
+
+        In addition to moving lineages from the derived population into the
+        ancestral population(s), an admixture has the following additional
+        effects:
+
+        - All migration rates to and from the derived population are set to 0.
+        - Population sizes and growth rates for the derived population are set
+          to 0, and the poulation is marked as inactive.
+
+        :param float time: The time at which this event occurs in generations.
+        :param str, int derived: The derived population.
+        :param list(str, int) ancestral: The ancestral populations.
+        :param list(float) proportions: The proportion of the derived population
+            from each of the ancestral populations at the time of the event.
+        """
+        # Useful feature here might be to support taking n - 1 proportion values
+        # and computing 1 - sum for the last value. Could be tedious for users to
+        # do this manually.
+        if not math.isclose(sum(proportions), 1.0):
+            raise ValueError("Sum of the admixture proportions must be approximately 1")
+        return self.add_event(
+            Admixture(
+                time=time, derived=derived, ancestral=ancestral, proportions=proportions
+            )
+        )
+
+    def add_mass_migration(self, time, *, source, dest, proportion):
+        # TODO document. Not clear whether we document this with a warning
+        # or we just leave it as population split, etc.
+        return self.add_event(MassMigration(time, source, dest, proportion))
+
+    def add_migration_rate_change(
+        self,
+        time: float,
+        *,
+        rate: float,
+        source: Union[int, str, None] = None,
+        dest: Union[int, str, None] = None,
+    ) -> MigrationRateChange:
+        """
+        Changes the rate of migration from one deme to another to a new value at a
+        specific time. Migration rates are specified in terms of the rate at which
+        lineages move from population ``source`` to ``dest`` during the progress of
+        the simulation.
+
+        .. warning::
+            Note that ``source`` and ``dest`` are from the perspective of the
+            coalescent process, i.e. **backwards in time**; please see the
+            :ref:`sec_demography_migration` section for more details on the
+            interpretation of this migration model.
+
+        By default, ``source=None`` and ``dest=None``, which results in all
+        non-diagonal elements of the migration matrix being changed to the new
+        rate. If ``source`` and ``dest`` are specified, they must refer to valid
+        populations (either integer IDs or string names).
+
+        :param float time: The time at which this event occurs in generations.
+        :param float rate: The new per-generation migration rate.
+        :param str, int source: The ID of the source population.
+        :param str, int dest: The ID of the destination population.
+        :param int source: The source population ID.
+        """
+        source = -1 if source is None else source
+        dest = -1 if dest is None else dest
+        return self.add_event(
+            MigrationRateChange(time=time, source=source, dest=dest, rate=rate)
+        )
+
+    def add_symmetric_migration_rate_change(
+        self, time: float, populations: List[Union[str, int]], rate: float
+    ) -> SymmetricMigrationRateChange:
+        """
+        Sets the symmetric migration rate between all pairs of populations in
+        the specified list to the specified value. For a given pair of population
+        IDs ``j`` and ``k``, this sets ``migration_matrix[j, k] = rate``
+        and ``migration_matrix[k, j] = rate``.
+
+        Populations may be specified either by their integer IDs or by
+        their string names.
+
+        :param float time: The time at which this event occurs in generations.
+        :param list populations: An sequence of population identifiers (integer
+            IDs or string names).
+        :param float rate: The new migration rate.
+        """
+        return self.add_event(
+            SymmetricMigrationRateChange(time=time, populations=populations, rate=rate)
+        )
+
+    def add_population_parameters_change(
+        self,
+        time: float,
+        *,
+        initial_size: Union[float, None] = None,
+        growth_rate: Union[float, None] = None,
+        population: Union[int, None] = None,
+    ) -> PopulationParametersChange:
+        """
+        Changes the size parameters of a population (or all populations)
+        at a given time.
+
+        :param float time: The length of time ago at which this event
+            occurred.
+        :param float initial_size: The absolute size of the population
+            at the beginning of the time slice starting at ``time``. If None,
+            the initial_size of the population is computed according to
+            the initial population size and growth rate over the preceding
+            time slice.
+        :param float growth_rate: The new per-generation growth rate. If None,
+            the growth rate is not changed. Defaults to None.
+        :param str, int population: The ID of the population affected. If
+            ``population`` is None, the changes affect all populations
+            simultaneously.
+        """
+        event = PopulationParametersChange(
+            time,
+            initial_size=initial_size,
+            growth_rate=growth_rate,
+            population=population,
+        )
+        return self.add_event(event)
+
+    def add_simple_bottleneck(
+        self,
+        time: float,
+        population: Union[int, str],
+        proportion: Union[float, None] = None,
+    ) -> SimpleBottleneck:
+        proportion = 1.0 if proportion is None else proportion
+        return self.add_event(
+            SimpleBottleneck(time=time, population=population, proportion=proportion)
+        )
+
+    def add_instantaneous_bottleneck(
+        self, time: float, *, population: Union[str, int], strength: float
+    ) -> InstantaneousBottleneck:
+        return self.add_event(
+            InstantaneousBottleneck(time=time, population=population, strength=strength)
+        )
+
+    def add_census(self, time: float) -> CensusEvent:
+        """
+        Add a "census" event at the specified time. In a census we add a node
+        to each branch of every tree, thus recording the population that each
+        lineage is in at the specified time.
+
+        This may be used to record all ancestral haplotypes present at that
+        time, and to extract other information related to these haplotypes: for
+        instance to trace the local ancestry of a sample back to a set of
+        contemporaneous ancestors, or to assess whether a subset of samples has
+        coalesced more recently than the census time.
+
+        See :ref:`sec_ancestry_census_events` for more details.
+        """
+        return self.add_event(CensusEvent(time))
+
     def _populations_table(self):
         col_titles = [
             "id",
@@ -276,17 +505,17 @@ class Demography:
             "description",
             "initial_size",
             "growth_rate",
+            "sampling_time",
             "extra_metadata",
         ]
-        data = []
-        for j, pop in enumerate(self.populations):
-            row = [str(j)] + [f"{getattr(pop, attr)}" for attr in col_titles[1:]]
-            data.append(row)
+        data = [
+            [f"{getattr(pop, attr)}" for attr in col_titles] for pop in self.populations
+        ]
         return col_titles, data
 
     def _populations_text(self):
         col_titles, data = self._populations_table()
-        alignments = ["^", "<", "<", "<", "^", "<"]
+        alignments = ["^", "<", "<", "<", "^", ">", "<"]
         data = [
             [
                 [item.as_text() if isinstance(item, core.TableEntry) else item]
@@ -371,18 +600,20 @@ class Demography:
         return core.html_table(title, col_titles, data)
 
     def _repr_html_(self):
+        resolved = self.validate()
         return (
             "<p>"
-            + self._populations_html()
-            + self._migration_matrix_html()
-            + self._events_html(self.events)
+            + resolved._populations_html()
+            + resolved._migration_matrix_html()
+            + resolved._events_html(self.events)
             + "</p>"
         )
 
     def __str__(self):
-        populations = self._populations_text()
-        migration_matrix = self._migration_matrix_text()
-        events = self._events_text(self.events)
+        resolved = self.validate()
+        populations = resolved._populations_text()
+        migration_matrix = resolved._migration_matrix_text()
+        events = resolved._events_text(self.events)
 
         def indent(table):
             lines = table.splitlines()
@@ -419,6 +650,16 @@ class Demography:
             return self.populations[identifier]
         raise TypeError("Keys must be either string population names or integer IDs")
 
+    def __contains__(self, identifier):
+        """
+        Support "in" lookups, i.e. ``if "YRI" in demography``.
+        """
+        try:
+            self.__getitem__(identifier)
+        except KeyError:
+            return False
+        return True
+
     @property
     def num_populations(self):
         return len(self.populations)
@@ -444,7 +685,8 @@ class Demography:
     def validate(self):
         """
         Checks the demography looks sensible and raises errors/warnings
-        appropriately.
+        appropriately, and return a copy in which all default values have
+        been appropriately resolved.
         """
         self._validate_populations()
         migration_matrix = np.array(self.migration_matrix)
@@ -458,13 +700,32 @@ class Demography:
                 "valid matrix for a 3 population system is "
                 "[[0, 1, 1], [1, 0, 1], [1, 1, 0]]"
             )
-
+        last_event = None
         for event in self.events:
             if not isinstance(event, DemographicEvent):
                 raise TypeError(
                     "Demographic events must be a list of DemographicEvent "
                     "instances sorted in non-decreasing order of time."
                 )
+            if last_event is not None:
+                if last_event.time > event.time:
+                    raise ValueError(
+                        "Events must be time-sorted. Please use demography.sort_events()"
+                        "if you add events out of order."
+                    )
+            last_event = event
+        resolved = copy.deepcopy(self)
+        for population in resolved.populations:
+            if population.sampling_time is None:
+                population.sampling_time = 0
+            if population.initially_active is None:
+                population.initially_active = True
+        return resolved
+
+    def sort_events(self):
+        # Sort demographic events by time. Sorting is stable so the relative
+        # order of events at the same time will be preserved.
+        self.events.sort(key=lambda de: de.time)
 
     def insert_populations(self, tables):
         """
@@ -510,7 +771,11 @@ class Demography:
             tables.populations.add_row(metadata=metadata)
 
     def asdict(self):
-        return dataclasses.asdict(self)
+        return {
+            "populations": [pop.asdict() for pop in self.populations],
+            "events": [event.asdict() for event in self.events],
+            "migration_matrix": self.migration_matrix.tolist(),
+        }
 
     def debug(self):
         """
@@ -547,6 +812,225 @@ class Demography:
         assert self.num_events == other.num_events
         for e1, e2 in zip(self.events, other.events):
             assert e1 == e2, f"{e1} ≠ {e2}"
+
+    def is_equivalent(self, other: Demography, rel_tol=None, abs_tol=None):
+        """
+        Compares this demography with the other and return True if they are
+        equivalent up to the specified numerical tolerances. Two demographies
+        are equivalent if, they have the same set of epochs defined by demographic
+        events, and for each epoch:
+
+        - The population's ``initial_size``, ``growth_rate`` and ``active``
+          values are equal in all populations.
+        - The migration matrices are equal
+        - The same sequence of lineage movements through population splits, etc.
+
+        All numerical comparisons are performed using :func:`py:math.isclose`.
+
+        :param Demography other: The other demography to compare against.
+        :param float rel_tol: The relative tolerance used by math.isclose.
+        :param float abs_tol: The relative tolerance used by math.isclose.
+        :return: True if this demography and other are equivalent up to numerical
+            tolerances.
+        :rtype bool: bool
+        """
+        try:
+            self.assert_equivalent(other, rel_tol=rel_tol, abs_tol=abs_tol)
+            return True
+        except AssertionError:
+            return False
+
+    def assert_equivalent(
+        self,
+        other: Demography,
+        rel_tol: Union[None, float] = None,
+        abs_tol: Union[None, float] = None,
+    ):
+        # Same defaults as math.isclose
+        rel_tol = 1e-9 if rel_tol is None else rel_tol
+        abs_tol = 0 if abs_tol is None else abs_tol
+        assert isinstance(other, Demography)
+        self_dbg = self.debug()
+        other_dbg = other.debug()
+        if self.num_populations != other.num_populations:
+            raise AssertionError(
+                "Number of populations not equal: "
+                f"{self.num_populations} ≠ {other.num_populations}"
+            )
+        # Compare the population attributes.
+        # NB use the *resolved* versions from the debug objects
+        for self_pop, other_pop in zip(
+            self_dbg.demography.populations, other_dbg.demography.populations
+        ):
+            if self_pop.name != other_pop.name:
+                raise AssertionError(
+                    f"Population names differ: {self_pop.name} ≠ {other_pop.name}"
+                )
+            self_st = 0 if self_pop.sampling_time is None else self_pop.sampling_time
+            other_st = 0 if other_pop.sampling_time is None else other_pop.sampling_time
+            if not math.isclose(self_st, other_st):
+                raise AssertionError(
+                    f"Sampling times not equal for {self_pop.name}: "
+                    f"{self_pop.sampling_time} ≠ {other_pop.sampling_time}"
+                )
+
+        if self_dbg.num_epochs != other_dbg.num_epochs:
+            raise AssertionError(
+                "Number of epochs not equal: "
+                f"{self_dbg.num_epochs} ≠ {other_dbg.num_epochs}"
+            )
+        for j, (self_epoch, other_epoch) in enumerate(
+            zip(self_dbg.epochs, other_dbg.epochs)
+        ):
+            if not math.isclose(
+                self_epoch.start_time,
+                other_epoch.start_time,
+                rel_tol=rel_tol,
+                abs_tol=abs_tol,
+            ):
+                raise AssertionError(
+                    f"Epoch[{j}] at different times: "
+                    f"{self_epoch.start_time} ≠ {other_epoch.start_time}"
+                )
+            for self_pop, other_pop in zip(
+                self_epoch.populations, other_epoch.populations
+            ):
+                if self_pop.state != other_pop.state:
+                    raise AssertionError(
+                        f"State mismatch in populations in epoch[{j}], {self_pop.name}: "
+                        f"{self_pop.state} ≠ {other_pop.state}"
+                    )
+                if self_pop.state == PopulationStateMachine.ACTIVE:
+                    if not math.isclose(
+                        self_pop.start_size,
+                        other_pop.start_size,
+                        rel_tol=rel_tol,
+                        abs_tol=abs_tol,
+                    ):
+                        raise AssertionError(
+                            "Population start_size not equal to required precision "
+                            f"in epoch[{j}], {self_pop.name}: "
+                            f"{self_pop.start_size} ≠ {other_pop.start_size}"
+                        )
+
+                    if not math.isclose(
+                        self_pop.growth_rate,
+                        other_pop.growth_rate,
+                        rel_tol=rel_tol,
+                        abs_tol=abs_tol,
+                    ):
+                        raise AssertionError(
+                            "Population growth_rate not equal to required precision "
+                            f"in epoch[{j}], {self_pop.name}: "
+                            f"{self_pop.growth_rate} ≠ {other_pop.growth_rate}"
+                        )
+            m_equal = np.isclose(
+                self_epoch.migration_matrix,
+                other_epoch.migration_matrix,
+                rtol=rel_tol,
+                atol=abs_tol,
+            )
+            if not np.all(m_equal):
+                differs = "Differences between: "
+                for source_id, dest_id in zip(*np.where(~m_equal)):
+                    source = self[source_id].name
+                    dest = self[dest_id].name
+                    self_rate = self_epoch.migration_matrix[source_id, dest_id]
+                    other_rate = other_epoch.migration_matrix[source_id, dest_id]
+                    differs += f"({source}, {dest}: {self_rate} ≠ {other_rate}), "
+                raise AssertionError(
+                    f"Migration matrices in epoch[{j}] not equal: \n"
+                    "self = \n"
+                    f"{self_epoch.migration_matrix}\n"
+                    "other = \n"
+                    f"{other_epoch.migration_matrix}\n"
+                    f"::{differs[:-2]}"
+                )
+            self._assert_lineage_movements_equivalent(
+                self_epoch.events, other_epoch.events, rel_tol=rel_tol, abs_tol=abs_tol
+            )
+
+            self_state_change = [
+                event
+                for event in self_epoch.events
+                if isinstance(event, StateChangeEvent)
+            ]
+            other_state_change = [
+                event
+                for event in other_epoch.events
+                if isinstance(event, StateChangeEvent)
+            ]
+            if len(self_state_change) > 0 or len(other_state_change) > 0:
+                raise ValueError(
+                    "State change events not currently supported in equivalent. "
+                    "Please open an issue on GitHub"
+                )
+
+    def _assert_lineage_movements_equivalent(
+        self, self_events, other_events, *, rel_tol, abs_tol
+    ):
+        self_lineage_movements = self._normalise_lineage_movements(self_events)
+        other_lineage_movements = self._normalise_lineage_movements(other_events)
+        source_pops = set(self_lineage_movements.keys())
+        if source_pops != set(other_lineage_movements.keys()):
+            raise AssertionError(
+                f"Mismatch in the set of populations affected by lineage movements: "
+                f"{source_pops} ≠ {set(other_lineage_movements.keys())}"
+            )
+        for source in source_pops:
+            self_out_movements = self_lineage_movements[source]
+            other_out_movements = other_lineage_movements[source]
+            if len(self_out_movements) != len(other_out_movements):
+                raise AssertionError(
+                    "Mismatch in number of normalised lineage movements out of "
+                    f"{source}: {len(self_out_movements)} ≠ {len(other_out_movements)}"
+                )
+            for self_lm, other_lm in zip(self_out_movements, other_out_movements):
+                if self_lm.dest != other_lm.dest:
+                    raise AssertionError(
+                        "Mismatch in lineage movement destination:"
+                        f"{self_lm.dest} ≠ {other_lm.dest}"
+                    )
+                if not math.isclose(
+                    self_lm.proportion,
+                    other_lm.proportion,
+                    rel_tol=rel_tol,
+                    abs_tol=abs_tol,
+                ):
+                    raise AssertionError(
+                        "Mismatch in normalised lineage movement proportions "
+                        f"from {self_lm.source} to {self_lm.dest}: "
+                        f"{self_lm.proportion} ≠ {other_lm.proportion}"
+                    )
+
+    def _normalise_lineage_movements(self, events: List[DemographicEvent]):
+        """
+        Extract the LineageMovementEvent instances from the specified list
+        and normalise their effects into LineageMovement instances, and
+        return a dictionary mapping source populations to the list of
+        sequential lineage movements. For each source population we have a
+        list of sequentual lineage movements, sorted by destination population ID.
+        """
+        assert len({event.time for event in events}) <= 1
+        ret = collections.defaultdict(list)
+        for event in events:
+            if isinstance(event, LineageMovementEvent):
+                for move in event._as_lineage_movements():
+                    ret[move.source].append(move)
+        for pop in list(ret.keys()):
+            # We have a list of *conditional* lineage movements out of a
+            # population. We canonicalise this by sorting by the
+            # destination population, so we have to first convert back to
+            # absolute proportions.
+            assert all(lm.source == pop for lm in ret[pop])
+            P = _sequential_to_proportions([pm.proportion for pm in ret[pop]])
+            id_value_pairs = sorted([(lm.dest, p) for lm, p in zip(ret[pop], P)])
+            S = _proportions_to_sequential([p for _, p in id_value_pairs])
+            ret[pop] = [
+                LineageMovement(source=pop, dest=id_value_pairs[j][0], proportion=S[j])
+                for j in range(len(S))
+            ]
+        return ret
 
     @staticmethod
     def from_species_tree(
@@ -679,29 +1163,273 @@ class Demography:
             time_units=time_units,
         )
 
+    def _from_old_style_map_populations(
+        population_configurations: List[PopulationConfiguration],
+        migration_matrix: List[List[float]],
+        demographic_events: List[DemographicEvent],
+        population_map: [List[Dict[int, str]]],
+    ):
+        direct_model = Demography._from_old_style_simple(
+            population_configurations, migration_matrix, demographic_events
+        )
+
+        for id_map in population_map:
+            if len(set(id_map.values())) != len(id_map):
+                raise ValueError("Population IDs in old model must be unique")
+            for old_id in id_map.values():
+                if old_id < 0 or old_id >= direct_model.num_populations:
+                    raise ValueError(
+                        f"Bad population reference {old_id} in old style model"
+                    )
+        if len(population_map[0]) != len(population_configurations):
+            raise ValueError(
+                "The ID map for the first epoch must have entries for all "
+                "populations in the old-style model"
+            )
+
+        # Suppress misspecification warnings; we'll give more specific messages
+        # later.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            dbg = direct_model.debug()
+
+        if dbg.num_epochs != len(population_map):
+            raise ValueError(
+                "Mismatch in the number of epochs in the old style model "
+                f"({dbg.num_epochs}) and specified in the population ID map "
+                f"({len(population_map)})"
+            )
+
+        demography = Demography()
+        # Set up the initial state of the model
+        id_map = population_map[0]
+        for new_name, old_id in id_map.items():
+            pc = population_configurations[old_id]
+            demography._add_population_from_old_style(pc, new_name)
+        for epoch_id_map in population_map[1:]:
+            for name in epoch_id_map.keys():
+                if name not in demography:
+                    demography.add_population(name=name, initial_size=0)
+
+        # Fill out migration matrix
+        for pop_1, pop_2 in itertools.combinations(id_map.keys(), 2):
+            for pop_j, pop_k in [(pop_1, pop_2), (pop_2, pop_1)]:
+                j = id_map[pop_j]
+                k = id_map[pop_k]
+                demography.set_migration_rate(
+                    source=pop_j, dest=pop_k, rate=direct_model.migration_matrix[j, k]
+                )
+
+        # Set the state of populations and migration rates epoch by epoch.
+        for epoch in dbg.epochs[1:]:
+            epoch_id_map = population_map[epoch.index]
+            # Set the population sizes and growth_rates for the extant populations.
+            for new_id, old_id in epoch_id_map.items():
+                pop_state = epoch.populations[old_id]
+                demography.add_population_parameters_change(
+                    epoch.start_time,
+                    population=new_id,
+                    initial_size=pop_state.start_size,
+                    growth_rate=pop_state.growth_rate,
+                )
+            # Set the migration rates.
+            for pop_1, pop_2 in itertools.combinations(epoch_id_map.keys(), 2):
+                for pop_j, pop_k in [(pop_1, pop_2), (pop_2, pop_1)]:
+                    j = epoch_id_map[pop_j]
+                    k = epoch_id_map[pop_k]
+                    demography.add_migration_rate_change(
+                        time=epoch.start_time,
+                        source=pop_j,
+                        dest=pop_k,
+                        rate=epoch.migration_matrix[j][k],
+                    )
+
+        # Add splits/admixtures/pulses according to the mass migrations in the
+        # original model and ID maps.
+        last_epoch_id_map = population_map[0]
+        for epoch in dbg.epochs:
+            logger.debug(
+                f"Converting epoch[{epoch.index}] "
+                f"{epoch.start_time:.2f}-{epoch.end_time:.2f}"
+            )
+            # New name -> old ID
+            epoch_id_map = population_map[epoch.index]
+            # Old ID -> new name
+            old_id_map = {value: key for key, value in epoch_id_map.items()}
+            last_epoch_pops = set(last_epoch_id_map.keys())
+            epoch_pops = set(epoch_id_map.keys())
+            derived = set()
+            events = copy.deepcopy(epoch.events)
+            old_derived_ids = []
+            if last_epoch_pops != epoch_pops:
+                ancestral = epoch_pops - last_epoch_pops
+                derived = last_epoch_pops - epoch_pops
+                old_derived_ids = []
+                if len(ancestral) == 1:
+                    logger.debug(
+                        f"Adding split ancestral={ancestral} derived={derived}"
+                    )
+                    ancestral = ancestral.pop()
+                    demography.add_population_split(
+                        time=epoch.start_time,
+                        derived=list(derived),
+                        ancestral=ancestral,
+                    )
+                    old_derived_ids = [last_epoch_id_map[pop] for pop in derived]
+                    derived_mass_migrations = 0
+                    for event in events:
+                        if isinstance(event, MassMigration):
+                            if event.source in old_derived_ids:
+                                derived_mass_migrations += 1
+                            if event.proportion != 1:
+                                raise ValueError(
+                                    "MassMigration associated with population split "
+                                    "with proportion != 1"
+                                )
+                    # This check is weak, but it will catch some errors at least.
+                    # We're assuming the old model is well-formed, so this should
+                    # help catch errors where the id map is slightly off.
+                    if derived_mass_migrations < len(old_derived_ids) - 1:
+                        raise ValueError(
+                            "Insufficient MassMigrations found for population split"
+                        )
+                elif len(derived) == 1:
+                    derived = derived.pop()
+                    ancestral = []
+                    sequential_proportions = []
+                    old_derived_id = last_epoch_id_map[derived]
+                    for event in events:
+                        if event.source == old_derived_id:
+                            ancestral.append(old_id_map[event.dest])
+                            sequential_proportions.append(event.proportion)
+                    proportions = _sequential_to_proportions(sequential_proportions)
+                    if math.isclose(sum(proportions), 1):
+                        if len(ancestral) == 1:
+                            # This is a single split from the ancestral population,
+                            # which continues to exist. We need to override the
+                            # defaults for the behaviour we want here.
+                            logger.debug(
+                                f"Adding single split ancestral={ancestral[0]} "
+                                f"derived={derived}"
+                            )
+                            pop = demography[ancestral[0]]
+                            pop.initially_active = True
+                            pop.sampling_time = None
+                            demography.add_population_split(
+                                time=epoch.start_time,
+                                derived=[derived],
+                                ancestral=ancestral[0],
+                            )
+                        else:
+                            logger.debug(
+                                f"Adding admixture ancestral={ancestral} "
+                                f"derived={derived} proportions={proportions}"
+                            )
+                            demography.add_admixture(
+                                time=epoch.start_time,
+                                derived=derived,
+                                ancestral=ancestral,
+                                proportions=proportions,
+                            )
+                        old_derived_ids = [old_derived_id]
+                    else:
+                        raise ValueError(
+                            "Admixture or single population split implied by ID map "
+                            "but absolute population proportions don't sum to 1"
+                        )
+            for event in events:
+                if isinstance(event, MassMigration):
+                    if event.source not in old_derived_ids:
+                        demography.add_mass_migration(
+                            time=epoch.start_time,
+                            source=old_id_map[event.source],
+                            dest=old_id_map[event.dest],
+                            proportion=event.proportion,
+                        )
+                elif not isinstance(
+                    event, (MigrationRateChange, PopulationParametersChange)
+                ):
+                    raise ValueError(
+                        "Only MassMigration, MigrationRateChange and "
+                        "PopulationParametersChange events are supported"
+                    )
+
+            # Go through the inactive populations and check the migration
+            # rates make sense. It's an error to migrate out of an inactive
+            # population and a warning to migrate out of inactive pops.
+            pairs = itertools.combinations(range(len(epoch.populations)), 2)
+            active = set(epoch_id_map.values())
+            for pop_1, pop_2 in pairs:
+                for source, dest in [(pop_1, pop_2), (pop_2, pop_1)]:
+                    if epoch.migration_matrix[source, dest] != 0:
+                        if source in active and dest not in active:
+                            raise ValueError(
+                                "Non zero migration from an active population "
+                                f"({source}) to inactive ({dest})"
+                            )
+                        if source not in active:
+                            warnings.warn(
+                                "Migration out of inactive population "
+                                f"({source}) to ({dest}). This may be an "
+                                "error in your model."
+                            )
+
+            last_epoch_id_map = epoch_id_map
+
+        demography.sort_events()
+        return demography
+
     @staticmethod
-    def from_old_style(
+    def _from_old_style_simple(
         population_configurations=None,
         migration_matrix=None,
         demographic_events=None,
-        Ne=1,
     ):
         """
         Creates a Demography object from the pre 1.0 style input parameters,
         reproducing the old semantics with respect to default values.
         """
-        populations = [Population(initial_size=Ne)]
-        if population_configurations is not None:
-            populations = [
-                Population.from_old_style(pop_config, Ne)
-                for pop_config in population_configurations
-            ]
-        demography = Demography(populations)
+        demography = Demography()
+        for pop_config in population_configurations:
+            demography._add_population_from_old_style(pop_config)
         if migration_matrix is not None:
             demography.migration_matrix = np.array(migration_matrix)
         if demographic_events is not None:
-            demography.events = copy.deepcopy(demographic_events)
+            for event in demographic_events:
+                demography.add_event(copy.deepcopy(event))
         return demography
+
+    @staticmethod
+    def from_old_style(
+        population_configurations=None,
+        *,
+        migration_matrix=None,
+        demographic_events=None,
+        Ne=1,
+        population_map: Union[[List[Dict[int, Union[str, int]]]], None] = None,
+    ):
+        """
+        Creates a Demography object from the pre 1.0 style input parameters,
+        reproducing the old semantics with respect to default values.
+        """
+        if population_configurations is None:
+            pop_configs = [PopulationConfiguration(initial_size=Ne)]
+        else:
+            pop_configs = copy.deepcopy(population_configurations)
+            for pop_config in pop_configs:
+                if pop_config.initial_size is None:
+                    pop_config.initial_size = Ne
+        if population_map is None:
+            return Demography._from_old_style_simple(
+                pop_configs, migration_matrix, demographic_events
+            )
+        else:
+            return Demography._from_old_style_map_populations(
+                pop_configs,
+                migration_matrix,
+                demographic_events,
+                population_map,
+            )
 
     @staticmethod
     def isolated_model(initial_size, *, growth_rate=None):
@@ -829,93 +1557,6 @@ class Demography:
                 model.migration_matrix[-1, 0] = 0
         return model
 
-    # TODO commenting these two out for now in the interest of getting the
-    # main changes merged. We can update the code to include these models
-    # ported in from stdpopsim as a follow up.
-
-    # @staticmethod
-    # def piecewise_constant_size(N0, *args):
-    #     """
-    #     Returns a piecewise constant size demographic model, which allows for
-    #     instantaneous population size change over multiple epochs in a single
-    #     population.
-
-    #     :ivar N0: The initial effective population size
-    #     :vartype N0: float
-    #     :ivar args: Each subsequent argument is a tuple (t, N) which gives the
-    #         time at which the size change takes place and the population size.
-
-    #     The usage is best illustrated by an example:
-
-    #     .. code-block:: python
-
-    #         # One change
-    #         model1 = msprime.Demography.piecewise_constant_size(N0, (t1, N1))
-    #         # Two changes
-    #         model2 = msprime.Demography.piecewise_constant_size(
-    #             N0, (t1, N1), (t2, N2))
-    #     """
-    #     model = Demography()
-    #     model.populations = [
-    #         Population(
-    #             initial_size=N0,
-    #             name="pop_0",
-    #             description="Population in piecewise constant model",
-    #         )
-    #     ]
-    #     model.migration_matrix = [[0]]
-    #     model.demographic_events = []
-    #     for t, N in args:
-    #         model.demographic_events.append(
-    #             PopulationParametersChange(
-    #                 time=t, initial_size=N, growth_rate=0, population=0
-    #             )
-    #         )
-    #     return model
-
-    # @staticmethod
-    # def im_model(N0, N1, NA, T, M01, M10):
-    #     """
-    #     An isolation with migration model where a single ancestral
-    #     population of size NA splits into two populations of constant size N0
-    #     and N1 at time T generations ago, with migration rates M01 and M10 between
-    #     the split populations. Sampling is disallowed in population index 2,
-    #     as this is the ancestral population.
-
-    #     .. fixme:: Not clear what direction the migration rates are here.
-
-    #     :ivar N0: The effective population size of population 0
-    #     :vartype N0: float
-    #     :ivar N1: The effective population size of population 1
-    #     :vartype N1: float
-    #     :ivar NA: The ancestral effective population size (population 2).
-    #     :vartype NA: float
-    #     :ivar T: Time of split between populations 0 and 1 (in generations)
-    #     :vartype T: float
-    #     :ivar M01: Migration rate from population 0 to 1
-    #     :vartype M01: float
-    #     :ivar M10: Migration rate from population M10
-    #     :vartype M10: float
-
-    #     Example usage:
-
-    #     .. code-block:: python
-
-    #         model = msprime.Demography.im_model(N0, N1, NA, T, M12, M21)
-    #     """
-    #     model = Demography()
-    #     model.populations = [
-    #         Population(initial_size=N0),
-    #         Population(initial_size=N1),
-    #         Population(initial_size=NA),
-    #     ]
-    #     model.migration_matrix = [[0, M01, 0], [M10, 0, 0], [0, 0, 0]]
-    #     model.demographic_events = [
-    #         MassMigration(time=T, source=0, destination=2, proportion=1),
-    #         MassMigration(time=T, source=1, destination=2, proportion=1),
-    #     ]
-    #     return model
-
     @staticmethod
     def _ooa_model():
         """
@@ -943,60 +1584,227 @@ class Demography:
         N_CEU = 1000 / math.exp(-r_CEU * T_OOA)
         N_CHB = 510 / math.exp(-r_CHB * T_OOA)
 
-        populations = [
-            Population(
-                name="YRI",
-                description="Yoruba in Ibadan, Nigeria",
-                initial_size=12300,
+        demography = Demography()
+        demography.add_population(
+            name="YRI",
+            description="Yoruba in Ibadan, Nigeria",
+            initial_size=12300,
+        )
+        demography.add_population(
+            name="CEU",
+            description=(
+                "Utah Residents (CEPH) with Northern and Western European Ancestry"
             ),
-            Population(
-                name="CEU",
-                description=(
-                    "Utah Residents (CEPH) with Northern and Western European Ancestry"
-                ),
-                initial_size=N_CEU,
-                growth_rate=r_CEU,
-            ),
-            Population(
-                name="CHB",
-                description="Han Chinese in Beijing, China",
-                initial_size=N_CHB,
-                growth_rate=r_CHB,
-            ),
-            Population(
-                name="OOA",
-                description="Bottleneck out-of-Africa population",
-                initial_size=2100,
-            ),
-            Population(
-                name="AMH", description="Anatomically modern humans", initial_size=12300
-            ),
-            Population(
-                name="ANC",
-                description="Ancestral equilibrium population",
-                initial_size=7300,
-            ),
-        ]
+            initial_size=N_CEU,
+            growth_rate=r_CEU,
+        )
+        demography.add_population(
+            name="CHB",
+            description="Han Chinese in Beijing, China",
+            initial_size=N_CHB,
+            growth_rate=r_CHB,
+        )
+        demography.add_population(
+            name="OOA",
+            description="Bottleneck out-of-Africa population",
+            initial_size=2100,
+        )
+        demography.add_population(
+            name="AMH", description="Anatomically modern humans", initial_size=12300
+        )
+        demography.add_population(
+            name="ANC",
+            description="Ancestral equilibrium population",
+            initial_size=7300,
+        )
 
-        demography = Demography(populations)
         # Set the migration rates between extant populations
         demography.set_symmetric_migration_rate(["CEU", "CHB"], 9.6e-5)
         demography.set_symmetric_migration_rate(["YRI", "CHB"], 1.9e-5)
         demography.set_symmetric_migration_rate(["YRI", "CEU"], 3e-5)
 
-        # TODO these should be added use add_x rather then passing in
-        # lists of events. This'll reduce some boilerplate.
+        demography.add_population_split(
+            time=T_OOA, derived=["CEU", "CHB"], ancestral="OOA"
+        )
+        demography.add_symmetric_migration_rate_change(
+            time=T_OOA, populations=["YRI", "OOA"], rate=25e-5
+        )
+        demography.add_population_split(
+            time=T_AMH, derived=["YRI", "OOA"], ancestral="AMH"
+        )
+        demography.add_population_split(time=T_ANC, derived=["AMH"], ancestral="ANC")
+        return demography
 
-        demography.events = [
-            # CEU and CHB merge into the OOA population
-            PopulationSplit(time=T_OOA, derived=["CEU", "CHB"], ancestral="OOA"),
-            # Set the migration rate between OOA and YRI
-            SymmetricMigrationRateChange(
-                time=T_OOA, populations=["YRI", "OOA"], rate=25e-5
+    @staticmethod
+    def _ooa_archaic_model():
+        """
+        See notes for the _ooa model above.
+        """
+        # Implement the OutOfAfricaArchaicAdmixture_5R19 model
+        # NOTE: this example isn't very well factored and needs more work.
+
+        # Times are provided in years, so we convert into generations.
+        generation_time = 29
+        T_OOA = 36_000 / generation_time
+        T_AMH = 60_700 / generation_time
+        T_ANC = 300_000 / generation_time
+        T_ArchaicAFR = 499_000 / generation_time
+        T_Neanderthal = 559_000 / generation_time
+        T_archaic_migration_start = 18_700 / generation_time
+        T_archaic_migration_end = 125_000 / generation_time
+
+        # We need to work out the starting (diploid) population sizes based on
+        # the growth rates provided for these two populations
+        r_CEU = 0.00125
+        r_CHB = 0.00372
+        N_CEU = 2300 / math.exp(-r_CEU * T_OOA)
+        N_CHB = 650 / math.exp(-r_CHB * T_OOA)
+
+        demography = Demography()
+        # This is the "trunk" population that we merge other populations into
+        demography.add_population(
+            name="AFR",
+            description="African population",
+            initial_size=13900,
+            initially_active=True,
+        )
+        demography.add_population(
+            name="CEU",
+            description=(
+                "Utah Residents (CEPH) with Northern and Western European Ancestry"
             ),
-            PopulationSplit(time=T_AMH, derived=["YRI", "OOA"], ancestral="AMH"),
-            PopulationSplit(time=T_ANC, derived=["AMH"], ancestral="ANC"),
-        ]
+            initial_size=N_CEU,
+            growth_rate=r_CEU,
+        )
+        demography.add_population(
+            name="CHB",
+            description="Han Chinese in Beijing, China",
+            initial_size=N_CHB,
+            growth_rate=r_CHB,
+        )
+        demography.add_population(
+            name="Neanderthal",
+            description="Putative Neanderthals",
+            initial_size=3600,
+        )
+        demography.add_population(
+            name="ArchaicAFR",
+            description="Putative Archaic Africans",
+            initial_size=3600,
+        )
+        demography.add_population(
+            name="OOA",
+            description="Bottleneck out-of-Africa population",
+            initial_size=880,
+        )
+
+        # Set the migration rates between extant populations
+        demography.set_symmetric_migration_rate(["CEU", "CHB"], 11.3e-5)
+        demography.set_symmetric_migration_rate(["AFR", "CEU"], 2.48e-5)
+
+        demography.add_symmetric_migration_rate_change(
+            T_archaic_migration_start, ["CEU", "Neanderthal"], 0.825e-5
+        )
+        demography.add_symmetric_migration_rate_change(
+            T_archaic_migration_start, ["CHB", "Neanderthal"], 0.825e-5
+        )
+        demography.add_symmetric_migration_rate_change(
+            T_archaic_migration_start, ["ArchaicAFR", "AFR"], 1.98e-5
+        )
+        demography.add_migration_rate_change(T_archaic_migration_end, rate=0)
+
+        demography.add_population_split(
+            time=T_OOA, derived=["CEU", "CHB"], ancestral="OOA"
+        )
+        demography.add_symmetric_migration_rate_change(
+            time=T_OOA, populations=["AFR", "OOA"], rate=52.2e-5
+        )
+        demography.add_symmetric_migration_rate_change(
+            time=T_OOA, populations=["OOA", "Neanderthal"], rate=0.825e-5
+        )
+        demography.add_population_split(time=T_AMH, derived=["OOA"], ancestral="AFR")
+        demography.add_symmetric_migration_rate_change(
+            T_AMH, ["ArchaicAFR", "AFR"], 1.98e-5
+        )
+        demography.add_population_parameters_change(
+            time=T_AMH, population="AFR", initial_size=13900
+        )
+        demography.add_population_parameters_change(
+            time=T_ANC, population="AFR", initial_size=3600
+        )
+        demography.add_population_split(
+            time=T_ArchaicAFR, derived=["ArchaicAFR"], ancestral="AFR"
+        )
+        demography.add_population_split(
+            time=T_Neanderthal, derived=["Neanderthal"], ancestral="AFR"
+        )
+        demography.sort_events()
+        return demography
+
+    @staticmethod
+    def _american_admixture_model():
+        # Implementation of AmericanAdmixture_4B11 model. See notes from the _ooa
+        # model above as to why this is here.
+        T_OOA = 920
+        N_EUR = 34039
+        r_EUR = 0.0038
+        N_EAS = 45852
+        r_EAS = 0.0048
+        T_ADMIX = 12
+        N_ADMIX = 54664
+        r_ADMIX = 0.05
+
+        demography = Demography()
+        demography.add_population(
+            name="AFR", description="African population", initial_size=14474
+        )
+        demography.add_population(
+            name="EUR",
+            description="European population",
+            initial_size=N_EUR,
+            growth_rate=r_EUR,
+        )
+        demography.add_population(
+            name="EAS",
+            description="East Asian population",
+            initial_size=N_EAS,
+            growth_rate=r_EAS,
+        )
+        demography.add_population(
+            name="ADMIX",
+            description="Admixed America",
+            initial_size=N_ADMIX,
+            growth_rate=r_ADMIX,
+        )
+        demography.add_admixture(
+            T_ADMIX,
+            derived="ADMIX",
+            ancestral=["AFR", "EUR", "EAS"],
+            proportions=[1 / 6, 2 / 6, 3 / 6],
+        )
+        demography.add_population(
+            name="OOA",
+            description="Bottleneck out-of-Africa population",
+            initial_size=1861,
+        )
+        demography.add_population(
+            name="AMH", description="Anatomically modern humans", initial_size=14474
+        )
+        demography.add_population(
+            name="ANC",
+            description="Ancestral equilibrium population",
+            initial_size=7310,
+        )
+        demography.set_symmetric_migration_rate(["AFR", "EUR"], 2.5e-5)
+        demography.set_symmetric_migration_rate(["AFR", "EAS"], 0.78e-5)
+        demography.set_symmetric_migration_rate(["EUR", "EAS"], 3.11e-5)
+
+        demography.add_population_split(T_OOA, derived=["EUR", "EAS"], ancestral="OOA")
+        demography.add_symmetric_migration_rate_change(
+            time=T_OOA, populations=["AFR", "OOA"], rate=15e-5
+        )
+        demography.add_population_split(2040, derived=["OOA", "AFR"], ancestral="AMH")
+        demography.add_population_split(5920, derived=["AMH"], ancestral="ANC")
         return demography
 
 
@@ -1046,29 +1854,14 @@ class PopulationConfiguration:
         )
 
 
-def _convert_id(demography, population_ref):
-    """
-    Converts the specified population reference into an integer,
-    suitable for input into the low-level code. We treat -1 as a special
-    case because it's used as meaning "all populations" by the events.
-
-    We need this awkward workaround taking into account that
-    demography might be None because stdpopsim is using this API
-    and won't provide this argument. All stdpopsim population references
-    will be integers, though.
-
-    https://github.com/tskit-dev/msprime/issues/1037
-    """
-    if demography is None or population_ref == -1:
-        return population_ref
-    return demography[population_ref].id
-
-
-def _list_str(a: List):
+def _list_str(a: List, fmt=None):
     """
     Returns the specified items rendered as a string without quotes.
     """
-    joined = ", ".join(str(item) for item in a)
+    if fmt is None:
+        joined = ", ".join(str(item) for item in a)
+    else:
+        joined = ", ".join(f"{item:{fmt}}" for item in a)
     return f"[{joined}]"
 
 
@@ -1079,6 +1872,9 @@ class DemographicEvent:
     """
 
     time: float
+    demography: Demography = dataclasses.field(
+        init=False, compare=False, default=None, repr=False
+    )
 
     def _parameters(self):
         raise NotImplementedError()
@@ -1093,9 +1889,39 @@ class DemographicEvent:
             if hasattr(self, key)
         }
 
+    def _convert_id(self, population_ref):
+        """
+        Converts the specified population reference into an integer,
+        suitable for input into the low-level code. We treat -1 as a special
+        case because it's used as meaning "all populations" by the events.
+        """
+        if population_ref in [-1, None]:
+            # Both of these mean "all populations"
+            return -1
+        if self.demography is None:
+            # We need to be able to handle Events that are not associated with
+            # a Demography to support old code. However, these should only ever
+            # happen with integer IDs.
+            if not core.isinteger(population_ref):
+                raise ValueError(
+                    "Working with demographic events not associated with a "
+                    "Demography object is a legacy-only operation. Population "
+                    "references must be integer IDs"
+                )
+            return population_ref
+        return self.demography[population_ref].id
+
+
+class ParameterChangeEvent(DemographicEvent):
+    """
+    Superclass of events that change some parameters in the underlying
+    simulation model but don't actually affect the state in any other
+    way.
+    """
+
 
 @dataclasses.dataclass
-class PopulationParametersChange(DemographicEvent):
+class PopulationParametersChange(ParameterChangeEvent):
     """
     Changes the demographic parameters of a population at a given time.
 
@@ -1141,13 +1967,13 @@ class PopulationParametersChange(DemographicEvent):
             raise ValueError("Cannot have a population size < 0")
         self.population = -1 if self.population is None else self.population
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.2 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         ret = {
             "type": "population_parameters_change",
             "time": self.time,
-            "population": _convert_id(demography, self.population),
+            "population": self._convert_id(self.population),
         }
         if self.growth_rate is not None:
             ret["growth_rate"] = self.growth_rate
@@ -1166,11 +1992,11 @@ class PopulationParametersChange(DemographicEvent):
     def _effect(self):
         s = ""
         if self.initial_size is not None:
-            s += f"initial_size → {self.initial_size} "
+            s += f"initial_size → {self.initial_size:.2g} "
             if self.growth_rate is not None:
                 s += "and "
         if self.growth_rate is not None:
-            s += f"growth_rate → {self.growth_rate} "
+            s += f"growth_rate → {self.growth_rate:.3g} "
         s += "for"
         if self.population == -1:
             s += " all populations"
@@ -1180,7 +2006,7 @@ class PopulationParametersChange(DemographicEvent):
 
 
 @dataclasses.dataclass
-class MigrationRateChange(DemographicEvent):
+class MigrationRateChange(ParameterChangeEvent):
     """
     Changes the rate of migration from one deme to another to a new value at a
     specific time. Migration rates are specified in terms of the rate at which
@@ -1217,7 +2043,7 @@ class MigrationRateChange(DemographicEvent):
             self.source = self.matrix_index[0]
             self.dest = self.matrix_index[1]
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.1 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         return {
@@ -1227,8 +2053,8 @@ class MigrationRateChange(DemographicEvent):
             # to leave this alone until stdpopsim has been moved away from
             # using this internal API.
             "migration_rate": self.rate,
-            "source": _convert_id(demography, self.source),
-            "dest": _convert_id(demography, self.dest),
+            "source": self._convert_id(self.source),
+            "dest": self._convert_id(self.dest),
         }
 
     def _parameters(self):
@@ -1244,8 +2070,82 @@ class MigrationRateChange(DemographicEvent):
         return ret
 
 
+# TODO not clear we want to document this as part of the external API.
 @dataclasses.dataclass
-class MassMigration(DemographicEvent):
+class SymmetricMigrationRateChange(ParameterChangeEvent):
+    """
+    Sets the symmetric migration rate between all pairs of populations in
+    the specified list to the specified value. For a given pair of population
+    IDs ``j`` and ``k``, this sets ``migration_matrix[j, k] = rate``
+    and ``migration_matrix[k, j] = rate``.
+
+    Populations may be specified either by their integer IDs or by
+    their string names.
+
+    :param float time: The time at which this event occurs in generations.
+    :param list populations: An iterable of population identifiers (integer
+        IDs or string names).
+    :param float rate: The new migration rate.
+    """
+
+    populations: List[Union[int, str]]
+    rate: float
+
+    _type_str: ClassVar[str] = dataclasses.field(
+        default="Symmetric migration rate change", repr=False
+    )
+
+    def get_ll_representation(self, num_populations=None):
+        # We need to keep the num_populations argument until stdpopsim 0.1 is out
+        # https://github.com/tskit-dev/msprime/issues/1037
+        return {
+            "type": "symmetric_migration_rate_change",
+            "time": self.time,
+            "populations": [self._convert_id(pop) for pop in self.populations],
+            "rate": self.rate,
+        }
+
+    def _parameters(self):
+        return f"populations={_list_str(self.populations)}, rate={self.rate}"
+
+    def _effect(self):
+        s = "Sets the symmetric migration rate between "
+        if len(self.populations) == 2:
+            s += f"{self.populations[0]} and {self.populations[1]} "
+        else:
+            s += f"all pairs of populations in {_list_str(self.populations)} "
+        s += f"to {self.rate} per generation"
+        return s
+
+
+@dataclasses.dataclass
+class LineageMovement:
+    """
+    A single instantaneous movement of lineages from one population to
+    another. Note that 'source' and 'dest' are in the backwards-in-time
+    sense.
+    """
+
+    source: int
+    dest: int
+    proportion: float
+
+
+class LineageMovementEvent(DemographicEvent):
+    """
+    Superclass of events that move lineages around between populations.
+    """
+
+    def _as_lineage_movements(self) -> List[LineageMovement]:
+        """
+        Returns the equivalent of this lineage movement event as a
+        list of lineage movements.
+        """
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass
+class MassMigration(LineageMovementEvent):
     """
     A mass migration event in which some fraction of the population in one deme
     (the ``source``) simultaneously move to another deme (``dest``) during the
@@ -1282,19 +2182,21 @@ class MassMigration(DemographicEvent):
         if self.destination is not None:
             self.dest = self.destination
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.1 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         return {
             "type": "mass_migration",
             "time": self.time,
-            "source": _convert_id(demography, self.source),
-            "dest": _convert_id(demography, self.dest),
+            "source": self._convert_id(self.source),
+            "dest": self._convert_id(self.dest),
             "proportion": self.proportion,
         }
 
     def _parameters(self):
-        return f"source={self.source}, dest={self.dest}, proportion={self.proportion}"
+        return (
+            f"source={self.source}, dest={self.dest}, proportion={self.proportion:.3g}"
+        )
 
     def _effect(self):
         if self.proportion == 1.0:
@@ -1305,7 +2207,7 @@ class MassMigration(DemographicEvent):
         else:
             ret = (
                 f"Lineages currently in population {self.source} move to {self.dest} "
-                f"with probability {self.proportion} "
+                f"with probability {self.proportion:.3g} "
             )
         ret += (
             "(equivalent to individuals "
@@ -1313,56 +2215,18 @@ class MassMigration(DemographicEvent):
         )
         return ret
 
-
-@dataclasses.dataclass
-class SymmetricMigrationRateChange(DemographicEvent):
-    """
-    Sets the symmetric migration rate between all pairs of populations in
-    the specified list to the specified value. For a given pair of population
-    IDs ``j`` and ``k``, this sets ``migration_matrix[j, k] = rate``
-    and ``migration_matrix[k, j] = rate``.
-
-    Populations may be specified either by their integer IDs or by
-    their string names.
-
-    :param float time: The time at which this event occurs in generations.
-    :param list populations: An iterable of population identifiers (integer
-        IDs or string names).
-    :param float rate: The new migration rate.
-    """
-
-    populations: List[Union[int, str]]
-    rate: float
-
-    _type_str: ClassVar[str] = dataclasses.field(
-        default="Symmetric migration rate change", repr=False
-    )
-
-    def get_ll_representation(self, num_populations=None, demography=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
-        return {
-            "type": "symmetric_migration_rate_change",
-            "time": self.time,
-            "populations": [_convert_id(demography, pop) for pop in self.populations],
-            "rate": self.rate,
-        }
-
-    def _parameters(self):
-        return f"populations={_list_str(self.populations)}, rate={self.rate}"
-
-    def _effect(self):
-        s = "Sets the symmetric migration rate between "
-        if len(self.populations) == 2:
-            s += f"{self.populations[0]} and {self.populations[1]} "
-        else:
-            s += f"all pairs of populations in {_list_str(self.populations)} "
-        s += f"to {self.rate} per generation"
-        return s
+    def _as_lineage_movements(self):
+        return [
+            LineageMovement(
+                source=self._convert_id(self.source),
+                dest=self._convert_id(self.dest),
+                proportion=self.proportion,
+            )
+        ]
 
 
 @dataclasses.dataclass
-class PopulationSplit(DemographicEvent):
+class PopulationSplit(LineageMovementEvent):
     """
 
     :param float time: The time at which this event occurs in generations.
@@ -1375,14 +2239,14 @@ class PopulationSplit(DemographicEvent):
 
     _type_str: ClassVar[str] = dataclasses.field(default="Population Split", repr=False)
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.1 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         return {
             "type": "population_split",
             "time": self.time,
-            "derived": [_convert_id(demography, pop) for pop in self.derived],
-            "ancestral": _convert_id(demography, self.ancestral),
+            "derived": [self._convert_id(pop) for pop in self.derived],
+            "ancestral": self._convert_id(self.ancestral),
         }
 
     def _parameters(self):
@@ -1399,29 +2263,106 @@ class PopulationSplit(DemographicEvent):
             else:
                 s += f"{_list_str(self.derived)} "
         s += f"to the ancestral '{self.ancestral}' population. "
-        s += "Also set all migration rates to and from "
+        s += "Also set "
         if len(self.derived) == 1:
             s += f"'{self.derived[0]}' "
         else:
             s += "the derived populations "
-        s += "to zero."
+        s += (
+            "to inactive, and all migration rates to and from "
+            f"the derived population{'s' if len(self.derived) > 1 else ''} "
+            "to zero."
+        )
 
         return s
+
+    def _as_lineage_movements(self):
+        ancestral = self._convert_id(self.ancestral)
+        return [
+            LineageMovement(source=self._convert_id(pop), dest=ancestral, proportion=1)
+            for pop in self.derived
+        ]
+
+
+@dataclasses.dataclass
+class Admixture(LineageMovementEvent):
+    """
+
+    :param float time: The time at which this event occurs in generations.
+    """
+
+    derived: Union[int, str]
+    ancestral: List[Union[int, str]]
+    proportions: List[float]
+
+    _type_str: ClassVar[str] = dataclasses.field(default="Admixture", repr=False)
+
+    @property
+    def num_ancestral(self):
+        return len(self.ancestral)
+
+    def get_ll_representation(self, num_populations=None):
+        # We need to keep the num_populations argument until stdpopsim 0.1 is out
+        # https://github.com/tskit-dev/msprime/issues/1037
+        return {
+            "type": "admixture",
+            "time": self.time,
+            "derived": self._convert_id(self.derived),
+            "ancestral": [self._convert_id(pop) for pop in self.ancestral],
+            "proportions": self.proportions,
+        }
+
+    def _parameters(self):
+        return (
+            f"derived={self.derived} ancestral={_list_str(self.ancestral)} "
+            f"proportions={_list_str(self.proportions, '.2f')}"
+        )
+
+    def _effect(self):
+        move_to = "; ".join(
+            f"'{pop}' with proba {proba:.3g}"
+            for pop, proba in zip(self.ancestral, self.proportions)
+        )
+        return (
+            f"Moves all lineages from admixed population '{self.derived}' "
+            f"to ancestral population{'s' if len(self.ancestral) > 1 else ''}. "
+            f"Lineages move to {move_to}. Set '{self.derived}' to inactive, "
+            f"and all migration rates to and from '{self.derived}' to zero."
+        )
+
+    def _as_lineage_movements(self):
+        derived = self._convert_id(self.derived)
+        ancestral = [self._convert_id(pop) for pop in self.ancestral]
+        # Conditioned on having already distributed a fraction q of the
+        # lineages, the we need a fraction p / (1 - q) of the remaining
+        # lineages to get an overall proportion of p.
+        S = _proportions_to_sequential(self.proportions)
+        return [
+            LineageMovement(source=derived, dest=ancestral[j], proportion=S[j])
+            for j in range(self.num_ancestral)
+        ]
+
+
+class StateChangeEvent(DemographicEvent):
+    """
+    Superclass of events that change the state of the simulation in complex
+    ways.
+    """
 
 
 # This is an unsupported/undocumented demographic event.
 @dataclasses.dataclass
-class SimpleBottleneck(DemographicEvent):
+class SimpleBottleneck(StateChangeEvent):
     population: int
     proportion: float = 1.0
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.1 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         return {
             "type": "simple_bottleneck",
             "time": self.time,
-            "population": _convert_id(demography, self.population),
+            "population": self._convert_id(self.population),
             "proportion": self.proportion,
         }
 
@@ -1441,17 +2382,17 @@ class SimpleBottleneck(DemographicEvent):
 
 # TODO document
 @dataclasses.dataclass
-class InstantaneousBottleneck(DemographicEvent):
+class InstantaneousBottleneck(StateChangeEvent):
     population: int
     strength: float = 1.0
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.1 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         return {
             "type": "instantaneous_bottleneck",
             "time": self.time,
-            "population": _convert_id(demography, self.population),
+            "population": self._convert_id(self.population),
             "strength": self.strength,
         }
 
@@ -1483,7 +2424,7 @@ class CensusEvent(DemographicEvent):
 
     _type_str: ClassVar[str] = dataclasses.field(default="Census", repr=False)
 
-    def get_ll_representation(self, num_populations=None, demography=None):
+    def get_ll_representation(self, num_populations=None):
         # We need to keep the num_populations argument until stdpopsim 0.1 is out
         # https://github.com/tskit-dev/msprime/issues/1037
         return {
@@ -1498,30 +2439,29 @@ class CensusEvent(DemographicEvent):
         return "Insert census nodes to record the location of all lineages"
 
 
-@dataclasses.dataclass
-class PopulationState:
+def _sequential_to_proportions(S):
     """
-    Simple class to represent the state of a population in terms of its
-    demographic parameters.
+    Given a list of sequential lineage proportions out of a population,
+    return the absolute proportions of the original population this
+    corresponds to.
     """
+    P = []
+    for j in range(len(S)):
+        P.append(S[j] * (1 - sum(P[:j])))
+    return P
 
-    start_size: float
-    end_size: float
-    growth_rate: float
 
-
-@dataclasses.dataclass
-class Epoch:
+def _proportions_to_sequential(P):
     """
-    Represents a single epoch in the simulation within which the state
-    of the demographic parameters are constant.
+    Given a list of absolute proportions of lineages moving out of
+    a population, return the sequential conditional movements required
+    to give them same proportions.
     """
-
-    start_time: float
-    end_time: float
-    populations: List[PopulationState]
-    migration_matrix: list  # TODO numpy array
-    demographic_events: List[DemographicEvent]
+    # Conditioned on having already distributed a fraction q of the
+    # lineages, the we need a fraction p / (1 - q) of the remaining
+    # lineages to get an overall proportion of p
+    C = [P[j] / (1 - sum(P[:j])) for j in range(len(P))]
+    return C
 
 
 def _matrix_exponential(A):
@@ -1536,6 +2476,90 @@ def _matrix_exponential(A):
     D = np.diag(np.exp(d))
     B = np.matmul(Y, np.matmul(D, Yinv))
     return np.real_if_close(B, tol=1000)
+
+
+class PopulationStateMachine(enum.IntEnum):
+    """
+    During a simulation each population has three possible states described
+    by this state machine. In general, a population follows:
+
+    INACTIVE -> ACTIVE -> PREVIOUSLY_ACTIVE
+
+    All populations are by default ACTIVE at the start of the simulation,
+    except if they are they are "ancestral" in a population split event.
+    In this case populations are initially INACTIVE. A population
+    then transitions from INACTIVE -> ACTIVE when the corresponding
+    population split event occurs.
+
+    Populations transition from ACTIVE -> PREVIOUSLY_ACTIVE when they
+    are "derived" in either population split or admixture events.
+
+    No other transitions are possible.
+    """
+
+    INACTIVE = 0
+    ACTIVE = 1
+    PREVIOUSLY_ACTIVE = 2
+
+
+@dataclasses.dataclass
+class PopulationState:
+    """
+    Simple class to represent the state of a population in terms of its
+    demographic parameters. Note: start and end here refer to time flowing
+    *backwards*!
+    """
+
+    id: int  # noqa: A003
+    name: str
+    start_size: float
+    end_size: float
+    growth_rate: float
+    state: int
+
+    @property
+    def active(self):
+        return self.state == PopulationStateMachine.ACTIVE
+
+
+@dataclasses.dataclass
+class Epoch:
+    """
+    Represents a single epoch in the simulation within which the state
+    of the demographic parameters are constant.
+    """
+
+    index: int
+    start_time: float
+    end_time: float
+    populations: List[PopulationState]
+    migration_matrix: list  # TODO numpy array
+    events: List[DemographicEvent]
+
+    def _title_text(self):
+        return (
+            f"Epoch[{self.index}]: "
+            f"[{self.start_time:.3g}, {self.end_time:.3g}) generations"
+        )
+
+    def _population_state_text(self):
+        return (
+            f"Populations "
+            f"(total={len(self.populations)} active={self.num_active_populations})"
+        )
+
+    @property
+    def demographic_events(self):
+        # For compatibility with msprime 0.x
+        return self.events
+
+    @property
+    def active_populations(self):
+        return [pop for pop in self.populations if pop.active]
+
+    @property
+    def num_active_populations(self):
+        return len(self.active_populations)
 
 
 class DemographyDebugger:
@@ -1563,29 +2587,20 @@ class DemographyDebugger:
             # Support the pre-1.0 syntax
             demography = Demography.from_old_style(
                 population_configurations,
-                migration_matrix,
-                demographic_events,
+                migration_matrix=migration_matrix,
+                demographic_events=demographic_events,
                 Ne=Ne,
             )
-        self.demography = demography
+        self.demography = demography.validate()
         self.num_populations = demography.num_populations
         self._make_epochs()
         self._check_misspecification()
 
     def _make_epochs(self):
         self.epochs = []
-        # We don't actually use the samples, this is just to get the simulator
-        # correctly initialised.
-        samples = {}
-        for j, pop in enumerate(self.demography.populations):
-            if pop.initial_size > 0 and pop.sampling_time == 0:
-                samples[j] = 1
-        if len(samples) == 0:
-            raise ValueError("No population with non-zero initial size.")
         simulator = ancestry._parse_sim_ancestry(
-            demography=self.demography, samples=samples
+            demography=self.demography, init_for_debugger=True
         )
-
         start_time = 0
         end_time = 0
         abs_tol = 1e-9
@@ -1600,19 +2615,28 @@ class DemographyDebugger:
                 event_index += 1
             end_time = simulator.debug_demography()
             migration_matrix = simulator.migration_matrix
-            growth_rates = [
-                conf["growth_rate"] for conf in simulator.population_configuration
-            ]
+            pop_conf = simulator.population_configuration
             populations = [
                 PopulationState(
+                    id=j,
+                    name=self.demography.populations[j].name,
                     start_size=simulator.compute_population_size(j, start_time),
                     end_size=simulator.compute_population_size(j, end_time),
-                    growth_rate=growth_rates[j],
+                    growth_rate=pop_conf[j]["growth_rate"],
+                    state=PopulationStateMachine(pop_conf[j]["state"]),
                 )
                 for j in range(self.num_populations)
             ]
+            epoch_index = len(self.epochs)
             self.epochs.append(
-                Epoch(start_time, end_time, populations, migration_matrix, events)
+                Epoch(
+                    epoch_index,
+                    start_time,
+                    end_time,
+                    populations,
+                    migration_matrix,
+                    events,
+                )
             )
             start_time = end_time
 
@@ -1622,7 +2646,7 @@ class DemographyDebugger:
         """
         merged_pops = set()
         for epoch in self.epochs:
-            for de in epoch.demographic_events:
+            for de in epoch.events:
                 if isinstance(de, MassMigration) and de.proportion == 1:
                     merged_pops.add(de.source)
             mm = epoch.migration_matrix
@@ -1635,57 +2659,62 @@ class DemographyDebugger:
                         "demographic misspecification."
                     )
 
-    def _populations_html(self, epoch):
-        column_titles = ["", "start", "end", "growth_rate"] + [
-            pop.name for pop in self.demography.populations
-        ]
+    def _populations_table(self, epoch, as_text=True):
+        active_populations = epoch.active_populations
+        column_titles = ["", "start", "end", "growth_rate"]
+        if len(active_populations) > 1:
+            column_titles += [pop.name for pop in active_populations]
         data = []
-        for j, pop in enumerate(epoch.populations):
+        for pop in active_populations:
             row = [
-                self.demography.populations[j].name,
-                f"{pop.start_size: .3g}",
-                f"{pop.end_size: .3g}",
+                pop.name,
+                f"{pop.start_size: .1f}",
+                f"{pop.end_size: .1f}",
                 f"{pop.growth_rate: .3g}",
             ]
-            for k in range(self.demography.num_populations):
-                item = self.demography._migration_rate_info(
-                    j, k, epoch.migration_matrix[j, k]
-                )
-                row.append(item)
+            if len(active_populations) > 1:
+                for other_pop in active_populations:
+                    item = self.demography._migration_rate_info(
+                        pop.id,
+                        other_pop.id,
+                        epoch.migration_matrix[pop.id, other_pop.id],
+                    )
+                    if as_text:
+                        row.append(item.as_text())
+                    else:
+                        row.append(item)
+
             data.append(row)
-        return core.html_table("", column_titles, data)
+        return column_titles, data
+
+    def _populations_html(self, epoch):
+        column_titles, data = self._populations_table(epoch, as_text=False)
+        return core.html_table(epoch._population_state_text(), column_titles, data)
 
     def _populations_text(self, epoch):
-        column_titles = [[""], ["start"], ["end"], ["growth_rate"]] + [
-            [pop.name] for pop in self.demography.populations
-        ]
-        alignments = ">>><" + "^" * self.demography.num_populations
-        data = []
-        for j, pop in enumerate(epoch.populations):
-            row = [
-                [self.demography.populations[j].name],
-                [f"{pop.start_size: .3g}"],
-                [f"{pop.end_size: .3g}"],
-                [f"{pop.growth_rate: .3g}"],
-            ]
-            for k in range(self.demography.num_populations):
-                row.append([f"{epoch.migration_matrix[j, k]:.3g}"])
-            data.append(row)
-        return core.text_table("Population state", column_titles, alignments, data)
+        column_titles, data = self._populations_table(epoch)
+        alignments = ">>><"
+        if epoch.num_active_populations > 1:
+            alignments += "^" * epoch.num_active_populations
+        # Repack the table items as lists
+        column_titles = [[x] for x in column_titles]
+        data = [[[x] for x in row] for row in data]
+        return core.text_table(
+            epoch._population_state_text(), column_titles, alignments, data
+        )
 
     def _repr_html_(self):
         out = ""
-        for j, epoch in enumerate(self.epochs):
-            if j > 0:
-                if len(epoch.demographic_events) > 0:
-                    title = f"Events @ generation {epoch.start_time}"
-                    out += self.demography._events_html(epoch.demographic_events, title)
+        for epoch in self.epochs:
+            if epoch.index > 0:
+                assert len(epoch.events) > 0
+                title = f"Events @ generation {epoch.start_time}"
+                out += self.demography._events_html(epoch.events, title)
                 out += "</div>"
             else:
-                assert len(epoch.demographic_events) == 0
-            epoch_title = f"Epoch: {epoch.start_time} -- {epoch.end_time} generations"
+                assert len(epoch.events) == 0
             out += '<div class="msprime-epoch">'
-            out += f"<h3>{epoch_title}</h3>"
+            out += f"<h3>{epoch._title_text()}</h3>"
             out += self._populations_html(epoch)
         out += "</div>"
         return f"""<div>
@@ -1718,15 +2747,12 @@ class DemographyDebugger:
             return f"{top}\n║ {title} ║\n{bottom}\n"
 
         out = "DemographyDebugger\n"
-        for j, epoch in enumerate(self.epochs):
-            if j > 0:
-                if len(epoch.demographic_events) > 0:
-                    title = f"Events @ generation {epoch.start_time}"
-                    out += indent(
-                        self.demography._events_text(epoch.demographic_events, title)
-                    )
-            epoch_title = f"Epoch: {epoch.start_time} -- {epoch.end_time} generations"
-            out += box(epoch_title)
+        for epoch in self.epochs:
+            if epoch.index > 0:
+                assert len(epoch.events) > 0
+                title = f"Events @ generation {epoch.start_time:.3g}"
+                out += indent(self.demography._events_text(epoch.events, title))
+            out += box(epoch._title_text())
             out += indent(self._populations_text(epoch))
         return out
 

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -653,7 +653,7 @@ class TestParseSimAncestry:
         demography = msprime.Demography.stepping_stone_model([1] * 5, 0.1)
         samples = {0: 2}
         sim = ancestry._parse_sim_ancestry(samples, demography=demography)
-        assert sim.demography is demography
+        assert sim.demography is not demography
         assert sim.num_populations == demography.num_populations
         assert np.array_equal(sim.migration_matrix, demography.migration_matrix)
         # Numeric samples fail here as we have more than 1 population
@@ -854,6 +854,7 @@ class TestSimAncestrySamples:
         assert np.all(tables.nodes.population[:4] == 0)
 
     def verify_samples_map(self, samples, demography, ploidy):
+        demography = demography.validate()
         sim = ancestry._parse_sim_ancestry(
             samples=samples, demography=demography, ploidy=ploidy
         )

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -40,6 +40,42 @@ import msprime
 from msprime import _msprime
 
 
+def all_events_example_demography(*, integer_ids=False):
+    demography = msprime.Demography.isolated_model([10] * 10)
+    demography.add_population_parameters_change(0.1, initial_size=2)
+    demography.add_population_parameters_change(0.1, growth_rate=10)
+    demography.add_migration_rate_change(0.4, rate=0)
+    demography.add_census(0.55)
+    if integer_ids:
+        demography.add_migration_rate_change(0.2, source=0, dest=1, rate=1)
+        demography.add_symmetric_migration_rate_change(
+            0.3, populations=[0, 1], rate=0.5
+        )
+        demography.add_mass_migration(0.4, source=1, dest=0, proportion=0.5)
+        demography.add_population_split(0.4, derived=[3, 4], ancestral=5)
+        demography.add_admixture(
+            0.45, derived=7, ancestral=[8, 9], proportions=[0.5, 0.5]
+        )
+        demography.add_instantaneous_bottleneck(0.5, population=0, strength=100)
+        demography.add_simple_bottleneck(0.56, population=1, proportion=0.1)
+    else:
+        demography.add_migration_rate_change(0.2, source="pop_0", dest="pop_1", rate=1)
+        demography.add_symmetric_migration_rate_change(
+            0.3, populations=["pop_0", "pop_1"], rate=0.5
+        )
+        demography.add_mass_migration(0.4, source="pop_1", dest="pop_0", proportion=0.5)
+        demography.add_population_split(
+            0.4, derived=["pop_3", "pop_4"], ancestral="pop_5"
+        )
+        demography.add_admixture(
+            0.45, derived="pop_7", ancestral=["pop_8", "pop_9"], proportions=[0.5, 0.5]
+        )
+        demography.add_instantaneous_bottleneck(0.5, population="pop_0", strength=100)
+        demography.add_simple_bottleneck(0.56, population="pop_1", proportion=0.1)
+    demography.sort_events()
+    return demography
+
+
 class TestNePopulationSizeEquivalence:
     """
     Test that setting Ne as a parameter of the population model and
@@ -285,19 +321,10 @@ class TestDemographicEventsHaveExtraLLParameter:
     """
 
     def test_demographic_events_have_param(self):
-        events = [
-            msprime.PopulationParametersChange(1.0, population=1, initial_size=2.0),
-            msprime.MigrationRateChange(1.0, 1.0),
-            msprime.MassMigration(1.0, source=0, dest=1),
-            msprime.PopulationSplit(1.0, derived=[0], ancestral=1),
-            msprime.SimpleBottleneck(1.0, 0),
-            msprime.InstantaneousBottleneck(1.0, 0),
-            msprime.CensusEvent(1.0),
-        ]
-        demography = msprime.Demography.isolated_model([1] * 10)
-        for event in events:
-            ll_config1 = event.get_ll_representation(demography=demography)
-            ll_config2 = event.get_ll_representation(None, demography=demography)
+        demography = all_events_example_demography()
+        for event in demography.events:
+            ll_config1 = event.get_ll_representation()
+            ll_config2 = event.get_ll_representation(None)
             assert ll_config1 == ll_config2
 
 
@@ -449,28 +476,15 @@ class TestZeroPopulationSize(unittest.TestCase):
             # Check ancient sampling.
             ([msprime.Sample(1, self.T), msprime.Sample(1, 0)], _msprime.LibraryError),
         ]:
-            with pytest.raises(err):
+            with pytest.raises(err, match="Bad sample"):
                 msprime.simulate(
                     population_configurations=self.population_configurations,
                     demographic_events=self.demographic_events,
                     samples=bad_samples * 10,
                 )
 
-    def test_demography_debugger(self):
-        msprime.DemographyDebugger(
-            population_configurations=self.population_configurations,
-            demographic_events=self.demographic_events,
-        )
 
-        with pytest.raises(ValueError):
-            msprime.DemographyDebugger(
-                population_configurations=[
-                    msprime.PopulationConfiguration(initial_size=0)
-                ]
-            )
-
-
-class TestDeprecatedParameters:
+class TestDeprecatedInterfaces:
     """
     Tests to check that aliased parameters are handled correctly.
     """
@@ -526,6 +540,35 @@ class TestDeprecatedParameters:
             assert e.growth_rate == 0.1
             assert e.population == j
 
+    def test_epoch_demographic_events(self):
+        demography = msprime.Demography.isolated_model([10] * 2)
+        demography.add_migration_rate_change(0.1, rate=1)
+        dbg = demography.debug()
+        assert dbg.num_epochs == 2
+        for epoch in dbg.epochs:
+            assert epoch.demographic_events == epoch.events
+
+
+class TestEventsWithoutDemography:
+    """
+    Tests for "raw" DemographicEvent objects that are not associated
+    with a Demography. These are supported for legacy reasons - downstream
+    code like stdpopsim relied on them.
+    """
+
+    def test_convert_id(self):
+        event = msprime.DemographicEvent(0.0)
+        for j in range(5):
+            assert event._convert_id(j) == j
+            numpy_val = np.array([j])[0]
+            assert event._convert_id(numpy_val) == j
+
+        assert event._convert_id(-1) == -1
+        assert event._convert_id(None) == -1
+
+        with pytest.raises(ValueError, match="legacy-only operation"):
+            event._convert_id("pop_0")
+
 
 class TestLowLevelRepresentation:
     """
@@ -538,23 +581,11 @@ class TestLowLevelRepresentation:
     https://github.com/tskit-dev/msprime/issues/1037
     """
 
-    def test_size_change_no_demography(self):
-        g = 100
-        new_size = 512
-        event = msprime.PopulationParametersChange(time=g, initial_size=new_size)
-        ll_event = {
-            "type": "population_parameters_change",
-            "time": g,
-            "population": -1,
-            "initial_size": new_size,
-        }
-        assert event.get_ll_representation() == ll_event
-
     def test_size_change(self):
         g = 100
         new_size = 512
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.PopulationParametersChange(
+        event = demography.add_population_parameters_change(
             time=g, initial_size=new_size, population="pop_0"
         )
         ll_event = {
@@ -563,27 +594,13 @@ class TestLowLevelRepresentation:
             "population": 0,
             "initial_size": new_size,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-
-    def test_growth_rate_change_no_demography(self):
-        g = 512
-        growth_rate = 1
-        event = msprime.PopulationParametersChange(
-            time=g, growth_rate=growth_rate, population=1
-        )
-        ll_event = {
-            "type": "population_parameters_change",
-            "time": g,
-            "population": 1,
-            "growth_rate": growth_rate,
-        }
         assert event.get_ll_representation() == ll_event
 
     def test_growth_rate_change(self):
         g = 512
         growth_rate = 1
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.PopulationParametersChange(
+        event = demography.add_population_parameters_change(
             time=g, growth_rate=growth_rate, population="pop_1"
         )
         ll_event = {
@@ -592,20 +609,20 @@ class TestLowLevelRepresentation:
             "population": 1,
             "growth_rate": growth_rate,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.PopulationParametersChange(
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_population_parameters_change(
             time=g,
             growth_rate=growth_rate,
             population=1,
         )
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
 
     def test_growth_rate_and_size_change(self):
         g = 1024
         growth_rate = 2
         initial_size = 8192
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.PopulationParametersChange(
+        event = demography.add_population_parameters_change(
             time=g, initial_size=initial_size, growth_rate=growth_rate, population=1
         )
         ll_event = {
@@ -615,26 +632,13 @@ class TestLowLevelRepresentation:
             "initial_size": initial_size,
             "growth_rate": growth_rate,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-
-    def test_migration_rate_change_no_demography(self):
-        g = 1024
-        migration_rate = 0.125
-        event = msprime.MigrationRateChange(time=g, rate=migration_rate)
-        ll_event = {
-            "type": "migration_rate_change",
-            "time": g,
-            "source": -1,
-            "dest": -1,
-            "migration_rate": migration_rate,
-        }
         assert event.get_ll_representation() == ll_event
 
     def test_migration_rate_change(self):
         g = 1024
         migration_rate = 0.125
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.MigrationRateChange(
+        event = demography.add_migration_rate_change(
             time=g, source="pop_0", dest="pop_1", rate=migration_rate
         )
         ll_event = {
@@ -644,18 +648,18 @@ class TestLowLevelRepresentation:
             "dest": 1,
             "migration_rate": migration_rate,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.MigrationRateChange(
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_migration_rate_change(
             time=g, source=0, dest=1, rate=migration_rate
         )
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
 
     def test_migration_rate_change_all_pops(self):
         g = 1024
         migration_rate = 0.125
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.MigrationRateChange(
-            time=g, source=-1, dest=-1, rate=migration_rate
+        event = demography.add_migration_rate_change(
+            time=g, source=None, dest=None, rate=migration_rate
         )
         ll_event = {
             "type": "migration_rate_change",
@@ -664,15 +668,15 @@ class TestLowLevelRepresentation:
             "dest": -1,
             "migration_rate": migration_rate,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.MigrationRateChange(time=g, rate=migration_rate)
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_migration_rate_change(time=g, rate=migration_rate)
+        assert event.get_ll_representation() == ll_event
 
     def test_symmetric_migration_rate_change(self):
         g = 1024
         migration_rate = 0.125
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.SymmetricMigrationRateChange(
+        event = demography.add_symmetric_migration_rate_change(
             time=g, populations=["pop_0", "pop_1"], rate=migration_rate
         )
         ll_event = {
@@ -681,16 +685,16 @@ class TestLowLevelRepresentation:
             "populations": [0, 1],
             "rate": migration_rate,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.SymmetricMigrationRateChange(
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_symmetric_migration_rate_change(
             time=g, populations=[0, 1], rate=migration_rate
         )
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
 
     def test_mass_migration(self):
         g = 1234
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.MassMigration(
+        event = demography.add_mass_migration(
             time=g, source="pop_0", dest="pop_1", proportion=0.5
         )
         ll_event = {
@@ -700,42 +704,68 @@ class TestLowLevelRepresentation:
             "dest": 1,
             "proportion": 0.5,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.MassMigration(time=g, source=0, dest=1, proportion=0.5)
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_mass_migration(time=g, source=0, dest=1, proportion=0.5)
+        assert event.get_ll_representation() == ll_event
 
     def test_population_split(self):
         g = 1234
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.PopulationSplit(time=g, derived=["pop_0"], ancestral="pop_1")
+        event = demography.add_population_split(
+            time=g, derived=["pop_0"], ancestral="pop_1"
+        )
         ll_event = {
             "type": "population_split",
             "time": g,
             "derived": [0],
             "ancestral": 1,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.PopulationSplit(time=g, derived=[0], ancestral=1)
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_population_split(time=g, derived=[0], ancestral="pop_1")
+        assert event.get_ll_representation() == ll_event
+
+    def test_admixture(self):
+        g = 1234
+        demography = msprime.Demography.isolated_model([10] * 10)
+        event = demography.add_admixture(
+            time=g,
+            derived="pop_0",
+            ancestral=["pop_1", "pop_2"],
+            proportions=[0.25, 0.75],
+        )
+        ll_event = {
+            "type": "admixture",
+            "time": g,
+            "derived": 0,
+            "ancestral": [1, 2],
+            "proportions": [0.25, 0.75],
+        }
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_admixture(
+            time=g, derived=0, ancestral=[1, 2], proportions=[0.25, 0.75]
+        )
+        assert event.get_ll_representation() == ll_event
 
     def test_simple_bottleneck(self):
         g = 1234
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.SimpleBottleneck(time=g, population="pop_0", proportion=0.5)
+        event = demography.add_simple_bottleneck(
+            time=g, population="pop_0", proportion=0.5
+        )
         ll_event = {
             "type": "simple_bottleneck",
             "time": g,
             "population": 0,
             "proportion": 0.5,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.SimpleBottleneck(time=g, population=0, proportion=0.5)
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_simple_bottleneck(time=g, population=0, proportion=0.5)
+        assert event.get_ll_representation() == ll_event
 
     def test_instantaneous_bottleneck(self):
         g = 1234
         demography = msprime.Demography.isolated_model([10] * 10)
-        event = msprime.InstantaneousBottleneck(
+        event = demography.add_instantaneous_bottleneck(
             time=g, population="pop_0", strength=0.5
         )
         ll_event = {
@@ -744,9 +774,11 @@ class TestLowLevelRepresentation:
             "population": 0,
             "strength": 0.5,
         }
-        assert event.get_ll_representation(demography=demography) == ll_event
-        event = msprime.InstantaneousBottleneck(time=g, population=0, strength=0.5)
-        assert event.get_ll_representation(demography=demography) == ll_event
+        assert event.get_ll_representation() == ll_event
+        event = demography.add_instantaneous_bottleneck(
+            time=g, population=0, strength=0.5
+        )
+        assert event.get_ll_representation() == ll_event
 
 
 class TestDemographyDebugger:
@@ -798,7 +830,7 @@ class TestDemographyDebugger:
         assert dd.epoch_times[0] == 0
         assert dd.population_size_history.shape[0] == 1
         assert math.isinf(e.end_time)
-        assert len(e.demographic_events) == 0
+        assert len(e.events) == 0
         assert len(e.populations) == 1
         assert e.migration_matrix == [[0]]
         pop = e.populations[0]
@@ -821,7 +853,7 @@ class TestDemographyDebugger:
         assert dd.population_size_history[0][0] == 10
         assert dd.population_size_history[1][0] == 20
         assert math.isinf(e.end_time)
-        assert len(e.demographic_events) == 0
+        assert len(e.events) == 0
         assert len(e.populations) == 2
         np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
         for pop in e.populations:
@@ -835,7 +867,7 @@ class TestDemographyDebugger:
         g2 = 0.5
         p0_end_size = 10 * math.exp(-g1 * 10)
         p1_end_size = 20 * math.exp(-g2 * 10)
-        dd = msprime.DemographyDebugger(
+        demog = msprime.Demography.from_old_style(
             population_configurations=[
                 msprime.PopulationConfiguration(initial_size=10, growth_rate=g1),
                 msprime.PopulationConfiguration(initial_size=20, growth_rate=g2),
@@ -844,6 +876,7 @@ class TestDemographyDebugger:
                 msprime.PopulationParametersChange(time=10, growth_rate=0)
             ],
         )
+        dd = demog.debug()
         self.verify_arrays(dd)
         # Make sure we're testing the __repr__ paths.
         s = repr(dd)
@@ -852,7 +885,7 @@ class TestDemographyDebugger:
         e = dd.epochs[0]
         assert e.start_time == 0
         assert e.end_time == 10
-        assert len(e.demographic_events) == 0
+        assert len(e.events) == 0
         assert len(e.populations) == 2
         np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
         assert e.populations[0].start_size == 10
@@ -863,8 +896,8 @@ class TestDemographyDebugger:
         e = dd.epochs[1]
         assert e.start_time == 10
         assert math.isinf(e.end_time)
-        assert len(e.demographic_events) == 1
-        d = e.demographic_events[0]
+        assert len(e.events) == 1
+        d = e.events[0]
         assert d.time == 10
         assert d.growth_rate == 0
         assert d.initial_size is None
@@ -903,8 +936,8 @@ class TestDemographyDebugger:
         e = dd.epochs[1]
         assert e.start_time == 20
         assert e.end_time, 22
-        assert len(e.demographic_events) == 1
-        d = e.demographic_events[0]
+        assert len(e.events) == 1
+        d = e.events[0]
         assert d.source == -1
         assert d.dest == -1
         assert d.time == 20
@@ -919,8 +952,8 @@ class TestDemographyDebugger:
         e = dd.epochs[2]
         assert e.start_time == 22
         assert math.isinf(e.end_time)
-        assert len(e.demographic_events) == 1
-        d = e.demographic_events[0]
+        assert len(e.events) == 1
+        d = e.events[0]
         assert d.source == 0
         assert d.dest == 1
         assert d.time == 22
@@ -967,7 +1000,7 @@ class TestDemographyDebugger:
             assert e.end_time == t1
             assert dd.epoch_times[0] == 0
             assert dd.epoch_times[1] == t1
-            assert len(e.demographic_events) == 0
+            assert len(e.events) == 0
             assert len(e.populations) == 2
             np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             assert e.populations[0].start_size == N0
@@ -979,7 +1012,7 @@ class TestDemographyDebugger:
             e = dd.epochs[1]
             assert e.start_time == t1
             assert e.end_time == t2
-            assert len(e.demographic_events) == 1
+            assert len(e.events) == 1
             assert len(e.populations) == 2
             np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             assert e.populations[0].start_size == n0
@@ -992,7 +1025,7 @@ class TestDemographyDebugger:
             e = dd.epochs[2]
             assert e.start_time == t2
             assert e.end_time == t3
-            assert len(e.demographic_events) == 1
+            assert len(e.events) == 1
             assert len(e.populations) == 2
             np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             assert e.populations[0].start_size == n0
@@ -1005,7 +1038,7 @@ class TestDemographyDebugger:
             e = dd.epochs[3]
             assert e.start_time == t3
             assert math.isinf(e.end_time)
-            assert len(e.demographic_events) == 1
+            assert len(e.events) == 1
             assert len(e.populations) == 2
             np.testing.assert_array_equal(e.migration_matrix, [[0, 0], [0, 0]])
             assert e.populations[0].start_size == n0
@@ -1045,20 +1078,20 @@ class TestDemographicEventMessages:
     def test_population_parameters_change(self):
         event = msprime.PopulationParametersChange(1.0, population=1, initial_size=2.0)
         assert event._parameters() == "population=1, initial_size=2.0"
-        assert event._effect() == "initial_size → 2.0 for population 1"
+        assert event._effect() == "initial_size → 2 for population 1"
 
         event = msprime.PopulationParametersChange(
             1.0, population="XX", growth_rate=2.0
         )
         assert event._parameters() == "population=XX, growth_rate=2.0"
-        assert event._effect() == "growth_rate → 2.0 for population XX"
+        assert event._effect() == "growth_rate → 2 for population XX"
 
         event = msprime.PopulationParametersChange(
             1.0, population=0, initial_size=3, growth_rate=2.0
         )
         assert event._parameters() == "population=0, initial_size=3, growth_rate=2.0"
         assert (
-            event._effect() == "initial_size → 3 and growth_rate → 2.0 for population 0"
+            event._effect() == "initial_size → 3 and growth_rate → 2 for population 0"
         )
 
         for pop in [None, -1]:
@@ -1066,7 +1099,7 @@ class TestDemographicEventMessages:
                 1.0, population=pop, growth_rate=2.0
             )
             assert event._parameters() == "population=-1, growth_rate=2.0"
-            assert event._effect() == "growth_rate → 2.0 for all populations"
+            assert event._effect() == "growth_rate → 2 for all populations"
 
     def test_migration_rate_change(self):
         event = msprime.MigrationRateChange(time=1, rate=2)
@@ -1099,24 +1132,44 @@ class TestDemographicEventMessages:
         assert event._parameters() == "derived=[0], ancestral=2"
         assert event._effect() == (
             "Moves all lineages from the '0' derived population to the "
-            "ancestral '2' population. Also set all migration rates to and "
-            "from '0' to zero."
+            "ancestral '2' population. Also set '0' to inactive, and "
+            "all migration rates to and from the derived population to zero."
         )
 
         event = msprime.PopulationSplit(time=1, derived=[0, 1], ancestral=2)
         assert event._parameters() == "derived=[0, 1], ancestral=2"
         assert event._effect() == (
             "Moves all lineages from derived populations '0' and '1' to the "
-            "ancestral '2' population. Also set all migration rates to and "
-            "from the derived populations to zero."
+            "ancestral '2' population. Also set the derived populations to inactive, "
+            "and all migration rates to and from the derived populations to zero."
         )
 
         event = msprime.PopulationSplit(time=1, derived=[0, 1, 2], ancestral=3)
         assert event._parameters() == "derived=[0, 1, 2], ancestral=3"
         assert event._effect() == (
             "Moves all lineages from derived populations [0, 1, 2] to the "
-            "ancestral '3' population. Also set all migration rates to and "
-            "from the derived populations to zero."
+            "ancestral '3' population. Also set the derived populations to inactive, "
+            "and all migration rates to and from the derived populations to zero."
+        )
+
+    def test_admixture(self):
+        event = msprime.Admixture(time=1, derived=0, ancestral=[1], proportions=[1])
+        assert event._parameters() == "derived=0 ancestral=[1] proportions=[1.00]"
+        assert event._effect() == (
+            "Moves all lineages from admixed population '0' to ancestral population. "
+            "Lineages move to '1' with proba 1. Set '0' to inactive, and all "
+            "migration rates to and from '0' to zero."
+        )
+        event = msprime.Admixture(
+            time=1, derived=0, ancestral=[1, 2], proportions=[1 / 4, 3 / 4]
+        )
+        assert (
+            event._parameters() == "derived=0 ancestral=[1, 2] proportions=[0.25, 0.75]"
+        )
+        assert event._effect() == (
+            "Moves all lineages from admixed population '0' to ancestral populations. "
+            "Lineages move to '1' with proba 0.25; '2' with proba 0.75. "
+            "Set '0' to inactive, and all migration rates to and from '0' to zero."
         )
 
     def test_mass_migration(self):
@@ -1163,10 +1216,8 @@ class DebugOutputBase:
 
     def test_one_population(self):
         demography = msprime.Demography.isolated_model([10])
-        demography.events = [
-            msprime.PopulationParametersChange(0.1, initial_size=2),
-            msprime.PopulationParametersChange(0.1, growth_rate=10),
-        ]
+        demography.add_population_parameters_change(0.1, initial_size=2),
+        demography.add_population_parameters_change(0.1, growth_rate=10),
         self.verify(demography)
 
     def test_no_events(self):
@@ -1187,40 +1238,18 @@ class DebugOutputBase:
         self.verify(demography)
 
     def test_all_events(self):
-        demography = msprime.Demography.isolated_model([1, 1])
-        demography.events = [
-            msprime.PopulationParametersChange(0.1, initial_size=2),
-            msprime.PopulationParametersChange(0.1, growth_rate=10),
-            msprime.MigrationRateChange(0.2, source=0, dest=1, rate=1),
-            msprime.MigrationRateChange(0.2, matrix_index=(1, 0), rate=1),
-            msprime.SymmetricMigrationRateChange(0.3, populations=[0, 1], rate=0.5),
-            msprime.MassMigration(0.4, source=1, dest=0),
-            msprime.PopulationSplit(0.4, derived=[1], ancestral=0),
-            msprime.MigrationRateChange(0.4, rate=0),
-            msprime.InstantaneousBottleneck(0.5, population=0, strength=100),
-            msprime.CensusEvent(0.55),
-            msprime.SimpleBottleneck(0.56, population=1, proportion=0.1),
-        ]
+        demography = all_events_example_demography(integer_ids=True)
         self.verify(demography)
 
     def test_all_events_string_names(self):
-        demography = msprime.Demography.isolated_model([1, 1])
-        demography.events = [
-            msprime.PopulationParametersChange(0.1, population="pop_0", initial_size=2),
-            msprime.PopulationParametersChange(0.1, population="pop_0", growth_rate=10),
-            msprime.MigrationRateChange(0.2, source="pop_0", dest="pop_1", rate=1),
-            msprime.MigrationRateChange(0.2, source="pop_1", dest="pop_0", rate=1),
-            msprime.SymmetricMigrationRateChange(
-                0.3, populations=["pop_0", "pop_1"], rate=0.5
-            ),
-            msprime.MassMigration(0.4, source="pop_1", dest="pop_0"),
-            msprime.PopulationSplit(0.4, derived=["pop_1"], ancestral="pop_0"),
-            msprime.MigrationRateChange(0.4, rate=0),
-            msprime.InstantaneousBottleneck(0.5, population="pop_0", strength=100),
-            msprime.CensusEvent(0.55),
-            msprime.SimpleBottleneck(0.56, population="pop_1", proportion=0.1),
-        ]
+        demography = all_events_example_demography()
         self.verify(demography)
+
+    def test_ooa_model(self):
+        self.verify(msprime.Demography._ooa_model())
+
+    def test_american_admixture_model(self):
+        self.verify(msprime.Demography._american_admixture_model())
 
 
 class TestDemographyHtml(DebugOutputBase):
@@ -1291,11 +1320,11 @@ class TestDemographyTextExamples:
             """\
         Demography
         ╟  Populations
-        ║  ┌────────────────────────────────────────────────────────────────────────┐
-        ║  │ id │name   │description  │initial_size  │ growth_rate │extra_metadata  │
-        ║  ├────────────────────────────────────────────────────────────────────────┤
-        ║  │ 0  │pop_0  │             │10.0          │     0.0     │{}              │
-        ║  └────────────────────────────────────────────────────────────────────────┘
+        ║  ┌────────────────────────────────────────────────────────────────────────────────────────┐
+        ║  │ id │name   │description  │initial_size  │ growth_rate │  sampling_time│extra_metadata  │
+        ║  ├────────────────────────────────────────────────────────────────────────────────────────┤
+        ║  │ 0  │pop_0  │             │10.0          │     0.0     │              0│{}              │
+        ║  └────────────────────────────────────────────────────────────────────────────────────────┘
         ╟  Migration Matrix
         ║  ┌───────────────┐
         ║  │       │ pop_0 │
@@ -1307,7 +1336,7 @@ class TestDemographyTextExamples:
         ║  │  time│type  │parameters  │effect  │
         ║  ├───────────────────────────────────┤
         ║  └───────────────────────────────────┘
-        """
+        """  # noqa: B950
         )
         assert out == str(demography)
 
@@ -1319,12 +1348,12 @@ class TestDemographyTextExamples:
             """\
         Demography
         ╟  Populations
-        ║  ┌────────────────────────────────────────────────────────────────────────┐
-        ║  │ id │name   │description  │initial_size  │ growth_rate │extra_metadata  │
-        ║  ├────────────────────────────────────────────────────────────────────────┤
-        ║  │ 0  │pop_0  │             │10.0          │     1.0     │{}              │
-        ║  │ 1  │pop_1  │             │20.0          │     2.0     │{}              │
-        ║  └────────────────────────────────────────────────────────────────────────┘
+        ║  ┌────────────────────────────────────────────────────────────────────────────────────────┐
+        ║  │ id │name   │description  │initial_size  │ growth_rate │  sampling_time│extra_metadata  │
+        ║  ├────────────────────────────────────────────────────────────────────────────────────────┤
+        ║  │ 0  │pop_0  │             │10.0          │     1.0     │              0│{}              │
+        ║  │ 1  │pop_1  │             │20.0          │     2.0     │              0│{}              │
+        ║  └────────────────────────────────────────────────────────────────────────────────────────┘
         ╟  Migration Matrix
         ║  ┌───────────────────────┐
         ║  │       │ pop_0 │ pop_1 │
@@ -1337,24 +1366,13 @@ class TestDemographyTextExamples:
         ║  │  time│type  │parameters  │effect  │
         ║  ├───────────────────────────────────┤
         ║  └───────────────────────────────────┘
-        """
+        """  # noqa: B950
         )
         assert out == str(demography)
 
+    @pytest.mark.skip("Skipping until events are stable.")
     def test_all_events(self):
-        demography = msprime.Demography.isolated_model([1, 1])
-        demography.events = [
-            msprime.PopulationParametersChange(0.1, initial_size=2),
-            msprime.PopulationParametersChange(0.1, growth_rate=10),
-            msprime.PopulationParametersChange(0.1, growth_rate=10, initial_size=1),
-            msprime.MigrationRateChange(0.2, matrix_index=(0, 1), rate=1),
-            msprime.MigrationRateChange(0.2, matrix_index=(1, 0), rate=1),
-            msprime.MassMigration(0.4, source=1, dest=0, proportion=0.9),
-            msprime.MigrationRateChange(0.4, rate=0),
-            msprime.InstantaneousBottleneck(0.5, population=0, strength=100),
-            msprime.CensusEvent(0.55),
-            msprime.SimpleBottleneck(0.56, population=1, proportion=0.1),
-        ]
+        demography = all_events_example_demography(integer_ids=True)
 
         out = textwrap.dedent(
             """\
@@ -3306,6 +3324,24 @@ class TestOldStylePopulationMetadata:
         }
         assert expected == pop.metadata
 
+    def test_old_style_metadata_name_conflicts(self):
+        demography = msprime.Demography()
+        md = {"name": "x"}
+        pc = msprime.PopulationConfiguration(initial_size=1, metadata=md)
+        with pytest.raises(ValueError, match="doesn't match"):
+            demography._add_population_from_old_style(pc, name="y")
+
+    def test_old_style_metadata_name(self):
+        demography = msprime.Demography()
+        md = {"name": "x"}
+        pc = msprime.PopulationConfiguration(initial_size=1, metadata=md)
+        pop = demography._add_population_from_old_style(pc)
+        assert pop.name == "x"
+
+        pc = msprime.PopulationConfiguration(initial_size=1)
+        pop = demography._add_population_from_old_style(pc, name="y")
+        assert pop.name == "y"
+
     def test_old_style_metadata_name_is_merged(self):
         md = {"name": "y"}
         demography = msprime.Demography.from_old_style(
@@ -4025,6 +4061,10 @@ class TestDemographyObject:
         assert not (m1 != m1)
         assert m1 is not None
         assert m1 != []
+        # Validation fills out defaults, so won't be strictly equal
+        assert m1.validate() != m1
+        assert m1.validate() == m1.validate()
+        assert m1.validate() == m2.validate()
 
         m3 = msprime.Demography.island_model([1, 1], 1 / 3 + 0.001)
         assert m1 != m3
@@ -4034,9 +4074,9 @@ class TestDemographyObject:
         assert m1 != msprime.Demography.isolated_model([1, 1])
         assert m1 != msprime.Demography.island_model([2, 1], 1 / 3)
 
-        m1.events.append(msprime.SymmetricMigrationRateChange(1, [0, 1], 0.1))
+        m1.add_event(msprime.SymmetricMigrationRateChange(1, [0, 1], 0.1))
         assert m1 != m2
-        m2.events.append(msprime.SymmetricMigrationRateChange(1, [0, 1], 0.1))
+        m2.add_event(msprime.SymmetricMigrationRateChange(1, [0, 1], 0.1))
         assert m1 == m2
         m1.events[0].rate = 0.01
         assert m1 != m2
@@ -4044,7 +4084,7 @@ class TestDemographyObject:
     def test_debug(self):
         model = msprime.Demography.island_model([1, 1], 1 / 3)
         dbg1 = model.debug()
-        assert dbg1.demography == model
+        assert dbg1.demography == model.validate()
         dbg2 = msprime.DemographyDebugger(demography=model)
         assert dbg1.demography == dbg2.demography
         assert str(dbg1) == str(dbg2)
@@ -4090,14 +4130,25 @@ class TestDemographyObject:
 
     def test_add_population_error(self):
         model = msprime.Demography.isolated_model([1])
-        with pytest.raises(TypeError, match="instance of Population"):
-            model.add_population(None)
-        pop = msprime.Population(10, id=1234)
-        with pytest.raises(ValueError, match="ID should not be set"):
-            model.add_population(pop)
-        pop = msprime.Population(10, name="pop_0")
         with pytest.raises(ValueError, match="Duplicate population name"):
-            model.add_population(pop)
+            model.add_population(name="pop_0")
+
+    def test_add_population_properties(self):
+        model = msprime.Demography()
+        pop = model.add_population(
+            initial_size=1234,
+            growth_rate=123,
+            name="XYZ",
+            description="asdf",
+            sampling_time=0.1234,
+            extra_metadata={"x": "y"},
+        )
+        assert pop.initial_size == 1234
+        assert pop.growth_rate == 123
+        assert pop.name == "XYZ"
+        assert pop.description == "asdf"
+        assert pop.sampling_time == 0.1234
+        assert pop.extra_metadata == {"x": "y"}
 
     def test_sidestepping_add_population(self):
         # It's possible for users to sidestep the add_population method.
@@ -4116,14 +4167,14 @@ class TestDemographyObject:
         model = msprime.Demography.island_model([1, 1], 0.1)
         M = np.array([[0, 0.1], [0.1, 0]])
         assert np.array_equal(model.migration_matrix, M)
-        model.add_population(msprime.Population(initial_size=1))
+        model.add_population(initial_size=1)
         M = np.array([[0, 0.1, 0], [0.1, 0, 0], [0, 0, 0]])
         assert np.array_equal(model.migration_matrix, M)
 
         model = msprime.Demography.island_model([1, 1, 1], 0.1)
         M = np.array([[0, 0.1, 0.1], [0.1, 0, 0.1], [0.1, 0.1, 0]])
         assert np.array_equal(model.migration_matrix, M)
-        model.add_population(msprime.Population(initial_size=1))
+        model.add_population(initial_size=1)
         M = np.array(
             [[0, 0.1, 0.1, 0], [0.1, 0, 0.1, 0], [0.1, 0.1, 0, 0], [0, 0, 0, 0]]
         )
@@ -4132,7 +4183,7 @@ class TestDemographyObject:
     def test_add_population_sequential(self):
         model = msprime.Demography()
         for j in range(5):
-            model.add_population(msprime.Population(1))
+            model.add_population(initial_size=1)
             model.validate()
             assert model.num_populations == j + 1
             assert np.all(model.migration_matrix == 0)
@@ -4147,15 +4198,22 @@ class TestDemographyObject:
         for bad_pop in [-1, -2, 2, "x", "AAA"]:
             with pytest.raises(KeyError):
                 demography[bad_pop]
+            assert bad_pop not in demography
         for bad_type in [b"sdf", 1.0]:
             with pytest.raises(TypeError):
                 demography[bad_type]
+            with pytest.raises(TypeError):
+                bad_type in demography
         # String name lookup works
         assert demography["pop_0"] == demography.populations[0]
+        assert "pop_0" in demography
         assert demography["pop_1"] == demography.populations[1]
+        assert "pop_1" in demography
         # As does integer lookup
         assert demography[0] == demography.populations[0]
+        assert 0 in demography
         assert demography[1] == demography.populations[1]
+        assert 1 in demography
         # Numpy integer types are OK too.
         int_array = np.array([0, 1], dtype=np.int8)
         assert demography[int_array[0]] == demography.populations[0]
@@ -4217,6 +4275,29 @@ class TestDemographyObject:
         assert np.array_equal(
             demography1.migration_matrix, demography2.migration_matrix
         )
+
+    def test_events_out_of_order(self):
+        demography = msprime.Demography.isolated_model([10] * 2)
+        demography.add_population_parameters_change(2, initial_size=1)
+        demography.add_population_parameters_change(1, initial_size=5)
+        demography.add_population_parameters_change(1, growth_rate=0.5)
+        with pytest.raises(ValueError, match="Events must be time-sorted"):
+            demography.debug()
+        demography.sort_events()
+        dbg = demography.debug()
+        assert dbg.num_epochs == 3
+
+        other = msprime.Demography.isolated_model([10] * 2)
+        other.add_population_parameters_change(1, initial_size=5)
+        other.add_population_parameters_change(1, growth_rate=0.5)
+        other.add_population_parameters_change(2, initial_size=1)
+        assert other == demography
+
+    def test_sidestepping_add_event(self):
+        demography = msprime.Demography.isolated_model([10] * 2)
+        demography.events = [None]
+        with pytest.raises(TypeError, match="DemographicEvent instances"):
+            demography.debug()
 
     def test_isolated_model(self):
         demography = msprime.Demography.isolated_model([2])
@@ -4287,6 +4368,27 @@ class TestDemographyObject:
         assert isinstance(demography, msprime.Demography)
         assert demography.populations[0].name == "spc12"
 
+    def test_validate_resolves_defaults(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="C", initial_size=100)
+        demography.set_symmetric_migration_rate(["A", "B"], 0.1)
+        demography.add_population_split(10, derived=["A", "B"], ancestral="C")
+        assert demography["A"].sampling_time is None
+        assert demography["B"].sampling_time is None
+        assert demography["C"].sampling_time == 10
+        assert demography["A"].initially_active is None
+        assert demography["B"].initially_active is None
+        assert not demography["C"].initially_active
+        validated = demography.validate()
+        assert validated["A"].sampling_time == 0
+        assert validated["B"].sampling_time == 0
+        assert validated["C"].sampling_time == 10
+        assert validated["A"].initially_active
+        assert validated["B"].initially_active
+        assert not validated["C"].initially_active
+
 
 class TestDemographyFromOldStyle:
     """
@@ -4332,24 +4434,17 @@ class TestDemographyFromOldStyle:
         assert list(demog.migration_matrix) == [[0]]
         assert events == demog.events
 
-
-class TestPopulationFromOldStyle:
-    """
-    Tests the method for creating a Population object from the old
-    style PopulationConfiguration.
-    """
-
-    # TODO figure out what to do with metadata
-
-    def test_defaults(self):
+    def test_population_defaults(self):
         pop_config = msprime.PopulationConfiguration()
-        pop = msprime.Population.from_old_style(pop_config)
+        demog = msprime.Demography.from_old_style([pop_config])
+        pop = demog.populations[0]
         assert pop.initial_size == 1
         assert pop_config.growth_rate == pop.growth_rate
 
     def test_Ne(self):
         pop_config = msprime.PopulationConfiguration()
-        pop = msprime.Population.from_old_style(pop_config, Ne=1234)
+        demog = msprime.Demography.from_old_style([pop_config], Ne=1234)
+        pop = demog.populations[0]
         assert pop.initial_size == 1234
         assert pop_config.growth_rate == pop.growth_rate
 
@@ -4357,7 +4452,8 @@ class TestPopulationFromOldStyle:
         pop_config = msprime.PopulationConfiguration(
             initial_size=1234, growth_rate=5678
         )
-        pop = msprime.Population.from_old_style(pop_config)
+        demog = msprime.Demography.from_old_style([pop_config], Ne=1234)
+        pop = demog.populations[0]
         assert pop_config.initial_size == pop.initial_size
         assert pop_config.growth_rate == pop.growth_rate
 
@@ -4370,29 +4466,43 @@ class TestPopulationNamesInEvents:
 
     def test_mass_migration(self):
         demography = msprime.Demography.isolated_model([1000, 1000])
-        demography.events = [msprime.MassMigration(1, source=0, dest=1, proportion=1)]
+        demography.add_mass_migration(1, source=0, dest=1, proportion=1)
         ts1 = msprime.sim_ancestry(
             {0: 1, 1: 1}, demography=demography, random_seed=1234
         )
 
-        demography.events = [
-            msprime.MassMigration(1, source="pop_0", dest="pop_1", proportion=1)
-        ]
+        demography = msprime.Demography.isolated_model([1000, 1000])
+        demography.add_mass_migration(1, source="pop_0", dest="pop_1", proportion=1)
         ts2 = msprime.sim_ancestry(
             {0: 1, 1: 1}, demography=demography, random_seed=1234
         )
         assert ts1.equals(ts2, ignore_provenance=True)
 
+    def test_admixture(self):
+        demography = msprime.Demography.isolated_model([1000, 1000, 1000, 1000])
+        demography.add_admixture(1, derived=0, ancestral=[1, 2], proportions=[0.5, 0.5])
+        demography.add_population_split(2, derived=[1, 2], ancestral=3)
+        ts1 = msprime.sim_ancestry({0: 10}, demography=demography, random_seed=1234)
+
+        demography = msprime.Demography.isolated_model([1000, 1000, 1000, 1000])
+        demography.add_admixture(
+            1, derived="pop_0", ancestral=["pop_1", "pop_2"], proportions=[0.5, 0.5]
+        )
+        demography.add_population_split(2, derived=[1, 2], ancestral=3)
+        ts2 = msprime.sim_ancestry({0: 10}, demography=demography, random_seed=1234)
+        assert ts1.equals(ts2, ignore_provenance=True)
+
     def test_population_split(self):
-        demography = msprime.Demography.isolated_model([1000, 1000])
-        demography.events = [msprime.PopulationSplit(1, derived=[0], ancestral=1)]
+        demography = msprime.Demography.isolated_model([1000, 1000, 1000])
+        demography.add_population_split(1, derived=[0, 1], ancestral=2)
         ts1 = msprime.sim_ancestry(
             {0: 1, 1: 1}, demography=demography, random_seed=1234
         )
 
-        demography.events = [
-            msprime.PopulationSplit(1, derived=["pop_0"], ancestral="pop_1")
-        ]
+        demography = msprime.Demography.isolated_model([1000, 1000, 1000])
+        demography.add_population_split(
+            1, derived=["pop_0", "pop_1"], ancestral="pop_2"
+        )
         ts2 = msprime.sim_ancestry(
             {0: 1, 1: 1}, demography=demography, random_seed=1234
         )
@@ -4400,13 +4510,13 @@ class TestPopulationNamesInEvents:
 
     def test_migration_rate_change(self):
         demography = msprime.Demography.isolated_model([1000, 1000])
-        demography.events = [msprime.MigrationRateChange(1, source=0, dest=1, rate=1)]
+        demography.add_migration_rate_change(1, source=0, dest=1, rate=1)
         ts1 = msprime.sim_ancestry(
             {0: 1, 1: 1}, demography=demography, random_seed=1234
         )
-        demography.events = [
-            msprime.MigrationRateChange(1, source="pop_0", dest="pop_1", rate=1)
-        ]
+
+        demography = msprime.Demography.isolated_model([1000, 1000])
+        demography.add_migration_rate_change(1, source="pop_0", dest="pop_1", rate=1)
         ts2 = msprime.sim_ancestry(
             {0: 1, 1: 1}, demography=demography, random_seed=1234
         )
@@ -4414,38 +4524,33 @@ class TestPopulationNamesInEvents:
 
     def test_population_parameters_change(self):
         demography = msprime.Demography.isolated_model([1000, 1000])
-        demography.events = [
-            msprime.PopulationParametersChange(1, population=0, initial_size=100)
-        ]
+        demography.add_population_parameters_change(1, population=0, initial_size=100)
         ts1 = msprime.sim_ancestry({0: 1}, demography=demography, random_seed=1234)
 
-        demography.events = [
-            msprime.PopulationParametersChange(1, population="pop_0", initial_size=100)
-        ]
+        demography = msprime.Demography.isolated_model([1000, 1000])
+        demography.add_population_parameters_change(
+            1, population="pop_0", initial_size=100
+        )
         ts2 = msprime.sim_ancestry({0: 1}, demography=demography, random_seed=1234)
         assert ts1.equals(ts2, ignore_provenance=True)
 
     def test_simple_bottleneck(self):
         demography = msprime.Demography.isolated_model([1000, 1000])
-        demography.events = [msprime.SimpleBottleneck(1, population=0, proportion=1)]
+        demography.add_simple_bottleneck(1, population=0, proportion=1)
         ts1 = msprime.sim_ancestry({0: 1}, demography=demography, random_seed=1234)
 
-        demography.events = [
-            msprime.SimpleBottleneck(1, population="pop_0", proportion=1)
-        ]
+        demography = msprime.Demography.isolated_model([1000, 1000])
+        demography.add_simple_bottleneck(1, population="pop_0", proportion=1)
         ts2 = msprime.sim_ancestry({0: 1}, demography=demography, random_seed=1234)
         assert ts1.equals(ts2, ignore_provenance=True)
 
     def test_instantaneous_bottleneck(self):
         demography = msprime.Demography.isolated_model([1000, 1000])
-        demography.events = [
-            msprime.InstantaneousBottleneck(1, population=0, strength=1)
-        ]
+        demography.add_instantaneous_bottleneck(1, population=0, strength=1)
         ts1 = msprime.sim_ancestry({0: 1}, demography=demography, random_seed=1234)
 
-        demography.events = [
-            msprime.InstantaneousBottleneck(1, population="pop_0", strength=1)
-        ]
+        demography = msprime.Demography.isolated_model([1000, 1000])
+        demography.add_instantaneous_bottleneck(1, population="pop_0", strength=1)
         ts2 = msprime.sim_ancestry({0: 1}, demography=demography, random_seed=1234)
         assert ts1.equals(ts2, ignore_provenance=True)
 
@@ -4456,64 +4561,108 @@ class TestPopulationSplit:
     """
 
     def test_two_pop_tree(self):
-        demography = msprime.Demography(
-            [
-                msprime.Population(name="A", initial_size=100),
-                msprime.Population(name="B", initial_size=100),
-                msprime.Population(name="root", initial_size=100),
-            ]
-        )
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="AB", initial_size=100)
         demography.set_symmetric_migration_rate(["A", "B"], 0.1)
-        demography.events = [
-            msprime.PopulationSplit(10, derived=["A", "B"], ancestral="root")
-        ]
+        demography.add_population_split(10, derived=["A", "B"], ancestral="AB")
+        assert demography["A"].sampling_time is None
+        assert demography["B"].sampling_time is None
+        assert demography["AB"].sampling_time == 10
         dbg = demography.debug()
         assert len(dbg.epochs) == 2
         assert dbg.epochs[1].start_time == 10
         assert np.all(dbg.epochs[1].migration_matrix == 0)
+        for derived in dbg.epochs[1].populations[:2]:
+            assert derived.start_size == 0
+            assert derived.end_size == 0
+            assert derived.growth_rate == 0
+            assert not derived.active
+        ancestral = dbg.epochs[1].populations[-1]
+        assert ancestral.start_size == 100
+        assert ancestral.end_size == 100
+        assert ancestral.growth_rate == 0
+        assert ancestral.active
+        ts = msprime.sim_ancestry(
+            {"A": 1, "B": 1}, demography=demography, random_seed=32
+        )
+        assert ts.tables.nodes.time[-1] > 10
+
+    def test_two_pop_merge_initially_active(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100, initially_active=True)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population_split(1, derived=["B"], ancestral="A")
+        debug = demography.debug()
+        assert debug.epochs[0].populations[0].active
+        assert debug.epochs[0].populations[1].active
+        assert debug.epochs[1].populations[0].active
+        assert not debug.epochs[1].populations[1].active
+
+    def test_two_pop_tree_growth_rates(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=10000, growth_rate=0.01)
+        demography.add_population(name="B", initial_size=10000, growth_rate=0.01)
+        demography.add_population(name="AB", initial_size=100000, growth_rate=0.005)
+        demography.set_symmetric_migration_rate(["A", "B"], 0.1)
+        demography.add_population_split(2, derived=["A", "B"], ancestral="AB")
+        assert demography["A"].sampling_time is None
+        assert demography["B"].sampling_time is None
+        assert demography["AB"].sampling_time == 2
+        dbg = demography.debug()
+        assert len(dbg.epochs) == 2
+        assert dbg.epochs[1].start_time == 2
+        assert np.all(dbg.epochs[1].migration_matrix == 0)
+        for derived in dbg.epochs[1].populations[:2]:
+            assert derived.start_size == 0
+            assert derived.end_size == 0
+            assert derived.growth_rate == 0
+        ancestral = dbg.epochs[1].populations[-1]
+        assert ancestral.growth_rate == 0.005
         ts = msprime.sim_ancestry(
             {"A": 1, "B": 1}, demography=demography, random_seed=32
         )
         assert ts.tables.nodes.time[-1] > 10
 
     def test_three_pop_tree(self):
-        demography = msprime.Demography(
-            [
-                msprime.Population(name="A", initial_size=100),
-                msprime.Population(name="B", initial_size=100),
-                msprime.Population(name="C", initial_size=100),
-                msprime.Population(name="root", initial_size=100),
-            ]
-        )
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="C", initial_size=100)
+        demography.add_population(name="ABC", initial_size=100)
         demography.set_symmetric_migration_rate(["A", "B", "C"], 0.1)
-        demography.events = [
-            msprime.PopulationSplit(10, derived=["A", "B", "C"], ancestral="root")
-        ]
+        demography.add_population_split(10, derived=["A", "B", "C"], ancestral="ABC")
         dbg = demography.debug()
         assert len(dbg.epochs) == 2
         assert dbg.epochs[1].start_time == 10
         assert np.all(dbg.epochs[1].migration_matrix == 0)
+        for derived in dbg.epochs[1].populations[:3]:
+            assert derived.start_size == 0
+            assert derived.end_size == 0
+            assert derived.growth_rate == 0
+        ancestral = dbg.epochs[1].populations[-1]
+        assert ancestral.start_size == 100
+        assert ancestral.end_size == 100
+        assert ancestral.growth_rate == 0
         ts = msprime.sim_ancestry(
             {"A": 1, "B": 1, "C": 1}, demography=demography, random_seed=32
         )
         assert ts.tables.nodes.time[-1] > 10
 
     def test_three_pop_binary_tree(self):
-        demography = msprime.Demography(
-            [
-                msprime.Population(name="A", initial_size=100),
-                msprime.Population(name="B", initial_size=100),
-                msprime.Population(name="C", initial_size=100),
-                msprime.Population(name="AB", initial_size=100),
-                msprime.Population(name="ABC", initial_size=100),
-            ]
-        )
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="C", initial_size=100)
+        demography.add_population(name="AB", initial_size=100)
+        demography.add_population(name="ABC", initial_size=100)
         demography.set_symmetric_migration_rate(["A", "B", "C"], 0.1)
-        demography.events = [
-            msprime.PopulationSplit(10, derived=["A", "B"], ancestral="AB"),
-            msprime.SymmetricMigrationRateChange(10, populations=["C", "AB"], rate=0.1),
-            msprime.PopulationSplit(20, derived=["AB", "C"], ancestral="ABC"),
-        ]
+        demography.add_population_split(10, derived=["A", "B"], ancestral="AB")
+        demography.add_symmetric_migration_rate_change(
+            10, populations=["C", "AB"], rate=0.1
+        )
+        demography.add_population_split(20, derived=["AB", "C"], ancestral="ABC")
         dbg = demography.debug()
         assert len(dbg.epochs) == 3
         assert dbg.epochs[1].start_time == 10
@@ -4529,26 +4678,22 @@ class TestPopulationSplit:
         assert ts.tables.nodes.time[-1] > 20
 
     def test_four_pop_binary_tree(self):
-        demography = msprime.Demography(
-            [
-                msprime.Population(name="A", initial_size=100),
-                msprime.Population(name="B", initial_size=100),
-                msprime.Population(name="C", initial_size=100),
-                msprime.Population(name="D", initial_size=100),
-                msprime.Population(name="AB", initial_size=100),
-                msprime.Population(name="CD", initial_size=100),
-                msprime.Population(name="ABCD", initial_size=100),
-            ]
-        )
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="C", initial_size=100)
+        demography.add_population(name="D", initial_size=100)
+        demography.add_population(name="AB", initial_size=100)
+        demography.add_population(name="CD", initial_size=100)
+        demography.add_population(name="ABCD", initial_size=100)
         demography.set_symmetric_migration_rate(["A", "B", "C", "D"], 0.1)
-        demography.events = [
-            msprime.PopulationSplit(10, derived=["A", "B"], ancestral="AB"),
-            msprime.PopulationSplit(20, derived=["C", "D"], ancestral="CD"),
-            msprime.SymmetricMigrationRateChange(
-                20, populations=["CD", "AB"], rate=0.1
-            ),
-            msprime.PopulationSplit(30, derived=["AB", "CD"], ancestral="ABCD"),
-        ]
+
+        demography.add_population_split(10, derived=["A", "B"], ancestral="AB")
+        demography.add_population_split(20, derived=["C", "D"], ancestral="CD")
+        demography.add_symmetric_migration_rate_change(
+            20, populations=["CD", "AB"], rate=0.1
+        )
+        demography.add_population_split(30, derived=["AB", "CD"], ancestral="ABCD")
         dbg = demography.debug()
         assert len(dbg.epochs) == 4
         assert dbg.epochs[1].start_time == 10
@@ -4568,58 +4713,1457 @@ class TestPopulationSplit:
         assert ts.tables.nodes.time[-1] > 30
         assert ts.tables.nodes.population[-1] == 6
 
-
-def test_ooa():
-    # This test is temporary while we are updating stdpopsim to use the
-    # msprime APIs. See the nodes in the _ooa_model() code.
-    demog_local = msprime.Demography._ooa_model()
-    debug_local = demog_local.debug()
-    model_sps = stdpopsim.get_species("HomSap").get_demographic_model(
-        "OutOfAfrica_3G09"
-    )
-    demog_sps = msprime.Demography.from_old_style(
-        model_sps.population_configurations,
-        migration_matrix=model_sps.migration_matrix,
-        demographic_events=model_sps.demographic_events,
-    )
-    debug_sps = demog_sps.debug()
-
-    # Map from local population names into the equivalent in the stdpopsim
-    # model, per epoch.
-    epoch_pop_map = [
-        ["YRI", "CEU", "CHB"],
-        ["YRI", "OOA"],
-        ["AMH"],
-        ["ANC"],
-    ]
-    assert len(epoch_pop_map) == debug_sps.num_epochs
-    assert debug_local.num_epochs == debug_sps.num_epochs
-    # In epoch 0 the top corner of the migration matrix should be
-    # the same.
-    assert np.array_equal(
-        debug_local.epochs[0].migration_matrix[:3, :3],
-        debug_sps.epochs[0].migration_matrix,
-    )
-    assert np.all(debug_local.epochs[0].migration_matrix[3:, 3:] == 0)
-    # There's only migration between OOA and YRI in epoch 1
-    M = debug_local.epochs[1].migration_matrix.copy()
-    assert M[0, 3] == debug_sps.epochs[1].migration_matrix[0, 1]
-    assert M[3, 0] == debug_sps.epochs[1].migration_matrix[1, 0]
-    M[0, 3] = 0
-    M[3, 0] = 0
-    assert np.all(M == 0)
-
-    for pop_map, epoch_local, epoch_sps in zip(
-        epoch_pop_map, debug_local.epochs, debug_sps.epochs
-    ):
-        assert epoch_local.start_time == epoch_sps.start_time
-        assert epoch_local.end_time == epoch_sps.end_time
-        for pop_id_sps, local_pop_name in enumerate(pop_map):
-            pop_id_local = demog_local[local_pop_name].id
-            assert (
-                epoch_local.populations[pop_id_local]
-                == epoch_sps.populations[pop_id_sps]
+    def test_lineages_move_into_derived(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="AB", initial_size=100)
+        demography.set_symmetric_migration_rate(["A", "B"], 0.1)
+        demography.add_population_split(10, derived=["A", "B"], ancestral="AB")
+        demography.add_mass_migration(10, source="AB", dest="A", proportion=1)
+        with pytest.raises(_msprime.LibraryError, match="inactive population"):
+            msprime.sim_ancestry(
+                {"A": 1, "B": 1}, demography=demography, random_seed=32
             )
-        if len(pop_map) == 1:
-            assert np.all(epoch_local.migration_matrix == 0)
-            assert np.all(epoch_sps.migration_matrix == 0)
+
+    def test_sample_derived(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="AB", initial_size=100)
+        demography.set_symmetric_migration_rate(["A", "B"], 0.1)
+        demography.add_population_split(10, derived=["A", "B"], ancestral="AB")
+        with pytest.raises(_msprime.LibraryError, match="inactive population"):
+            msprime.sim_ancestry(
+                samples=[
+                    msprime.SampleSet(1, "A"),
+                    msprime.SampleSet(1, "B"),
+                    msprime.SampleSet(1, "A", time=11),
+                ],
+                demography=demography,
+                random_seed=32,
+            )
+
+    def test_sample_ancestral(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="AB", initial_size=100)
+        demography.add_population_split(10, derived=["A", "B"], ancestral="AB")
+        with pytest.raises(_msprime.LibraryError, match="inactive population"):
+            msprime.sim_ancestry(
+                samples=[
+                    msprime.SampleSet(1, "A"),
+                    msprime.SampleSet(1, "B"),
+                    msprime.SampleSet(1, "AB", time=5),  # Before split
+                ],
+                demography=demography,
+                random_seed=32,
+            )
+
+    @pytest.mark.parametrize("n", range(2, 13))
+    def test_random_population_tree(self, n):
+        ts = msprime.sim_ancestry(n, ploidy=1, random_seed=52)
+        demography = msprime.Demography.isolated_model([10] * ts.num_nodes)
+        tree = ts.first()
+        for node in tree.nodes(order="timeasc"):
+            if tree.is_internal(node):
+                demography.add_population_split(
+                    time=tree.time(node), derived=tree.children(node), ancestral=node
+                )
+
+        dbg = demography.debug()
+        epoch = dbg.epochs[0]
+        assert epoch.start_time == 0
+        assert len(epoch.events) == 0
+        for u in tree.nodes():
+            if tree.is_leaf(u):
+                assert epoch.populations[u].active
+            else:
+                assert not epoch.populations[u].active
+
+        sm = msprime.PopulationStateMachine
+        for epoch in dbg.epochs[1:]:
+            ancestral = epoch.events[0].ancestral
+            assert tree.time(ancestral) == epoch.start_time
+            assert epoch.populations[ancestral].active
+            assert epoch.populations[ancestral].state == sm.ACTIVE
+            # All the populations older than ancestal should be
+            # inactive
+            u = tree.parent(ancestral)
+            while u != tskit.NULL:
+                assert not epoch.populations[u].active
+                assert epoch.populations[u].state == sm.INACTIVE
+                u = tree.parent(u)
+            # All populations below ancestral should be previously active.
+            for u in tree.nodes(ancestral):
+                if u != ancestral:
+                    assert not epoch.populations[u].active
+                    assert epoch.populations[u].state == sm.PREVIOUSLY_ACTIVE
+        assert math.isinf(epoch.end_time)
+
+    def test_record_migrations(self):
+        demography = msprime.Demography.isolated_model([10] * 2)
+        demography.add_population_split(0.01, derived=[0], ancestral=1)
+        ts = msprime.sim_ancestry(
+            {0: 10}, demography=demography, record_migrations=True, random_seed=1234
+        )
+        assert ts.tables.nodes.population[-1] == 1
+        assert ts.num_migrations > 1
+        for migration in ts.migrations():
+            assert migration.source == 0
+            assert migration.dest == 1
+            assert migration.time == 0.01
+
+    def test_multi_split_3_pop(self):
+        #   | <-
+        #   |  |
+        #   2  |
+        #   ^  |
+        #   |  |
+        #   0  1
+        demography = msprime.Demography.isolated_model([10] * 3)
+        demography.add_population_split(time=1, ancestral=2, derived=[0])
+        demography.add_population_split(time=2, ancestral=2, derived=[1])
+        dbg = demography.debug()
+        assert dbg.num_epochs == 3
+        ts = msprime.sim_ancestry({0: 1, 1: 1}, demography=demography, random_seed=1234)
+        assert ts.tables.nodes.population[-1] == 2
+
+    def test_multi_split_4_pop(self):
+        #   | <---
+        #   |  | |
+        #   3  | |
+        #   ^  | |
+        #   |  | |
+        #   0  1 2
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_population_split(time=1, ancestral=3, derived=[0])
+        demography.add_population_split(time=2, ancestral=3, derived=[1, 2])
+        dbg = demography.debug()
+        assert dbg.num_epochs == 3
+        ts = msprime.sim_ancestry(
+            {0: 1, 1: 1, 2: 1}, demography=demography, random_seed=1234
+        )
+        assert ts.tables.nodes.population[-1] == 3
+
+    def test_multi_split_sample_pop(self):
+        #   | <--
+        #   |   |
+        #   |   3
+        #   |  | |
+        #   |  | |
+        #   0  1 2
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_population_split(time=1, ancestral=3, derived=[1, 2])
+        demography.add_population_split(time=2, ancestral=0, derived=[3])
+        dbg = demography.debug()
+        assert dbg.demography[0].sampling_time == 2
+        assert dbg.num_epochs == 3
+        assert not dbg.epochs[0].populations[0].active
+        assert dbg.epochs[0].populations[1].active
+        assert dbg.epochs[0].populations[2].active
+        # We can't sample from 0 because it is assumed to be inactive
+        with pytest.raises(_msprime.InputError, match="sample .* inactive population"):
+            msprime.sim_ancestry(
+                [msprime.SampleSet(1, population=0, time=0)],
+                demography=demography,
+                random_seed=1234,
+            )
+        ts = msprime.sim_ancestry(
+            {0: 1, 1: 1, 2: 1}, demography=demography, random_seed=1234
+        )
+        assert ts.tables.nodes.population[-1] == 0
+
+    def test_multi_split_4_pop_sequential(self):
+        #   | <---
+        #   | <- |
+        #   |  | |
+        #   3  | |
+        #   ^  | |
+        #   |  | |
+        #   0  1 2
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_population_split(time=1, ancestral=3, derived=[0])
+        demography.add_population_split(time=2, ancestral=3, derived=[1])
+        demography.add_population_split(time=3, ancestral=3, derived=[2])
+        dbg = demography.debug()
+        assert dbg.num_epochs == 4
+        ts = msprime.sim_ancestry(
+            {0: 1, 1: 1, 2: 1}, demography=demography, random_seed=1234
+        )
+        assert ts.tables.nodes.population[-1] == 3
+
+    def test_sampling_time_not_overwritten_in_ancestral(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A", initial_size=100)
+        demography.add_population(name="B", initial_size=100)
+        demography.add_population(name="C", initial_size=100, sampling_time=12)
+        demography.add_population_split(10, derived=["A", "B"], ancestral="C")
+        assert demography["A"].sampling_time is None
+        assert demography["B"].sampling_time is None
+        assert demography["C"].sampling_time == 12
+        validated = demography.validate()
+        assert validated["A"].sampling_time == 0
+        assert validated["B"].sampling_time == 0
+        assert validated["C"].sampling_time == 12
+
+
+class TestAdmixture:
+    """
+    Tests for the admixture functionality.
+    """
+
+    def test_proportions_sum_to_one(self):
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_admixture(
+            1, derived=0, ancestral=[1, 2], proportions=[1 / 3, 2 / 3]
+        )
+        assert math.isclose(sum(demography.events[0].proportions), 1)
+
+        for N in range(1, 100):
+            demography = msprime.Demography.isolated_model([10] * (N + 1))
+            demography.add_admixture(
+                1, derived=N, ancestral=range(N), proportions=[1 / N] * N
+            )
+            assert math.isclose(sum(demography.events[0].proportions), 1)
+
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_admixture(
+            1, derived=0, ancestral=[1, 2, 3], proportions=[0.1, 0.1, 0.8]
+        )
+        assert math.isclose(sum(demography.events[0].proportions), 1)
+
+        demography = msprime.Demography.isolated_model([10] * 4)
+        with pytest.raises(ValueError, match="Sum of the admixture proportions"):
+            # Arguably this is too strict, but we can relax later if needs be.
+            # However, probably more useful to allow the N - 1 form, and compute
+            # the remaining value, than to have a high tolerance for error.
+            demography.add_admixture(
+                1, derived=0, ancestral=[1, 2, 3], proportions=[0.33, 0.33, 0.33]
+            )
+
+    def test_4_pop_diamond(self):
+        #     3
+        #    / \
+        #   1   2
+        #    \ /
+        #     0
+        # Equal probabilities of going either direction
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_admixture(
+            1, derived=0, ancestral=[1, 2], proportions=[1 / 2, 1 / 2]
+        )
+        demography.add_population_split(2, derived=[1, 2], ancestral=3)
+        ts = msprime.sim_ancestry({0: 100}, demography=demography, random_seed=1234)
+        # We should have coalescences in all 4 populations
+        assert set(ts.tables.nodes.population) == set(range(4))
+        assert ts.tables.nodes.population[-1] == 3
+
+        # Only go via pop 1
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_admixture(1, derived=0, ancestral=[1, 2], proportions=[1, 0])
+        demography.add_population_split(2, derived=[1, 2], ancestral=3)
+        ts = msprime.sim_ancestry({0: 100}, demography=demography, random_seed=1234)
+        # We should have no coalescences in 2
+        assert set(ts.tables.nodes.population) == {0, 1, 3}
+        assert ts.tables.nodes.population[-1] == 3
+
+        # Only go via pop 2
+        demography = msprime.Demography.isolated_model([10] * 4)
+        demography.add_admixture(1, derived=0, ancestral=[1, 2], proportions=[0, 1])
+        demography.add_population_split(2, derived=[1, 2], ancestral=3)
+        ts = msprime.sim_ancestry({0: 100}, demography=demography, random_seed=1234)
+        # We should have no coalescences in 1
+        assert set(ts.tables.nodes.population) == {0, 2, 3}
+        assert ts.tables.nodes.population[-1] == 3
+
+    def test_multi_admixture(self):
+        #     4
+        #    / \
+        #   2   3
+        #   | x |
+        #   0   1
+        # Two different admixed populations from the same sources.
+        demography = msprime.Demography.isolated_model([10] * 5)
+        demography.add_admixture(
+            1, derived=0, ancestral=[2, 3], proportions=[1 / 2, 1 / 2]
+        )
+        demography.add_admixture(
+            1, derived=1, ancestral=[2, 3], proportions=[2 / 3, 1 / 3]
+        )
+        demography.add_population_split(3, derived=[2, 3], ancestral=4)
+        ts = msprime.sim_ancestry(
+            {0: 100, 1: 100}, demography=demography, random_seed=1234
+        )
+        # We should have coalescences in all 5 populations
+        assert set(ts.tables.nodes.population) == set(range(5))
+        assert ts.tables.nodes.population[-1] == 4
+
+    def test_admix_into_ancestral(self):
+        #          7
+        #         / \
+        #   |------->
+        #   |--> 5   6
+        #   | x / \ / \
+        #   0   1 2 3 4
+        # Amixture where ancestral populations are from population splits.
+        demography = msprime.Demography.isolated_model([10] * 8)
+        demography.add_population_split(1, derived=[3, 4], ancestral=6)
+        demography.add_population_split(1, derived=[1, 2], ancestral=5)
+        demography.add_admixture(
+            2, derived=0, ancestral=[5, 6], proportions=[1 / 2, 1 / 2]
+        )
+        demography.add_population_split(3, derived=[5, 6], ancestral=7)
+        ts = msprime.sim_ancestry(
+            {0: 100, 1: 100}, demography=demography, random_seed=1234
+        )
+        assert ts.tables.nodes.population[-1] == 7
+
+    def test_1_pop_admix(self):
+        demography = msprime.Demography.isolated_model([10] * 2)
+        demography.add_admixture(1, derived=0, ancestral=[1], proportions=[1])
+        ts = msprime.sim_ancestry({0: 100}, demography=demography, random_seed=1234)
+        assert ts.tables.nodes.population[-1] == 1
+
+    def test_record_migrations(self):
+        demography = msprime.Demography.isolated_model([10] * 2)
+        demography.add_admixture(0.01, derived=0, ancestral=[1], proportions=[1])
+        ts = msprime.sim_ancestry(
+            {0: 10}, demography=demography, record_migrations=True, random_seed=1234
+        )
+        assert ts.tables.nodes.population[-1] == 1
+        assert ts.num_migrations > 1
+        for migration in ts.migrations():
+            assert migration.source == 0
+            assert migration.dest == 1
+            assert migration.time == 0.01
+
+
+class TestPopulationLoops:
+    def verify_loop_error(self, demography):
+        msg = "derived population in a population split must be active"
+        with pytest.raises(
+            _msprime.InputError, match="sample a lineage from an inactive"
+        ):
+            msprime.sim_ancestry({0: 1}, demography=demography)
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            demography.debug()
+
+    def test_ABA_loop(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A")
+        demography.add_population(name="B")
+        demography.add_population_split(1, derived=["A"], ancestral="B")
+        demography.add_population_split(2, derived=["B"], ancestral="A")
+        self.verify_loop_error(demography)
+
+    def test_ABA_admixture_loop(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A")
+        demography.add_population(name="B")
+        demography.add_admixture(0.1, derived="A", ancestral=["B"], proportions=[1])
+        demography.add_admixture(0.2, derived="B", ancestral=["A"], proportions=[1])
+        msg = "All ancestral populations in admixture must already be active"
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            demography.debug()
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            msprime.sim_ancestry(
+                {"A": 10, "B": 10}, demography=demography, random_seed=123
+            )
+
+    def test_admixture_derived_inactive(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A")
+        demography.add_population(name="B")
+        demography.add_population(name="C")
+        demography.add_population_split(0.1, derived=["A"], ancestral="B")
+        demography.add_admixture(0.2, derived="A", ancestral=["C"], proportions=[1])
+        msg = "derived population in an admixture must be active"
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            demography.debug()
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            msprime.sim_ancestry(
+                {"A": 10, "B": 10}, demography=demography, random_seed=123
+            )
+
+    def test_admixture_ancestral_inactive(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A")
+        demography.add_population(name="B")
+        demography.add_population(name="C")
+        demography.add_population_split(0.1, derived=["A"], ancestral="B")
+        demography.add_admixture(0.2, derived="C", ancestral=["A"], proportions=[1])
+        msg = "ancestral populations in admixture must already be active"
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            demography.debug()
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            msprime.sim_ancestry(
+                {"A": 10, "C": 10}, demography=demography, random_seed=123
+            )
+
+    def test_ABCA_loop(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A")
+        demography.add_population(name="B")
+        demography.add_population(name="C")
+        demography.add_population_split(1, derived=["A"], ancestral="B")
+        demography.add_population_split(2, derived=["B"], ancestral="C")
+        demography.add_population_split(3, derived=["C"], ancestral="A")
+        self.verify_loop_error(demography)
+
+    @pytest.mark.parametrize("n", range(2, 8))
+    def test_line_loop(self, n):
+        demography = msprime.Demography.isolated_model([1] * n)
+        for j in range(n):
+            if j < n - 1:
+                demography.add_population_split(j + 1, derived=[j], ancestral=j + 1)
+
+        demography.add_population_split(n, derived=[n - 1], ancestral=0)
+        self.verify_loop_error(demography)
+
+    def test_ABCDB_loop(self):
+        demography = msprime.Demography()
+        demography.add_population(name="A")
+        demography.add_population(name="B")
+        demography.add_population(name="C")
+        demography.add_population(name="D")
+        demography.add_population_split(1, derived=["A"], ancestral="B")
+        demography.add_population_split(2, derived=["B"], ancestral="C")
+        demography.add_population_split(3, derived=["C"], ancestral="D")
+        demography.add_population_split(3, derived=["D"], ancestral="B")
+        msg = "Attempt to set a previously active population to active"
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            msprime.sim_ancestry({0: 1, 2: 1}, demography=demography, random_seed=1)
+        with pytest.raises(_msprime.LibraryError, match=msg):
+            demography.debug()
+
+
+class TestNormaliseLineageMovements:
+    """
+    Tests for the function to normalise events that result in lineage
+    movements into equivalent MassMigrations.
+    """
+
+    def test_single_mass_migration(self):
+        demography = msprime.Demography.isolated_model([10] * 10)
+        mm = msprime.MassMigration(time=1, source=1, dest=0, proportion=0.2)
+        assert demography._normalise_lineage_movements([mm]) == {
+            1: [msprime.LineageMovement(1, 0, 0.2)]
+        }
+
+    def test_filter_other_events(self):
+        demography = msprime.Demography.isolated_model([10] * 10)
+        events = [
+            msprime.CensusEvent(0.1),
+            msprime.PopulationParametersChange(0.1, growth_rate=10, initial_size=1),
+            msprime.MigrationRateChange(0.1, rate=0),
+            msprime.SymmetricMigrationRateChange(0.1, [0, 1], rate=0),
+            msprime.InstantaneousBottleneck(0.1, population=0, strength=100),
+            msprime.SimpleBottleneck(0.1, population=1, proportion=0.1),
+            # Just include the mass migration here.
+            msprime.MassMigration(time=0.1, source=1, dest=0, proportion=0.2),
+        ]
+        # Only lineage movements are included.
+        assert demography._normalise_lineage_movements(events) == {
+            1: [msprime.LineageMovement(1, 0, 0.2)]
+        }
+
+    def test_convert_population_split(self):
+        demography = msprime.Demography.isolated_model([10] * 10)
+        events = [msprime.PopulationSplit(0.1, [0], 2)]
+        equiv = {
+            0: [msprime.LineageMovement(0, 2, 1.0)],
+        }
+        assert equiv == demography._normalise_lineage_movements(events)
+
+        events = [msprime.PopulationSplit(0.1, [0, 1], 2)]
+        equiv = {
+            0: [msprime.LineageMovement(0, 2, 1.0)],
+            1: [msprime.LineageMovement(1, 2, 1.0)],
+        }
+        assert equiv == demography._normalise_lineage_movements(events)
+
+        events = [msprime.PopulationSplit(0.1, [1, 0], 2)]
+        assert equiv == demography._normalise_lineage_movements(events)
+
+        events = [msprime.PopulationSplit(0.1, [1, 0, 3], 2)]
+        equiv = {
+            0: [msprime.LineageMovement(0, 2, 1.0)],
+            1: [msprime.LineageMovement(1, 2, 1.0)],
+            3: [msprime.LineageMovement(3, 2, 1.0)],
+        }
+        assert equiv == demography._normalise_lineage_movements(events)
+
+    def test_convert_admixture(self):
+        demography = msprime.Demography.isolated_model([10] * 10)
+        demography.add_admixture(time=0.1, derived=0, ancestral=[1], proportions=[1])
+        equiv = {
+            0: [msprime.LineageMovement(0, 1, 1.0)],
+        }
+        assert equiv == demography._normalise_lineage_movements(demography.events)
+
+        demography = msprime.Demography.isolated_model([10] * 10)
+        demography.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2], proportions=[0, 1]
+        )
+        equiv = {
+            0: [msprime.LineageMovement(0, 1, 0.0), msprime.LineageMovement(0, 2, 1.0)]
+        }
+        assert equiv == demography._normalise_lineage_movements(demography.events)
+
+        demography = msprime.Demography.isolated_model([10] * 10)
+        demography.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[0.25, 0.25, 0.5]
+        )
+        equiv = {
+            0: [
+                msprime.LineageMovement(0, 1, 0.25),
+                msprime.LineageMovement(0, 2, 1 / 3),
+                msprime.LineageMovement(0, 3, 1),
+            ]
+        }
+        assert equiv == demography._normalise_lineage_movements(demography.events)
+
+        # We reorder the populations by ID
+        demography = msprime.Demography.isolated_model([10] * 10)
+        demography.add_admixture(
+            time=0.1, derived=0, ancestral=[3, 2, 1], proportions=[0.5, 0.25, 0.25]
+        )
+        equiv = {
+            0: [
+                msprime.LineageMovement(0, 1, 0.25),
+                msprime.LineageMovement(0, 2, 1 / 3),
+                msprime.LineageMovement(0, 3, 1),
+            ]
+        }
+        assert equiv == demography._normalise_lineage_movements(demography.events)
+
+
+class TestProportionConversion:
+    """
+    Tests for the conversion of absolute and sequential proportions.
+    """
+
+    def verify_round_trip(self, P):
+        C = msprime.demography._proportions_to_sequential(P)
+        # assert math.isclose(C[-1], total)
+        assert np.all(np.array(C) >= 0)
+        Pp = msprime.demography._sequential_to_proportions(C)
+        np.allclose(P, Pp)
+
+    def test_simple(self):
+        assert msprime.demography._proportions_to_sequential([1]) == [1]
+        assert msprime.demography._sequential_to_proportions([1]) == [1]
+        assert msprime.demography._proportions_to_sequential([0.25, 0.25, 0.5]) == [
+            0.25,
+            1 / 3,
+            1,
+        ]
+        assert msprime.demography._sequential_to_proportions([0.25, 1 / 3, 1]) == [
+            0.25,
+            0.25,
+            0.5,
+        ]
+
+    @pytest.mark.parametrize(
+        "P",
+        [
+            [1],
+            [1 / 2, 1 / 2],
+            [1 / 3] * 3,
+            [1 / 6] * 6,
+            [2 / 6, 1 / 6, 2 / 6, 1 / 6],
+            np.ones(100) / 100,
+        ],
+    )
+    def test_simple_examples(self, P):
+        self.verify_round_trip(P)
+
+    @pytest.mark.parametrize("n", [1, 10, 100, 1000])
+    def test_random(self, n):
+        rng = np.random.default_rng(n)
+        z = rng.random(n)
+        self.verify_round_trip(z / np.sum(z))
+
+    @pytest.mark.parametrize(
+        "P",
+        [
+            [0.1],
+            [1 / 2, 1 / 4],
+            [1 / 3] * 2,
+            [1 / 6] * 5,
+            [1 / 6, 1 / 6, 2 / 6, 1 / 6],
+            np.ones(100) / 100,
+        ],
+    )
+    def test_examples_less_than_1(self, P):
+        self.verify_round_trip(P)
+
+
+class TestDemographyEquivalent:
+    """
+    Tests for the function to normalise events that result in lineage
+    movements into equivalent MassMigrations.
+    """
+
+    def test_different_population_parameters(self):
+        d1 = msprime.Demography.isolated_model([1, 1])
+        d2 = msprime.Demography.isolated_model([1, 1])
+        d1.assert_equivalent(d2)
+        assert d1.is_equivalent(d2)
+        d2 = msprime.Demography.isolated_model([1, 2])
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(AssertionError, match="1.0 ≠ 2.0"):
+            d1.assert_equivalent(d2)
+        d2 = msprime.Demography.isolated_model([1, 1], growth_rate=[0.1, 0.1])
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(AssertionError, match="growth_rate not equal"):
+            d1.assert_equivalent(d2)
+
+    def test_different_migration_rates(self):
+        d1 = msprime.Demography.stepping_stone_model([1, 1], migration_rate=0.1)
+        d2 = msprime.Demography.stepping_stone_model([1, 1], migration_rate=0.1)
+        d1.assert_equivalent(d2)
+        assert d1.is_equivalent(d2)
+        d2 = msprime.Demography.stepping_stone_model([1, 1], migration_rate=0.2)
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(AssertionError, match="Migration matrices"):
+            d1.assert_equivalent(d2)
+
+        d1 = msprime.Demography.stepping_stone_model([1, 1, 1], migration_rate=0.1)
+        d2 = msprime.Demography.stepping_stone_model([1, 1, 1], migration_rate=0.1)
+        d2.set_migration_rate(source=0, dest=1, rate=0.5)
+        with pytest.raises(AssertionError, match="pop_0, pop_1"):
+            d1.assert_equivalent(d2)
+
+    def test_different_names(self):
+        d1 = msprime.Demography()
+        d1.add_population(name="x")
+        d2 = msprime.Demography()
+        d2.add_population(name="y")
+        with pytest.raises(AssertionError, match="names differ"):
+            d1.assert_equivalent(d2)
+
+    def test_population_split(self):
+        d1 = msprime.Demography.isolated_model([1, 1, 1])
+        d1.add_population_split(1.0, derived=[0, 1], ancestral=2)
+        assert d1.is_equivalent(d1)
+
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_split(1.0, derived=[0, 1], ancestral=2)
+        assert d1.is_equivalent(d2)
+
+        # The order of derived populations in a split isn't significant.
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_split(1.0, derived=[1, 0], ancestral=2)
+        d1.assert_equivalent(d2)
+
+        # The equivilant mass migrations aren't the same as the population
+        # states don't match.
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_mass_migration(1.0, source=0, dest=2, proportion=1.0)
+        d2.add_mass_migration(1.0, source=1, dest=2, proportion=1.0)
+        assert not d1.is_equivalent(d2)
+
+    def test_different_num_epochs(self):
+        d1 = msprime.Demography.isolated_model([1, 1, 1])
+        d1.add_migration_rate_change(1.0, rate=1)
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(AssertionError, match="Number of epochs not equal: 2 ≠ 1"):
+            d1.assert_equivalent(d2)
+
+    def test_different_num_populations(self):
+        d1 = msprime.Demography.isolated_model([1, 1, 1])
+        d2 = msprime.Demography.isolated_model([1, 1])
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(
+            AssertionError, match="Number of populations not equal: 3 ≠ 2"
+        ):
+            d1.assert_equivalent(d2)
+
+    def test_different_sampling_times(self):
+        d1 = msprime.Demography.isolated_model([1, 1])
+        d2 = msprime.Demography.isolated_model([1, 1])
+        d1[0].sampling_time = 0.01
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(
+            AssertionError, match="Sampling times not equal for pop_0: 0.01 ≠ 0"
+        ):
+            d1.assert_equivalent(d2)
+
+    def test_different_epoch_times(self):
+        d1 = msprime.Demography.isolated_model([1, 1, 1])
+        d1.add_population_parameters_change(1.0, initial_size=2)
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(2.0, initial_size=2)
+        assert not d1.is_equivalent(d2)
+        with pytest.raises(AssertionError, match="at different times: 1.0 ≠ 2.0"):
+            d1.assert_equivalent(d2)
+
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(1.00001, initial_size=2)
+        assert not d1.is_equivalent(d2)
+
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(1 + 1e-10, initial_size=2)
+        d1.assert_equivalent(d2)
+        with pytest.raises(AssertionError, match="at different times"):
+            d1.assert_equivalent(d2, rel_tol=1e-12)
+
+    def test_different_population_size_epoch(self):
+        d1 = msprime.Demography.isolated_model([1, 1, 1])
+        d1.add_population_parameters_change(time=1.0, initial_size=2)
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(time=1.0, initial_size=3)
+        with pytest.raises(AssertionError, match="start_size not equal"):
+            d1.assert_equivalent(d2)
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(time=1.0, initial_size=2 + 1e-10)
+        d1.assert_equivalent(d2)
+
+    def test_different_growth_rate_epoch(self):
+        d1 = msprime.Demography.isolated_model([1, 1, 1])
+        d1.add_population_parameters_change(time=1.0, growth_rate=2)
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(time=1.0, growth_rate=3)
+        with pytest.raises(AssertionError, match="growth_rate not equal"):
+            d1.assert_equivalent(d2)
+        d2 = msprime.Demography.isolated_model([1, 1, 1])
+        d2.add_population_parameters_change(time=1.0, growth_rate=2 + 1e-10)
+        d1.assert_equivalent(d2)
+
+    def test_state_changes_unsupported(self):
+        d1 = msprime.Demography.isolated_model([1, 1])
+        d1.add_population_parameters_change(0.1, initial_size=1)
+        d2 = msprime.Demography.isolated_model([1, 1])
+        d2.add_simple_bottleneck(0.1, population=0, proportion=1)
+        with pytest.raises(ValueError, match="State change events"):
+            d1.assert_equivalent(d2)
+
+        d1 = msprime.Demography.isolated_model([1, 1])
+        d1.add_instantaneous_bottleneck(0.1, population=0, strength=1)
+        d2 = msprime.Demography.isolated_model([1, 1])
+        d2.add_population_parameters_change(0.1, initial_size=1)
+        with pytest.raises(ValueError, match="State change events"):
+            d1.assert_equivalent(d2)
+
+    def test_admixture(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[0.1, 0.2, 0.7]
+        )
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[0.1, 0.2, 0.7]
+        )
+        d1.assert_equivalent(d2)
+
+        # Robust to permutations
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_admixture(
+            time=0.1, derived=0, ancestral=[3, 2, 1], proportions=[0.7, 0.2, 0.1]
+        )
+        d1.assert_equivalent(d2)
+
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_admixture(
+            time=0.1, derived=0, ancestral=[2, 3, 1], proportions=[0.2, 0.7, 0.1]
+        )
+        d1.assert_equivalent(d2)
+
+        # We detect significantly different model
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[0.1, 0.21, 0.69]
+        )
+        assert not d1.is_equivalent(d2)
+
+    def test_admixture_equivalent_mass_migrations(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[1 / 3, 1 / 6, 1 / 2]
+        )
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_mass_migration(time=0.1, source=0, dest=1, proportion=1 / 3)
+        d2.add_mass_migration(time=0.1, source=0, dest=2, proportion=1 / 4)
+        d2.add_mass_migration(time=0.1, source=0, dest=3, proportion=1)
+        with pytest.raises(AssertionError, match="State mismatch"):
+            d1.assert_equivalent(d2)
+
+    def test_different_lineage_movement_dest(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[1 / 3, 1 / 6, 1 / 2]
+        )
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 4], proportions=[1 / 3, 1 / 6, 1 / 2]
+        )
+        with pytest.raises(AssertionError, match="movement destination"):
+            d1.assert_equivalent(d2)
+
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_mass_migration(time=0.1, source=0, dest=1, proportion=1)
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_mass_migration(time=0.1, source=0, dest=2, proportion=1)
+        with pytest.raises(AssertionError, match="movement destination"):
+            d1.assert_equivalent(d2)
+
+    def test_different_lineage_movement_source_pops(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_mass_migration(time=0.1, source=1, dest=0, proportion=1)
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_mass_migration(time=0.1, source=2, dest=0, proportion=1)
+        with pytest.raises(AssertionError, match="set of populations"):
+            d1.assert_equivalent(d2)
+
+    def test_different_lineage_movement_numbers_out(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_mass_migration(time=0.1, source=1, dest=0, proportion=0.5)
+        d1.add_mass_migration(time=0.1, source=1, dest=0, proportion=0.5)
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_mass_migration(time=0.1, source=1, dest=0, proportion=0.5)
+        with pytest.raises(
+            AssertionError, match="number of normalised lineage movements"
+        ):
+            d1.assert_equivalent(d2)
+
+    def test_different_lineage_movement_proportion(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_mass_migration(time=0.1, source=1, dest=0, proportion=0.5)
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_mass_migration(time=0.1, source=1, dest=0, proportion=0.51)
+        with pytest.raises(AssertionError, match="movement proportions"):
+            d1.assert_equivalent(d2)
+
+    def test_different_admixture_proportions(self):
+        d1 = msprime.Demography.isolated_model([10] * 10)
+        d1.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[1 / 3, 1 / 6, 1 / 2]
+        )
+        d2 = msprime.Demography.isolated_model([10] * 10)
+        d2.add_admixture(
+            time=0.1, derived=0, ancestral=[1, 2, 3], proportions=[1 / 2, 1 / 6, 1 / 3]
+        )
+        with pytest.raises(AssertionError, match="movement proportions"):
+            d1.assert_equivalent(d2)
+
+
+class TestFromOldStyleMap:
+    """
+    Tests for the conversion of populations into a new-style demography
+    using a map of population IDs, describing active populations in
+    each epoch and how they map to original populations.
+    """
+
+    def test_single_epoch(self):
+        d = msprime.Demography.from_old_style(
+            [msprime.PopulationConfiguration(initial_size=1)], population_map=[{"A": 0}]
+        )
+        assert d.num_populations == 1
+        assert d.debug().num_epochs == 1
+        assert "A" in d
+
+    def test_one_pop_size_changes(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[
+                msprime.PopulationParametersChange(1, initial_size=1),
+                msprime.PopulationParametersChange(2, initial_size=2),
+                msprime.PopulationParametersChange(3, initial_size=3),
+            ],
+            population_map=[{"A": 0}, {"A": 0}, {"A": 0}, {"A": 0}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population_parameters_change(1, population="A", initial_size=1)
+        d2.add_population_parameters_change(2, population="A", initial_size=2)
+        d2.add_population_parameters_change(3, population="A", initial_size=3)
+        d1.assert_equivalent(d2)
+
+    def test_initial_migration_rates(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            migration_matrix=[
+                [0, 0.1],
+                [0.2, 0],
+            ],
+            population_map=[{"A": 0, "B": 1}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B")
+        d2.set_migration_rate(source="A", dest="B", rate=0.1)
+        d2.set_migration_rate(source="B", dest="A", rate=0.2)
+        d1.assert_equivalent(d2)
+
+    def test_migration_rate_change(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[
+                msprime.MigrationRateChange(1, source=0, dest=1, rate=0.1),
+                msprime.MigrationRateChange(1, source=1, dest=0, rate=0.2),
+            ],
+            population_map=[{"A": 0, "B": 1}, {"A": 0, "B": 1}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B")
+        d2.add_migration_rate_change(time=1, source="A", dest="B", rate=0.1)
+        d2.add_migration_rate_change(time=1, source="B", dest="A", rate=0.2)
+        d1.assert_equivalent(d2)
+
+    def test_two_pop_tree(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[msprime.MassMigration(1, source=1, dest=0)],
+            population_map=[{"A": 0, "B": 1}, {"C": 0}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B")
+        d2.add_population(initial_size=1, name="C")
+        d2.add_population_split(1, derived=["A", "B"], ancestral="C")
+        d1.assert_equivalent(d2)
+
+        # Also same if we map C to 1
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[msprime.MassMigration(1, source=0, dest=1)],
+            population_map=[{"A": 0, "B": 1}, {"C": 1}],
+        )
+        d1.assert_equivalent(d2)
+
+    def test_two_pop_merge_into_first(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[msprime.MassMigration(1, source=1, dest=0)],
+            population_map=[{"A": 0, "B": 1}, {"A": 0}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A", initially_active=True)
+        d2.add_population(initial_size=1, name="B")
+        d2.add_population_split(1, derived=["B"], ancestral="A")
+        d1.assert_equivalent(d2)
+
+        # Try the other way around also
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[msprime.MassMigration(1, source=0, dest=1)],
+            population_map=[{"A": 0, "B": 1}, {"B": 1}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B", initially_active=True)
+        d2.add_population_split(1, derived=["A"], ancestral="B")
+        d1.assert_equivalent(d2)
+
+    def test_two_pop_tree_no_mass_migration(self):
+        with pytest.raises(ValueError, match="Insufficient MassMigrations"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                demographic_events=[
+                    msprime.MigrationRateChange(1, source=1, dest=0, rate=0)
+                ],
+                population_map=[{"A": 0, "B": 1}, {"C": 0}],
+            )
+
+    def test_two_pop_tree_incorrect_mass_migration(self):
+        with pytest.raises(ValueError, match="MassMigration associated with pop"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                demographic_events=[
+                    msprime.MassMigration(1, source=0, dest=1, proportion=0.1)
+                ],
+                population_map=[{"A": 0, "B": 1}, {"C": 0}],
+            )
+
+    def test_three_pop_multiple_splits(self):
+        # 1 and 2 sequentially merge into 0
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[
+                msprime.MassMigration(1, source=2, dest=0),
+                msprime.MassMigration(2, source=1, dest=0),
+            ],
+            population_map=[{"A": 0, "B": 1, "C": 2}, {"A": 0, "B": 1}, {"A": 0}],
+        )
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A", initially_active=True)
+        d2.add_population(initial_size=1, name="B")
+        d2.add_population(initial_size=1, name="C")
+        d2.add_population_split(1, derived=["C"], ancestral="A")
+        d2.add_population_split(2, derived=["B"], ancestral="A")
+        d1.assert_equivalent(d2)
+
+    def test_two_pop_admix(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[
+                msprime.MassMigration(1, source=2, dest=0, proportion=0.5),
+                msprime.MassMigration(1, source=2, dest=1, proportion=1),
+            ],
+            population_map=[{"A": 0, "B": 1, "C": 2}, {"A": 0, "B": 1}],
+        )
+
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B")
+        d2.add_population(initial_size=1, name="C")
+        d2.add_admixture(1, derived="C", ancestral=["A", "B"], proportions=[0.5, 0.5])
+        d1.assert_equivalent(d2)
+
+    def test_two_pop_admix_not_summing_to_one(self):
+        with pytest.raises(ValueError, match="don't sum to 1"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                demographic_events=[
+                    msprime.MassMigration(1, source=2, dest=0, proportion=0.5),
+                    msprime.MassMigration(1, source=2, dest=1, proportion=0.5),
+                ],
+                population_map=[{"A": 0, "B": 1, "C": 2}, {"A": 0, "B": 1}],
+            )
+
+    def test_two_pop_admix_plus_simultaneous_pulse(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[
+                msprime.MassMigration(1, source=2, dest=0, proportion=0.5),
+                msprime.MassMigration(1, source=2, dest=1, proportion=1),
+                # Pulse of migration from 3 into 0
+                msprime.MassMigration(1, source=3, dest=0, proportion=0.5),
+            ],
+            population_map=[{"A": 0, "B": 1, "C": 2, "D": 3}, {"A": 0, "B": 1, "D": 3}],
+        )
+
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B")
+        d2.add_population(initial_size=1, name="C")
+        d2.add_population(initial_size=1, name="D")
+        d2.add_admixture(1, derived="C", ancestral=["A", "B"], proportions=[0.5, 0.5])
+        d2.add_mass_migration(1, source="D", dest="A", proportion=0.5)
+        d1.assert_equivalent(d2)
+
+    def test_two_pop_admix_plus_simultaneous_pulse_with_split(self):
+        d1 = msprime.Demography.from_old_style(
+            [
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+                msprime.PopulationConfiguration(initial_size=1),
+            ],
+            demographic_events=[
+                msprime.MassMigration(1, source=2, dest=0, proportion=0.5),
+                msprime.MassMigration(1, source=2, dest=1, proportion=1),
+                # Pulse of migration from 3 into 0
+                msprime.MassMigration(1, source=3, dest=0, proportion=0.5),
+                # A, B, D merge into E
+                msprime.MassMigration(2, source=1, dest=0, proportion=1),
+                msprime.MassMigration(2, source=3, dest=0, proportion=1),
+            ],
+            population_map=[
+                {"A": 0, "B": 1, "C": 2, "D": 3},
+                {"A": 0, "B": 1, "D": 3},
+                {"E": 0},
+            ],
+        )
+
+        d2 = msprime.Demography()
+        d2.add_population(initial_size=1, name="A")
+        d2.add_population(initial_size=1, name="B")
+        d2.add_population(initial_size=1, name="C")
+        d2.add_population(initial_size=1, name="D")
+        d2.add_population(initial_size=1, name="E")
+        d2.add_admixture(1, derived="C", ancestral=["A", "B"], proportions=[0.5, 0.5])
+        d2.add_mass_migration(1, source="D", dest="A", proportion=0.5)
+        d2.add_population_split(2, derived=["A", "B", "D"], ancestral="E")
+        d1.assert_equivalent(d2)
+
+    def test_epoch_mismatch(self):
+        with pytest.raises(ValueError, match="number of epochs"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                demographic_events=[],
+                population_map=[{"A": 0, "B": 1}, {"C": 0}],
+            )
+
+        with pytest.raises(ValueError, match="number of epochs"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                demographic_events=[
+                    msprime.MassMigration(1, source=1, dest=0, proportion=1),
+                    msprime.PopulationParametersChange(1.1, initial_size=2),
+                ],
+                population_map=[{"A": 0, "B": 1}, {"C": 0}],
+            )
+
+    def test_bad_population_ref(self):
+        with pytest.raises(ValueError, match="Bad population reference"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                population_map=[{"A": 0, "B": 3}],
+            )
+
+        with pytest.raises(ValueError, match="Bad population reference"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                population_map=[{"A": -1}],
+            )
+
+    def test_repeated_ids(self):
+        with pytest.raises(ValueError, match="must be unique"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                population_map=[{"A": 0, "B": 0}],
+            )
+
+    def test_mismatch_populations(self):
+        with pytest.raises(ValueError, match="entries for all"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                population_map=[{"A": 0}],
+            )
+
+    def test_unsupported_events(self):
+        unsupported_events = [
+            msprime.SimpleBottleneck(time=1, population=0, proportion=1),
+            msprime.InstantaneousBottleneck(time=1, population=0, strength=1),
+            msprime.CensusEvent(time=1),
+        ]
+        for event in unsupported_events:
+            with pytest.raises(ValueError, match="Only MassMigration"):
+                msprime.Demography.from_old_style(
+                    [
+                        msprime.PopulationConfiguration(initial_size=1),
+                    ],
+                    demographic_events=[event],
+                    population_map=[{"A": 0}, {"A": 0}],
+                )
+
+    def test_migration_into_inactive_error(self):
+        with pytest.raises(ValueError, match="Non zero migration from an active"):
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                migration_matrix=[[0, 1], [0, 0]],
+                demographic_events=[
+                    msprime.MassMigration(1, source=1, dest=0),
+                ],
+                population_map=[{"A": 0, "B": 1}, {"A": 0}],
+            )
+
+    def test_migration_out_of_inactive_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            msprime.Demography.from_old_style(
+                [
+                    msprime.PopulationConfiguration(initial_size=1),
+                    msprime.PopulationConfiguration(initial_size=1),
+                ],
+                migration_matrix=[[0, 0], [1, 0]],
+                demographic_events=[
+                    msprime.MassMigration(1, source=1, dest=0),
+                ],
+                population_map=[{"A": 0, "B": 1}, {"A": 0}],
+            )
+        assert len(w) == 1
+        assert str(w[0].message).startswith("Migration out of inactive")
+
+
+class TestLineageMovementEvents:
+    def test_as_lineage_movement_abstract(self):
+        e = msprime.LineageMovementEvent(1234)
+        with pytest.raises(NotImplementedError):
+            e._as_lineage_movements()
+
+
+class TestStdpopsimModels:
+    def stdpopsim_browning_admixture_model(self):
+        """
+        The currently released version of the AmericanAdmixture_4B11 model in
+        stdpopsim has arbitrary time deltas put in between different events,
+        making it incomparable with the models we define here. This has been
+        fixed upstream, but while we're waiting for it to be released, here
+        is the model copied verbatim.
+        """
+
+        # Model code was ported from Supplementary File 1.
+        N0 = 7310  # initial population size
+        Thum = 5920  # time (gens) of advent of modern humans
+        Naf = 14474  # size of african population
+        Tooa = 2040  # number of generations back to Out of Africa
+        Nb = 1861  # size of out of Africa population
+        mafb = 1.5e-4  # migration rate Africa and Out-of-Africa
+        Teu = 920  # number generations back to Asia-Europe split
+        Neu = 1032  # bottleneck population sizes
+        Nas = 554
+        mafeu = 2.5e-5  # mig. rates
+        mafas = 7.8e-6
+        meuas = 3.11e-5
+        reu = 0.0038  # growth rate per generation in Europe
+        ras = 0.0048  # growth rate per generation in Asia
+        Tadmix = 12  # time of admixture
+        Nadmix = 30000  # initial size of admixed population
+        radmix = 0.05  # growth rate of admixed population
+        # pop0 is Africa, pop1 is Europe, pop2 is Asia,  pop3 is admixed
+
+        population_configurations = [
+            msprime.PopulationConfiguration(
+                initial_size=Naf,
+                growth_rate=0.0,
+            ),
+            msprime.PopulationConfiguration(
+                initial_size=Neu * math.exp(reu * Teu),
+                growth_rate=reu,
+            ),
+            msprime.PopulationConfiguration(
+                initial_size=Nas * math.exp(ras * Teu),
+                growth_rate=ras,
+            ),
+            msprime.PopulationConfiguration(
+                initial_size=Nadmix * math.exp(radmix * Tadmix),
+                growth_rate=radmix,
+            ),
+        ]
+
+        migration_matrix = [
+            [0, mafeu, mafas, 0],
+            [mafeu, 0, meuas, 0],
+            [mafas, meuas, 0, 0],
+            [0, 0, 0, 0],
+        ]
+        # Admixture event, 1/6 Africa, 2/6 Europe, 3/6 Asia
+        admixture_event = [
+            msprime.MassMigration(
+                time=Tadmix, source=3, destination=0, proportion=1.0 / 6.0
+            ),
+            msprime.MassMigration(
+                time=Tadmix, source=3, destination=1, proportion=2.0 / 5.0
+            ),
+            msprime.MassMigration(time=Tadmix, source=3, destination=2, proportion=1.0),
+        ]
+        # Asia and Europe split
+        eu_event = [
+            msprime.MigrationRateChange(time=Teu, rate=0.0),
+            msprime.MassMigration(time=Teu, source=2, destination=1, proportion=1.0),
+            msprime.PopulationParametersChange(
+                time=Teu, initial_size=Nb, growth_rate=0.0, population_id=1
+            ),
+            msprime.MigrationRateChange(time=Teu, rate=mafb, matrix_index=(0, 1)),
+            msprime.MigrationRateChange(time=Teu, rate=mafb, matrix_index=(1, 0)),
+        ]
+        # Out of Africa event
+        ooa_event = [
+            msprime.MigrationRateChange(time=Tooa, rate=0.0),
+            msprime.MassMigration(time=Tooa, source=1, destination=0, proportion=1.0),
+        ]
+        # initial population size
+        init_event = [
+            msprime.PopulationParametersChange(
+                time=Thum, initial_size=N0, population_id=0
+            )
+        ]
+        demographic_events = admixture_event + eu_event + ooa_event + init_event
+
+        return (
+            population_configurations,
+            migration_matrix,
+            demographic_events,
+        )
+
+    def test_browning_admixture(self):
+        # Compare to stdpopsim model
+        (
+            pop_configs,
+            migration_matrix,
+            events,
+        ) = self.stdpopsim_browning_admixture_model()
+        population_map = [
+            {"AFR": 0, "EUR": 1, "EAS": 2, "ADMIX": 3},
+            {"AFR": 0, "EUR": 1, "EAS": 2},
+            {"AFR": 0, "OOA": 1},
+            {"AMH": 0},
+            {"ANC": 0},
+        ]
+        demog_sps = msprime.Demography.from_old_style(
+            pop_configs,
+            migration_matrix=migration_matrix,
+            demographic_events=events,
+            population_map=population_map,
+        )
+        demog_local = msprime.Demography._american_admixture_model()
+        demog_local.assert_equivalent(demog_sps, rel_tol=1e-5)
+
+    def test_ooa_remap(self):
+        # This test is temporary while we are updating stdpopsim to use the
+        # msprime APIs. See the nodes in the _ooa_model() code.
+        demog_local = msprime.Demography._ooa_model()
+        model_sps = stdpopsim.get_species("HomSap").get_demographic_model(
+            "OutOfAfrica_3G09"
+        )
+
+        # Map from local population names into the equivalent in the stdpopsim
+        # model, per epoch.
+        epoch_pop_map = [
+            {"YRI": 0, "CEU": 1, "CHB": 2},
+            {"YRI": 0, "OOA": 1},
+            {"AMH": 0},
+            {"ANC": 0},
+        ]
+
+        remapped_demog = msprime.Demography.from_old_style(
+            model_sps.population_configurations,
+            migration_matrix=model_sps.migration_matrix,
+            demographic_events=model_sps.demographic_events,
+            population_map=epoch_pop_map,
+        )
+        demog_local.assert_equivalent(remapped_demog)
+
+    def test_ooa_archaic(self):
+        demog_local = msprime.Demography._ooa_archaic_model()
+        model_sps = stdpopsim.get_species("HomSap").get_demographic_model(
+            "OutOfAfricaArchaicAdmixture_5R19"
+        )
+        demog_sps = msprime.Demography.from_old_style(
+            model_sps.population_configurations,
+            migration_matrix=model_sps.migration_matrix,
+            demographic_events=model_sps.demographic_events,
+            population_map=[
+                # Initial populations
+                {"AFR": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+                # Archaic migrations start
+                {"AFR": 0, "CEU": 1, "CHB": 2, "Neanderthal": 3, "ArchaicAFR": 4},
+                # CEU, CHB -> OOA
+                {"AFR": 0, "OOA": 1, "Neanderthal": 3, "ArchaicAFR": 4},
+                # OOA -> AFR
+                {"AFR": 0, "Neanderthal": 3, "ArchaicAFR": 4},
+                # Archaic migrations stop
+                {"AFR": 0, "Neanderthal": 3, "ArchaicAFR": 4},
+                # Ancestral popsize -> 3600
+                {"AFR": 0, "Neanderthal": 3, "ArchaicAFR": 4},
+                # ArchaicAFR -> AFR
+                {"AFR": 0, "Neanderthal": 3},
+                # Neanderthal -> AFR
+                {"AFR": 0},
+            ],
+        )
+        demog_local.assert_equivalent(demog_sps)
+
+    def test_ooa_manual(self):
+        demog_local = msprime.Demography._ooa_model()
+        debug_local = demog_local.debug()
+        model_sps = stdpopsim.get_species("HomSap").get_demographic_model(
+            "OutOfAfrica_3G09"
+        )
+        demog_sps = msprime.Demography.from_old_style(
+            model_sps.population_configurations,
+            migration_matrix=model_sps.migration_matrix,
+            demographic_events=model_sps.demographic_events,
+        )
+        debug_sps = demog_sps.debug()
+
+        # We map the populations the other way around in this test
+        epoch_pop_map = [
+            {0: "YRI", 1: "CEU", 2: "CHB"},
+            {0: "YRI", 1: "OOA"},
+            {0: "AMH"},
+            {0: "ANC"},
+        ]
+
+        assert len(epoch_pop_map) == debug_sps.num_epochs
+        assert debug_local.num_epochs == debug_sps.num_epochs
+        # In epoch 0 the top corner of the migration matrix should be
+        # the same.
+        assert np.array_equal(
+            debug_local.epochs[0].migration_matrix[:3, :3],
+            debug_sps.epochs[0].migration_matrix,
+        )
+        assert np.all(debug_local.epochs[0].migration_matrix[3:, 3:] == 0)
+        # There's only migration between OOA and YRI in epoch 1
+        M = debug_local.epochs[1].migration_matrix.copy()
+        assert M[0, 3] == debug_sps.epochs[1].migration_matrix[0, 1]
+        assert M[3, 0] == debug_sps.epochs[1].migration_matrix[1, 0]
+        M[0, 3] = 0
+        M[3, 0] = 0
+        assert np.all(M == 0)
+
+        for pop_map, epoch_local, epoch_sps in zip(
+            epoch_pop_map, debug_local.epochs, debug_sps.epochs
+        ):
+            assert epoch_local.start_time == epoch_sps.start_time
+            assert epoch_local.end_time == epoch_sps.end_time
+            for pop_id_sps, local_pop_name in pop_map.items():
+                pop_id_local = demog_local[local_pop_name].id
+                pop_local = epoch_local.populations[pop_id_local]
+                pop_sps = epoch_sps.populations[pop_id_sps]
+                assert pop_local.active
+                assert pop_local.start_size == pop_sps.start_size
+                assert pop_local.end_size == pop_sps.end_size
+                assert pop_local.growth_rate == pop_sps.growth_rate
+            if len(pop_map) == 1:
+                assert np.all(epoch_local.migration_matrix == 0)
+                assert np.all(epoch_sps.migration_matrix == 0)

--- a/tests/test_species_tree_parsing.py
+++ b/tests/test_species_tree_parsing.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 University of Oxford
+# Copyright (C) 2020-2021 University of Oxford
 #
 # This file is part of msprime.
 #


### PR DESCRIPTION
This has ended up being quite a big change, but I think the new demography API makes it much harder to make mistakes, and provides a reasonable transition path from old 0.x style demography towards Demes. (I'm thinking in particular of stdpopsim, where we need to provide a reasonably smooth upgrade path).

The new API is best explained with an example. This is the Browning et al model, derived from the [Demes example](https://popsim-consortium.github.io/demes-docs/main/tutorial.html#admixture-events):

```python
T_OOA = 920
# We need to work out the growth rates based on the start and end sizes provided.
N_EUR = 34039
r_EUR = math.log(N_EUR / 1000) / T_OOA
N_EAS = 45852
r_EAS = math.log(N_EAS / 510) / T_OOA

T_ADMIX = 12
N_ADMIX = 54664
r_ADMIX = math.log(N_ADMIX / 30000) / T_ADMIX

demography = msprime.Demography()
demography.add_population(
    name="ANC", description="Ancestral equilibrium population", initial_size=7310
)
demography.add_population(
    name="AMH", description="Anatomically modern humans", initial_size=14474
)
demography.add_population(
    name="OOA", description="Bottleneck out-of-Africa population", initial_size=1861
)
demography.add_population(
    name="AFR", description="African population", initial_size=14474
)
demography.add_population(
    name="EUR",
    description="European population",
    initial_size=N_EUR,
    growth_rate=r_EUR,
)
demography.add_population(
    name="EAS",
    description="East Asian population",
    initial_size=N_EAS,
    growth_rate=r_EAS,
)
demography.add_population(
    name="ADMIX",
    description="Admixed America",
    initial_size=N_ADMIX,
    growth_rate=r_ADMIX,
)
demography.add_admixture(
    T_ADMIX,
    derived="ADMIX",
    ancestral=["AFR", "EUR", "EAS"],
    proportions=[1 / 6, 2 / 6, 3 / 6],
)
demography.set_symmetric_migration_rate(["AFR", "EUR"], 2.5e-5)
demography.set_symmetric_migration_rate(["AFR", "EAS"], 0.78e-5)
demography.set_symmetric_migration_rate(["EUR", "EAS"], 3.11e-5)

demography.add_population_split(T_OOA, derived=["EUR", "EAS"], ancestral="OOA")
demography.add_symmetric_migration_rate_change(
    time=T_OOA, populations=["AFR", "OOA"], rate=15e-5
)
demography.add_population_split(2040, derived=["OOA", "AFR"], ancestral="AMH")
demography.add_population_split(5920, derived=["AMH"], ancestral="ANC")
print(demography.debug())
```
gives:
```
╠═══════════════════════════════╗                                                              
║ Epoch[0]: [0, 12) generations ║                                                              
╠═══════════════════════════════╝                                                              
╟    Populations (total=7 active=4)                                                            
║    ┌───────────────────────────────────────────────────────────────────────────────────┐     
║    │       │     start│       end│growth_rate  │   AFR   │   EUR    │   EAS    │ ADMIX │     
║    ├───────────────────────────────────────────────────────────────────────────────────┤     
║    │    AFR│   14474.0│   14474.0│ 0           │    0    │ 2.5e-05  │ 7.8e-06  │   0   │     
║    │    EUR│   34039.0│   32508.3│ 0.00383     │ 2.5e-05 │    0     │ 3.11e-05 │   0   │     
║    │    EAS│   45852.0│   43238.8│ 0.00489     │ 7.8e-06 │ 3.11e-05 │    0     │   0   │     
║    │  ADMIX│   54664.0│   30000.0│ 0.05        │    0    │    0     │    0     │   0   │     
║    └───────────────────────────────────────────────────────────────────────────────────┘     
╟    Events @ generation 12                                                                    
║    ┌──────────────────────────────────────────────────────────────────────────────────┐      
║    │  time│type       │parameters            │effect                                  │      
║    ├──────────────────────────────────────────────────────────────────────────────────┤      
║    │    12│Admixture  │derived=ADMIX         │Moves all lineages from admixed         │      
║    │      │           │ancestral=[AFR, EUR,  │population 'ADMIX' to ancestral         │      
║    │      │           │EAS]                  │populations. Lineages move to 'AFR'     │      
║    │      │           │proportions=[0.17,    │with proba 0.167; 'EUR' with proba      │      
║    │      │           │0.33, 0.50]           │0.333; 'EAS' with proba 0.5. Set        │      
║    │      │           │                      │'ADMIX' to inactive, and all migration  │                                                                                                     
║    │      │           │                      │rates to and from 'ADMIX' to zero.      │      
║    └──────────────────────────────────────────────────────────────────────────────────┘      
╠═════════════════════════════════╗                                                            
║ Epoch[1]: [12, 920) generations ║                                                            
╠═════════════════════════════════╝                                                            
╟    Populations (total=7 active=3)                                                            
║    ┌─────────────────────────────────────────────────────────────────────────┐               
║    │     │     start│       end│growth_rate  │   AFR   │   EUR    │   EAS    │                                                                                                              
║    ├─────────────────────────────────────────────────────────────────────────┤               
║    │  AFR│   14474.0│   14474.0│ 0           │    0    │ 2.5e-05  │ 7.8e-06  │               
║    │  EUR│   32508.3│    1000.0│ 0.00383     │ 2.5e-05 │    0     │ 3.11e-05 │               
║    │  EAS│   43238.8│     510.0│ 0.00489     │ 7.8e-06 │ 3.11e-05 │    0     │               
║    └─────────────────────────────────────────────────────────────────────────┘               
╟    Events @ generation 920
║    ┌────────────────────────────────────────────────────────────────────────────────────┐    
║    │  time│type            │parameters           │effect                                │    
║    ├────────────────────────────────────────────────────────────────────────────────────┤    
║    │   920│Population      │derived=[EUR, EAS],  │Moves all lineages from derived       │    
║    │      │Split           │ancestral=OOA        │populations 'EUR' and 'EAS' to the    │    
║    │      │                │                     │ancestral 'OOA' population. Also set  │    
║    │      │                │                     │the derived populations to inactive,  │    
║    │      │                │                     │and all migration rates to and from   │    
║    │      │                │                     │the derived populations to zero.      │    
║    │┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈│    
║    │   920│Symmetric       │populations=[AFR,    │Sets the symmetric migration rate     │    
║    │      │migration rate  │OOA], rate=0.00015   │between AFR and OOA to 0.00015 per    │    
║    │      │change          │                     │generation                            │    
║    └────────────────────────────────────────────────────────────────────────────────────┘    
╠═══════════════════════════════════════╗
║ Epoch[2]: [920, 2.04e+03) generations ║
╠═══════════════════════════════════════╝
╟    Populations (total=7 active=2)
║    ┌─────────────────────────────────────────────────────────────┐                           
║    │     │     start│       end│growth_rate  │   OOA   │   AFR   │                           
║    ├─────────────────────────────────────────────────────────────┤                           
║    │  OOA│    1861.0│    1861.0│ 0           │    0    │ 0.00015 │                           
║    │  AFR│   14474.0│   14474.0│ 0           │ 0.00015 │    0    │                           
║    └─────────────────────────────────────────────────────────────┘                           
╟    Events @ generation 2.04e+03
║    ┌────────────────────────────────────────────────────────────────────────────────┐        
║    │  time│type        │parameters           │effect                                │        
║    ├────────────────────────────────────────────────────────────────────────────────┤        
║    │  2040│Population  │derived=[OOA, AFR],  │Moves all lineages from derived       │        
║    │      │Split       │ancestral=AMH        │populations 'OOA' and 'AFR' to the    │        
║    │      │            │                     │ancestral 'AMH' population. Also set  │        
║    │      │            │                     │the derived populations to inactive,  │        
║    │      │            │                     │and all migration rates to and from   │        
║    │      │            │                     │the derived populations to zero.      │        
║    └────────────────────────────────────────────────────────────────────────────────┘        
╠════════════════════════════════════════════╗
║ Epoch[3]: [2.04e+03, 5.92e+03) generations ║
╠════════════════════════════════════════════╝
╟    Populations (total=7 active=1)
║    ┌─────────────────────────────────────────┐                                               
║    │     │     start│       end│growth_rate  │                                               
║    ├─────────────────────────────────────────┤                                               
║    │  AMH│   14474.0│   14474.0│ 0           │                                               
║    └─────────────────────────────────────────┘                                               
╟    Events @ generation 5.92e+03
║    ┌───────────────────────────────────────────────────────────────────────────┐             
║    │  time│type        │parameters      │effect                                │             
║    ├───────────────────────────────────────────────────────────────────────────┤             
║    │  5920│Population  │derived=[AMH],  │Moves all lineages from the 'AMH'     │             
║    │      │Split       │ancestral=ANC   │derived population to the ancestral   │             
║    │      │            │                │'ANC' population. Also set 'AMH' to   │             
║    │      │            │                │inactive, and all migration rates to  │             
║    │      │            │                │and from the derived population to    │             
║    │      │            │                │zero.                                 │             
║    └───────────────────────────────────────────────────────────────────────────┘             
╠═══════════════════════════════════════╗
║ Epoch[4]: [5.92e+03, inf) generations ║
╠═══════════════════════════════════════╝
╟    Populations (total=7 active=1)
║    ┌───────────────────────────────────────┐
║    │     │    start│      end│growth_rate  │
║    ├───────────────────────────────────────┤
║    │  ANC│   7310.0│   7310.0│ 0           │
║    └───────────────────────────────────────┘
```

Things to note:
- Rather than work with objects like Population() and various Event classes, we now call methods on the Demography object. This both reduces boilerplate and makes the model easier to program with.
- We have two new event types PopulationSplit and Admixture. These should be much less confusing an error prone than manually putting things together via MassMigrations (which are still there, if you need them)
- Populations now have a "state machine" where they are active or inactive. It is an error to either sample lineages or move lineages into (via migration or events) a population is not active. This allows us to refine the output in the Debugger and also should make it much harder to make mistakes. The details of the actual state-machine were tedious to work out, but I think it's pretty solid now.

There's quite a few things we could improve and make more "demes-like", but I think changing things any more would move the model too far. We want to provide existing users an opportunity to upgrade their code in a relatively painless way, and ultimately a path to converting to demes.

The PR isn't quite ready to merge as I need to work out the details of how to compare Demographys for equivalence, and in particular how to compare an "new style" model with an old style one (which will be super useful in stdpopsim). It would be good to get some feedback on the overall design (and review, if anyone is up for it), though.

Pinging @grahamgower @apragsdale @molpopgen @petrelharp @gtsambos 