### PR TITLE
Make newick import optional for conda package.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
             python setup.py check
             python -m twine check dist/*.tar.gz --strict
             python -m build
+
       - run:
           name: Install from the distribution tarball
           command: |
@@ -89,3 +90,8 @@ jobs:
             source venv/bin/activate
             pip install --upgrade setuptools pip
             pip install dist/*.tar.gz
+            python -c 'import msprime; print(msprime.__version__)'
+
+            # We should still be able to import without the newick module
+            python -m pip uninstall -y newick
+            python -c 'import msprime; print(msprime.__version__)'

--- a/msprime/species_trees.py
+++ b/msprime/species_trees.py
@@ -22,18 +22,36 @@ Module responsible for parsing species trees.
 import collections
 import re
 
-import newick
+try:
+    _newick_imported = False
+    import newick
+
+    _newick_imported = True
+except ImportError:  # pragma: no cover
+    pass
 
 from . import demography as demog
 
 
+def check_newick_import():
+    if not _newick_imported:
+        raise ImportError(
+            "The 'newick' module is required for species tree parsing. "
+            "If you installed msprime using conda, please install the "
+            "newick module using `conda install -c bioconda newick` or "
+            "'pip install newick'. If you installed msprime using pip "
+            "newick should have been automatically installed; please "
+            "open an issue on GitHub with details of your installation."
+        )
+
+
 def parse_starbeast(tree, generation_time, time_units="myr"):
     """
-    Parse a nexusencoded species tree into a Demography object. See the
+    Parse a nexus encoded species tree into a Demography object. See the
     documentation of :class:`.Demography.from_starbeast` (the public interface)
     for details.
     """
-
+    check_newick_import()
     # Make sure that branch length units are either "myr" or "yr".
     allowed_branch_lenth_units = ["myr", "yr"]
     if time_units not in allowed_branch_lenth_units:
@@ -99,6 +117,7 @@ def parse_species_tree(
     documentation of :class:`.Demography.from_species_tree` (the public interface)
     for details.
     """
+    check_newick_import()
     # Make sure that branch length units are either "myr", "yr", or "gen".
     allowed_branch_lenth_units = ["myr", "yr", "gen"]
     if time_units not in allowed_branch_lenth_units:

--- a/tests/test_species_tree_parsing.py
+++ b/tests/test_species_tree_parsing.py
@@ -797,3 +797,12 @@ class TestStarbeastExamples:
             assert len(spec.events) == 11
             for mm in spec.events:
                 assert isinstance(mm, msprime.PopulationSplit)
+
+
+def test_newick_import():
+    try:
+        species_trees._newick_imported = False
+        with pytest.raises(ImportError, match="The 'newick' module"):
+            species_trees.check_newick_import()
+    finally:
+        species_trees._newick_imported = True


### PR DESCRIPTION
This seems like the simplest approach to making a useable conda package. The import failure should sort most users out.

Ultimately, the only way to solve this would be to migrate the bioconda newick package into conda-forge.