### PR TITLE
Docs update to multiple chromosomes and likelihoods

### DIFF
--- a/docs/ancestry.md
+++ b/docs/ancestry.md
@@ -696,9 +696,18 @@ ancestry patterns for very recently admixed populations.
 
 Additionally,
 {ref}`Multiple merger coalescents <sec_ancestry_models_multiple_mergers>`
-result in positively correlated ancestries between unlinked chromosomes.
+result in positively correlated ancestries between unlinked chromosomes
+(see [Birkner et al. 2013](https://www.genetics.org/content/193/1/255)).
 This correlation does not break down in time and multiple chromosomes should
-not be simulated independently under the multiple merger models.
+not be simulated independently under the multiple merger models. Unlinked
+chromosomes should scatter into distinct ancestors instantaneously under
+multiple merger coalescents, not with probability 1/2 per generation
+as in discrete population models. In msprime, this waiting time of length zero
+is approximated by an exponential distribution with rate {math}`r`, i.e. the
+recombination rate at the base pair separating the chromosomes, which
+should be set to a high enough value to obtain an acceptable approximation.
+We recommend considering in particular the relative error in comparison to
+the magnitudes other waiting times which are likely to arise in the simulation.
 
 :::{important}
 Simulations of multiple chromosomes under either DTWF or the multiple merger

--- a/msprime/likelihood.py
+++ b/msprime/likelihood.py
@@ -28,9 +28,19 @@ def log_mutation_likelihood(ts, mutation_rate):
     """
     Returns the unnormalised log probability of the stored pattern of mutations
     on the stored tree sequence, assuming infinite sites mutation. In particular,
-    each stored site must only contain a single mutation. The omitted normalising
-    constant depends on the pattern of mutations, but not on the tree sequence or
-    the mutation rate.
+    each stored site must only contain a single mutation, and all mutant alleles
+    are treated interchangeably as having arisen from a single mutation rate.
+    This is automatically true for some msprime mutation models, such as JC69.
+    The omitted normalising constant depends on the pattern of mutations, but not
+    on the tree sequence or the mutation rate.
+
+    .. warning::
+        The infinite sites assumption means that this method is only valid for
+        continuous genomes. It can also be run on discrete genomes, for which it
+        may provide a reasonable approximation when the number of sites is large
+        and the mutation rate is low. See :ref:`sec_ancestry_discrete_genome`
+        for how continuous genomes can be specified when simulating tree sequences
+        using msprime.
 
     The function first computes the probability of the overall number of mutations
     :math:`M` from the Poisson probability mass function


### PR DESCRIPTION
Some brief clarifications to the section on simulating multiple chromosomes under multiple merger coalescents, and to the mutation likelihood docstring.

Ping @jeromekelleher, @hyanwong, @apragsdale.

Closes #1600.