### PR TITLE
Change the infinite sites wording

### DIFF
--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -207,9 +207,13 @@ mts = msprime.sim_mutations(ts, rate=0.1, random_seed=5, discrete_genome=False)
 mts.tables.sites.position
 ```
 
-Note that using `discrete_genome=False` is equivalent to specifying an infinite sites
-model.
+:::{note}
 
+Using `discrete_genome=False` means that the mutation model will conform
+to the classic _infinite sites_ assumption, where each mutation in the simulation
+occurs at a new site.
+
+:::
 
 (sec_mutations_time_span)=
 


### PR DESCRIPTION
While discussing https://github.com/tskit-dev/msprime/issues/1600 I noticed that the text describing infinite sites could be a bit confusing to the uninitiated, as it refers to the "infinite sites model", which is not one of the "mutation model"s that we actually list. So perhaps we should refer to it as the "infinite sites assumption" instead (and indeed, this makes it a little more obvious that any of the mutation models we have can be combined with an IS assumption?

I've also put it in a `{note}` for greater emphasis, as I think it's pretty important. But we could even put it in an `{important}` block instead?