### PR TITLE
Add missing matplotlib dev requirement to compile docs locally

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,6 +4,7 @@ codecov
 coverage
 daiquiri
 flake8
+matplotlib
 mock
 mypy
 numpy


### PR DESCRIPTION
I had to do this extra step to get the docs compiled locally on my machine.