### PR TITLE
Finalise CLI

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,13 +3,13 @@
 # Command line interface
 
 Two command line applications are provided with `msprime`: {ref}`sec_msp` and
-{ref}`sec_mspms`. The {command}`msp` program is a POSIX compliant command line 
+{ref}`sec_mspms`. The {command}`msp` program is a POSIX compliant command line
 interface to the library. The {command}`mspms` program is a fully-{command}`ms`
 compatible interface. This is useful for those who wish to get started quickly
 with using
 the library, and also as a means of plugging `msprime` into existing work
 flows. However, there is a substantial overhead involved in translating data
-from `msprime`'s native history file into legacy formats, and so new code
+from `msprime`'s native history file into legacy formats like `ms`, and so new code
 should use the Python API where possible.
 
 (sec_msp)=
@@ -19,22 +19,70 @@ should use the Python API where possible.
 The {command}`msp` program provides a convenient interface to the `msprime` API.
 It is based on subcommands that either generate or consume a
 tree sequence file. The `ancestry` sub-command simulates tree sequences from the
- coalescent with recombination. The `mutate` sub-command places 
-mutations onto an existing tree sequence. Several mutation models are available.
+ coalescent with recombination. The `mutations` sub-command places
+mutations onto an existing tree sequence. Several
+{ref}`mutation models<sec_mutations_models>` are available.
 The deprecated `simulate` sub-command simulates tree sequences from the
- coalescent with recombination and mutations.
+coalescent with recombination and mutations.
+
+:::{important}
+The {command}`msp ancestry` and {command}`msp mutations` commands write
+their output to stdout by default so make sure you redirect this to a
+file or use the ``--output`` option.
+:::
+
+### Examples
+
+Simulate 10 diploid samples from a population of size 1000
+with a genome of 100 base pairs, and write the output to ``ancestry.trees``:
+
+```sh
+$ msp ancestry 10 -N 1000 -L 100 > ancestry.trees
+```
+
+Simulate mutations from the {class}`Jukes-Cantor<.JC69>` mutation model
+at rate 0.01 per-base per-generation, and write this to ``mutations.trees``.
+
+```sh
+$ msp mutations 0.01 ancestry.trees > mutations.trees
+```
+
+Do the same simulations, but pipe the output of the ancestry simulation
+directly to the mutations simulation:
+```sh
+$ msp ancestry 10 -N 1000 -L 100 | msp mutations 0.01 > combined.trees
+```
+
+Show a summary of the properties of the trees file ``combined.trees``:
+```
+$ tskit info combined.trees
+sequence_length:  100.0
+trees:            1
+samples:          20
+individuals:      10
+nodes:            39
+edges:            38
+sites:            100
+mutations:        16997
+migrations:       0
+populations:      1
+provenances:      2
+```
+
+See the {ref}`tskit documentation<tskit:sec_cli>` for more details on the
+{program}`tskit` command line interface.
 
 (sec_msp_ancestry)=
 
 ### msp ancestry
 
-{command}`msp ancestry` generates coalescent simulations with recombination 
+{command}`msp ancestry` generates coalescent simulations with recombination
 from a constant population size and stores the result as a tree sequence in
 an output file. This sub-command is an interface to the
-{func}`msprime.sim_ancestry` API function. 
+{func}`msprime.sim_ancestry` API function.
 
 ```{eval-rst}
-.. argparse:: 
+.. argparse::
     :module: msprime.cli
     :func: get_msp_parser
     :prog: msp
@@ -45,37 +93,39 @@ an output file. This sub-command is an interface to the
 
 (sec_msp_mutate)=
 
-### msp mutate
+### msp mutations
 
 {command}`msp mutate` can be used to add mutations to a tree sequence and store
 a copy of the resulting tree sequence in a second file. This
 sub-command is an interface to the
-{func}`msprime.sim_mutations` API function. 
+{func}`msprime.sim_mutations` API function.
 
 ```{eval-rst}
 .. argparse::
     :module: msprime.cli
     :func: get_msp_parser
     :prog: msp
