### PR TITLE
HTML display for ratemap

### DIFF
--- a/msprime/intervals.py
+++ b/msprime/intervals.py
@@ -23,6 +23,8 @@ import warnings
 
 import numpy as np
 
+from . import core
+
 
 class RateMap:
     """
@@ -297,6 +299,29 @@ class RateMap:
             end += self.sequence_length
         return self.slice(start=start, end=end, trim=True)
 
+    def _repr_html_(self):
+        details = f"{len(self.rate)} {'rate' if len(self.rate) == 1 else 'rates'}"
+        details += f",  mean rate {self.mean_rate:g}"
+        if (
+            self.start_position != self.position[0]
+            or self.end_position != self.position[-1]
+        ):
+            details += " between positions {} and {}".format(
+                self.start_position, self.end_position
+            )
+        return core.html_table(
+            f"Rate Map ({details})",
+            ("from", "to", "rate"),
+            (
+                (
+                    f"{self.position[i]:.9g}",
+                    f"{self.position[i+1]:.9g}",
+                    f"{self.rate[i]:g}",
+                )
+                for i in range(len(self.rate))
+            ),
+        )
+
     @staticmethod
     def read_hapmap(
         fileobj,
@@ -448,6 +473,10 @@ class RateMap:
         )
 
 
+# The RecombinationMap class is deprecated since 1.0. We maintain the
+# functionality where it is possible to do so.
+
+
 class RecombinationMap:
     """
     A RecombinationMap represents the changing rates of recombination
@@ -462,10 +491,6 @@ class RecombinationMap:
     .. important::
         This class is deprecated (but supported indefinitely);
         please use the :class:`.RateMap` class in new code.
-        In particular, note that when specifying ``rates`` in the
-        the :class:`.RateMap` class we now require an array
-        of length :math:`n - 1` (this class requires an array
-        of length :math:`n` in which the last entry is zero).
 
     :param list positions: The positions (in bases) denoting the
         distinct intervals where recombination rates change. These can
@@ -473,12 +498,12 @@ class RecombinationMap:
     :param list rates: The list of rates corresponding to the supplied
         ``positions``. Recombination rates are specified per base,
         per generation.
-    :param int num_loci: **This parameter is no longer supported.**
-        Must be either None (meaning a continuous genome of the
-        finest possible resolution) or be equal to ``positions[-1]``
-        (meaning a discrete genome). Any other value will result in
-        an error. Please see the :ref:`sec_legacy_0x_genome_discretisation`
-        section for more information.
+    :param int num_loci: **This parameter is deprecated**.
+        The maximum number of non-recombining loci
+        in the underlying simulation. By default this is set to
+        the largest possible value, allowing the maximum resolution
+        in the recombination process. However, for a finite sites
+        model this can be set to smaller values.
     """
 
     def __init__(self, positions, rates, num_loci=None, map_start=0):
@@ -519,8 +544,8 @@ class RecombinationMap:
         Parses the specified file in HapMap format.
 
         .. warning::
-            This method is deprecated, use the :meth:`.RateMap.read_hapmap`
-            method instead.
+            This method is deprecated, use the module-level
+            :func:`read_hapmap` function instead.
 
         :param str filename: The name of the file to be parsed. This may be
             in plain text or gzipped plain text.


### PR DESCRIPTION
Fixes #1590 - slightly complicated so that we can show the start and end positions when they are not the same as the first and last pos in the positions array.