### PR TITLE
base docker image off of data science image and intall latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,10 @@
 #organization tskit-dev
 #application "Msprime: A reimplementation of Hudson's classical ms simulator for modern data sets."
 
-FROM ubuntu:20.04
+FROM jupyter/scipy-notebook:latest
 
 # Set the working directory to /app
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
-COPY . /app
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-            python3 \
-            python3-dev \
-            python3-pip \
-            libgsl-dev \
-            build-essential \
-            python3-wheel \
-            git \
-            && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install --upgrade setuptools
-RUN pip3 install .
+# Install latest msprime release
+RUN pip install --pre msprime


### PR DESCRIPTION
I used the jupyter/scipy-notebook base. One thing to consider is that it makes it a fairly large image (~2.69G). I personally, would probably prefer keeping the base msprime image lightweight and only using the Ubuntu base. The current docker image with the Ubuntu base is only 565MB.
And then I'd say make an additional image for a whole tskit ecosystem based on jupyter/scipy-notebook base.

Jupyter lab can be run as follows using Docker:
```
docker run -it -v ${PWD}:/app --rm -p 8888:8888 tskit/msprime:<<tag>> jupyter-lab
```
And you need to take care to not be in the msprime directory, or else you will get a conflict when trying to import `msprime`.

closes https://github.com/tskit-dev/msprime/issues/1530