-    :path: mutate
+    :path: mutations
     :nodefault:
 ```
 
-
-
 ### msp simulate
 
-{command}`msp simulate` generates coalescent simulations with recombination 
+:::{warning}
+The {command}`msp simulate` command is deprecated.
+:::
+
+{command}`msp simulate` generates coalescent simulations with recombination
 from a constant population size and stores the result as a tree sequence in
 an output file.
-{command}`msp simulate` is deprecated, but will be supported indefinitely. 
+{command}`msp simulate` is deprecated, but will be supported indefinitely.
 {ref}`sec_msp_mutate` provides further mutation models.
-{command}`msp ancestry` will provide further demographic scenarios from 
+{command}`msp ancestry` will provide further demographic scenarios from
 which to simulate tree sequences. {command}`msp simulate` is an
-interface to the deprecated {func}`msprime.simulate` API function. 
+interface to the deprecated {func}`msprime.simulate` API function.
 
 ```{eval-rst}
-.. argparse:: 
+.. argparse::
     :module: msprime.cli
     :func: get_msp_parser
     :prog: msp

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -1057,7 +1057,10 @@ def get_msp_parser():
 
 def add_mutate_subcommand(subparsers):
     parser = subparsers.add_parser(
-        "mutations", aliases=["mut"], help="Simulate mutations on a tree sequence."
+        # see note above on aliases and sphinx-argparse
+        # aliases=["mut"],
+        "mutations",
+        help="Simulate mutations on a tree sequence.",
     )
     parser.add_argument(
         "mutation_rate",
@@ -1147,7 +1150,10 @@ def add_simulate_subcommand(subparsers) -> None:
 def add_ancestry_subcommand(subparsers) -> None:
     parser = subparsers.add_parser(
         "ancestry",
-        aliases=["anc"],
+        # We'd like to use aliases there but sphinx-argparse doesn't support it
+        # in the released version. Looks like the project has been abandoned by
+        # its original maintainers, so we might want to stop using it.
+        # aliases=["anc"],
         help="Simulate an ancestral history and output as a tskit tree sequence.",
     )
     parser.add_argument(

--- a/msprime/cli.py
+++ b/msprime/cli.py
@@ -101,30 +101,6 @@ def add_sample_size_argument(parser):
     )
 
 
-def add_tree_sequence_argument(parser):
-    parser.add_argument("tree_sequence", help="The msprime tree sequence file")
-
-
-def add_precision_argument(parser):
-    parser.add_argument(
-        "--precision",
-        "-p",
-        type=int,
-        default=6,
-        help="The number of decimal places to print in records",
-    )
-
-
-def add_mutation_rate_argument(parser):
-    parser.add_argument(
-        "--mutation-rate",
-        "-u",
-        type=float,
-        default=0,
-        help="The mutation rate per base per generation",
-    )
-
-
 def add_random_seed_argument(parser):
     parser.add_argument(
         "--random-seed",
@@ -132,6 +108,19 @@ def add_random_seed_argument(parser):
         type=int,
         default=None,
         help="The random seed; If not specified, one is chosen randomly.",
+    )
+
+
+def add_output_argument(parser):
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("wb"),
+        default=sys.stdout,
+        help=(
+            "Where to write the output tree sequence file. If omitted or '-', "
+            "write to standard output"
+        ),
     )
 
 
@@ -1001,9 +990,9 @@ def mspms_main(arg_list=None):
 def run_simulate(args):
     warnings.warn(
         "The simulate command is deprecated but will continue to work "
-        "indefinitely. To simulate ancestries, please use the ancestry "
+        "indefinitely. To simulate ancestries, please use the 'ancestry' "
         "command. To place mutations on a tree sequence, please use "
-        "the mutate command."
+        "the 'mutations' command."
     )
 
     if args.compress:
@@ -1022,10 +1011,10 @@ def run_simulate(args):
     tree_sequence.dump(args.tree_sequence)
 
 
-def run_mutate(args):
-    tree_sequence = tskit.load(args.tree_sequence)
-    tree_sequence = msprime.sim_mutations(
-        tree_sequence=tree_sequence,
+def run_mutations(args):
+    input_ts = tskit.load(args.input)
+    output_ts = msprime.sim_mutations(
+        tree_sequence=input_ts,
         rate=args.mutation_rate,
         random_seed=args.random_seed,
         keep=True,
@@ -1034,19 +1023,19 @@ def run_mutate(args):
         discrete_genome=True,
         model=args.model,
     )
-    tree_sequence.dump(args.output_tree_sequence)
+    output_ts.dump(args.output)
 
 
 def run_ancestry(args):
     tree_sequence = msprime.sim_ancestry(
-        samples=int(args.sample_size),
+        samples=int(args.samples),
         population_size=args.population_size,
         sequence_length=args.length,
         ploidy=args.ploidy,
         recombination_rate=args.recombination_rate,
         random_seed=args.random_seed,
     )
-    tree_sequence.dump(args.tree_sequence)
+    tree_sequence.dump(args.output)
 
 
 def get_msp_parser():
@@ -1067,14 +1056,23 @@ def get_msp_parser():
 
 
 def add_mutate_subcommand(subparsers):
-    parser = subparsers.add_parser("mutate", help="Add mutations to a tree sequence.")
-    add_tree_sequence_argument(parser)
-    add_mutation_rate_argument(parser)
-    add_random_seed_argument(parser)
-    parser.add_argument(
-        "output_tree_sequence",
-        help="The tree sequence output file containing the new mutations",
+    parser = subparsers.add_parser(
+        "mutations", aliases=["mut"], help="Simulate mutations on a tree sequence."
     )
+    parser.add_argument(
+        "mutation_rate",
+        type=float,
+        help="The mutation rate per base",
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        type=argparse.FileType("rb"),
+        default=sys.stdin,
+        help=("The input tree sequence. If omitted or '-' read from standard input"),
+    )
+    add_output_argument(parser)
+    add_random_seed_argument(parser)
     parser.add_argument(
         "--start-time",
         type=float,
@@ -1093,15 +1091,21 @@ def add_mutate_subcommand(subparsers):
         type=str,
         default="jc69",
         choices=sorted(mutations.MODEL_MAP.keys()),
-        help="The mutation model to use to generate mutations",
+        help="The mutation model to use (default=JC69)",
     )
-    parser.set_defaults(runner=run_mutate)
+    parser.set_defaults(runner=run_mutations)
 
 
 def add_simulate_subcommand(subparsers) -> None:
-    parser = subparsers.add_parser("simulate", help="Run the simulation.")
+    parser = subparsers.add_parser(
+        "simulate",
+        help=(
+            "Run a simulation. DEPRECATED - please use `msp ancestry` "
+            "and `msp mutations` instead"
+        ),
+    )
     add_sample_size_argument(parser)
-    add_tree_sequence_argument(parser)
+    parser.add_argument("tree_sequence", help="The output tree sequence file")
     parser.add_argument(
         "--length",
         "-L",
@@ -1116,7 +1120,13 @@ def add_simulate_subcommand(subparsers) -> None:
         default=0,
         help="The recombination rate per base per generation",
     )
-    add_mutation_rate_argument(parser)
+    parser.add_argument(
+        "--mutation-rate",
+        "-u",
+        type=float,
+        default=0,
+        help="The mutation rate per base per generation",
+    )
     parser.add_argument(
         "--effective-population-size",
         "-N",
@@ -1136,12 +1146,14 @@ def add_simulate_subcommand(subparsers) -> None:
 
 def add_ancestry_subcommand(subparsers) -> None:
     parser = subparsers.add_parser(
-        "ancestry", help="Simulate an ancestry from the coalescent."
+        "ancestry",
+        aliases=["anc"],
+        help="Simulate an ancestral history and output as a tskit tree sequence.",
     )
     parser.add_argument(
-        "sample_size", type=positive_int, help="The number of individuals in the sample"
+        "samples", type=positive_int, help="The number of individuals in the sample"
     )
-    add_tree_sequence_argument(parser)
+    add_output_argument(parser)
     add_random_seed_argument(parser)
     parser.add_argument(
         "--length",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1262,19 +1262,19 @@ class TestMspArgumentParser:
         parser = cli.get_msp_parser()
         args = parser.parse_args(["mutations", "10"])
         assert args.output is sys.stdout
-        args = parser.parse_args(["ancestry", "10", "-o", "-"])
+        args = parser.parse_args(["mutations", "10", "-o", "-"])
         assert args.output is sys.stdout
 
     def test_mutations_stdin(self):
         parser = cli.get_msp_parser()
         args = parser.parse_args(["mutations", "10"])
         assert args.input is sys.stdin
-        args = parser.parse_args(["ancestry", "10", "-"])
+        args = parser.parse_args(["mutations", "10", "-"])
         assert args.input is sys.stdin
 
     def test_mut_default_values(self):
         parser = cli.get_msp_parser()
-        cmd = "mut"
+        cmd = "mutations"
         args = parser.parse_args([cmd, "0.1"])
         assert args.input is sys.stdin
         assert args.output is sys.stdout
@@ -1296,7 +1296,7 @@ class TestMspArgumentParser:
     def test_mutate_model_is_changeable(self):
         parser = cli.get_msp_parser()
         for model_arg in ["--model", "-m"]:
-            args = parser.parse_args(["mut", "1", model_arg, "blosum62"])
+            args = parser.parse_args(["mutations", "1", model_arg, "blosum62"])
             assert args.model == "blosum62"
 
 
@@ -1443,7 +1443,7 @@ def tree_sequence_file(tmp_path, tree_sequence):
     def test_mutate_discrete_start_end_time(self, tree_sequence_file, tmp_path):
         out_tree_sequence_file = str(tmp_path / "out.ts")
 
-        cmd = "mut"
+        cmd = "mutations"
         stdout, stderr = capture_output(
             cli.msp_main,
             [
@@ -1473,7 +1473,7 @@ def tree_sequence_file(tmp_path, tree_sequence):
 
 class TestMspMutateModelOutput:
     def test_binary_uses_0_or_1_states(self, tree_sequence_file, tmp_path):
-        cmd = "mut"
+        cmd = "mutations"
         out_tree_sequence_file = str(tmp_path / "out.ts")
         stdout, stderr = capture_output(
             cli.msp_main,
@@ -1498,7 +1498,7 @@ class TestMspMutateModelOutput:
         assert set(tables.mutations.derived_state) <= {ord("0"), ord("1")}
 
     def test_default_jc69_uses_ACGT_states(self, tree_sequence_file, tmp_path):
-        cmd = "mut"
+        cmd = "mutations"
         out_tree_sequence_file = str(tmp_path / "out.ts")
         stdout, stderr = capture_output(
             cli.msp_main,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1242,23 +1242,43 @@ class TestMspArgumentParser:
 
     def test_ancestry_default_values(self):
         parser = cli.get_msp_parser()
-        args = parser.parse_args(["ancestry", "10", "out.trees"])
-        assert args.tree_sequence == "out.trees"
-        assert "mutation_rate" not in args
-        assert args.sample_size == 10
+        args = parser.parse_args(["ancestry", "10"])
+        assert args.output is sys.stdout
+        assert args.samples == 10
         assert args.random_seed is None
         assert args.population_size == 1.0
         assert args.ploidy == 2
         assert args.recombination_rate == 0
         assert args.length == 1
 
-    def test_mutate_default_values(self):
+    def test_ancestry_stdout(self):
         parser = cli.get_msp_parser()
-        cmd = "mutate"
-        args = parser.parse_args([cmd, "out.trees", "out2.trees"])
-        assert args.tree_sequence == "out.trees"
-        assert args.output_tree_sequence == "out2.trees"
-        assert args.mutation_rate == 0
+        args = parser.parse_args(["ancestry", "10"])
+        assert args.output is sys.stdout
+        args = parser.parse_args(["ancestry", "10", "-o", "-"])
+        assert args.output is sys.stdout
+
+    def test_mutations_stdout(self):
+        parser = cli.get_msp_parser()
+        args = parser.parse_args(["mutations", "10"])
+        assert args.output is sys.stdout
+        args = parser.parse_args(["ancestry", "10", "-o", "-"])
+        assert args.output is sys.stdout
+
+    def test_mutations_stdin(self):
+        parser = cli.get_msp_parser()
+        args = parser.parse_args(["mutations", "10"])
+        assert args.input is sys.stdin
+        args = parser.parse_args(["ancestry", "10", "-"])
+        assert args.input is sys.stdin
+
+    def test_mut_default_values(self):
+        parser = cli.get_msp_parser()
+        cmd = "mut"
+        args = parser.parse_args([cmd, "0.1"])
+        assert args.input is sys.stdin
+        assert args.output is sys.stdout
+        assert args.mutation_rate == 0.1
         assert args.random_seed is None
         assert args.start_time is None
         assert args.end_time is None
@@ -1266,7 +1286,7 @@ class TestMspArgumentParser:
 
     def test_mutate_raises_with_invalid_model_name(self):
         parser = cli.get_msp_parser()
-        cmd = "mutate"
+        cmd = "mutations"
         with pytest.raises(SystemExit):
             capture_output(
                 parser.parse_args,
@@ -1275,11 +1295,8 @@ class TestMspArgumentParser:
 
     def test_mutate_model_is_changeable(self):
         parser = cli.get_msp_parser()
-        cmd = "mutate"
         for model_arg in ["--model", "-m"]:
-            args = parser.parse_args(
-                [cmd, "out.trees", "out2.trees", model_arg, "blosum62"]
-            )
+            args = parser.parse_args(["mut", "1", model_arg, "blosum62"])
             assert args.model == "blosum62"
 
 
@@ -1338,7 +1355,7 @@ class TestMspAncestryOutput:
     def test_run_defaults(self, tmp_path):
         tree_sequence_file = str(tmp_path / "out.ts")
         stdout, stderr = capture_output(
-            cli.msp_main, ["ancestry", "10", tree_sequence_file]
+            cli.msp_main, ["ancestry", "10", "-o", tree_sequence_file]
         )
         assert len(stderr) == 0
         assert len(stdout) == 0
@@ -1352,7 +1369,18 @@ class TestMspAncestryOutput:
         tree_sequence_file = str(tmp_path / "out.ts")
         stdout, stderr = capture_output(
             cli.msp_main,
-            ["ancestry", "100", tree_sequence_file, "-L", "1e2", "-r", "5", "-k", "2"],
+            [
+                "ancestry",
+                "100",
+                "-o",
+                tree_sequence_file,
+                "-L",
+                "1e2",
+                "-r",
+                "5",
+                "-k",
+                "2",
+            ],
         )
         tree_sequence = tskit.load(tree_sequence_file)
         assert len(stderr) == 0
@@ -1383,8 +1411,6 @@ def tree_sequence_file(tmp_path, tree_sequence):
     tree_sequence.dump(tree_path)
     return str(tree_path)
 
-
-class TestMspMutateOutput:
     """
     Tests the output of msp mutate to ensure it's correct.
     """
@@ -1394,17 +1420,17 @@ class TestMspMutateOutput:
         out_path = tmp_path / "output.trees"
         mutated_tree_sequence.dump(in_path)
 
-        cmd = "mutate"
+        cmd = "mutations"
         mutation_rate = 10
         seed = 1
         stdout, stderr = capture_output(
             cli.msp_main,
             [
                 cmd,
-                str(in_path),
-                str(out_path),
-                "-u",
                 str(mutation_rate),
+                str(in_path),
+                "-o",
+                str(out_path),
                 "-s",
                 str(seed),
             ],
@@ -1412,21 +1438,20 @@ class TestMspMutateOutput:
         assert len(stderr) == 0
 
         tree_sequence = tskit.load(out_path)
-
         assert tree_sequence.num_mutations > mutated_tree_sequence.num_mutations
 
     def test_mutate_discrete_start_end_time(self, tree_sequence_file, tmp_path):
         out_tree_sequence_file = str(tmp_path / "out.ts")
 
-        cmd = "mutate"
+        cmd = "mut"
         stdout, stderr = capture_output(
             cli.msp_main,
             [
                 cmd,
-                tree_sequence_file,
-                out_tree_sequence_file,
-                "-u",
                 "10",
+                tree_sequence_file,
+                "-o",
+                out_tree_sequence_file,
                 "-s",
                 "1",
                 "--start-time",
@@ -1448,16 +1473,16 @@ class TestMspMutateOutput:
 
 class TestMspMutateModelOutput:
     def test_binary_uses_0_or_1_states(self, tree_sequence_file, tmp_path):
-        cmd = "mutate"
+        cmd = "mut"
         out_tree_sequence_file = str(tmp_path / "out.ts")
         stdout, stderr = capture_output(
             cli.msp_main,
             [
                 cmd,
+                "1",
                 tree_sequence_file,
+                "-o",
                 out_tree_sequence_file,
-                "--mutation-rate",
-                "10",
                 "--random-seed",
                 "1",
                 "--model",
@@ -1473,16 +1498,16 @@ class TestMspMutateModelOutput:
         assert set(tables.mutations.derived_state) <= {ord("0"), ord("1")}
 
     def test_default_jc69_uses_ACGT_states(self, tree_sequence_file, tmp_path):
-        cmd = "mutate"
+        cmd = "mut"
         out_tree_sequence_file = str(tmp_path / "out.ts")
         stdout, stderr = capture_output(
             cli.msp_main,
             [
                 cmd,
-                tree_sequence_file,
-                out_tree_sequence_file,
-                "--mutation-rate",
                 "10",
+                tree_sequence_file,
+                "-o",
+                out_tree_sequence_file,
                 "--random-seed",
                 "1",
             ],


### PR DESCRIPTION
A few updates to the CLI. We can now do:

```
$ msp ancestry 10 | msp mutations 0.1 -o mutated.trees
```

I renamed the ``mutate`` command to ``mutations`` for symmetry with the API functions. There's lots more that could be added, but I think this is a good forward compatible base to build on.

@winni2k @grahamgower, fancy taking a look? I'd kinda like to tag msprime 1.0 tomorrow morning, so it'd be great if you could have a quick look over.