### PR TITLE
Initial demes support (some updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.0.1] - 2021-05-XX
+
+- Change the semantics of Admixture events slightly so that ancestral
+  populations that are inactive, are marked as active ({pr}`1662`,
+  {issue}`1657`, {user}`jeromekelleher`, {user}`apragsdale`)
+
+- Initial support for Demes via the ``Demography.from_demes`` method.
+  ({pr}`1662`, {issue}`1675`, {user}`jeromekelleher`, {user}`apragsdale`)
+
+
 ## [1.0.0] - 2021-04-14
 
 Msprime 1.0 is a major update, recommended for all users. It introduces

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -6059,8 +6059,10 @@ msp_admixture(msp_t *self, demographic_event_t *event)
     for (index = 0; index < num_ancestral; index++) {
         pop = &self->populations[ancestral[index]];
         if (pop->state != MSP_POP_STATE_ACTIVE) {
-            ret = MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE;
-            goto out;
+            ret = msp_activate_population(self, ancestral[index]);
+            if (ret != 0) {
+                goto out;
+            }
         }
     }
 

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -2647,29 +2647,6 @@ test_population_state_machine_errors(void)
     msp_free(&msp);
     tsk_table_collection_free(&tables);
 
-    /* Inactive population as admix ancestral.*/
-    ret = build_sim(&msp, &tables, rng, 1, 2, NULL, 0);
-    CU_ASSERT_EQUAL(ret, 0);
-    /* 1 -> 0 */
-    ancestral[0] = 0;
-    ret = msp_add_admixture(&msp, 2, 1, 1, ancestral, proba);
-    CU_ASSERT_EQUAL(ret, 0);
-    /* 1 -> 0 */
-    derived[0] = 1;
-    ret = msp_add_population_split(&msp, 2, 1, derived, 0);
-    CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_set_population_configuration(&msp, 0, 1, 0, false);
-    CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_initialise(&msp);
-    CU_ASSERT_EQUAL(ret, 0);
-    ret = msp_debug_demography(&msp, &time);
-    CU_ASSERT_EQUAL_FATAL(ret, 0);
-    CU_ASSERT_EQUAL_FATAL(time, 2);
-    ret = msp_debug_demography(&msp, &time);
-    CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE);
-    msp_free(&msp);
-    tsk_table_collection_free(&tables);
-
     /* derived not active in split */
     ret = build_sim(&msp, &tables, rng, 1, 2, NULL, 0);
     CU_ASSERT_EQUAL(ret, 0);

--- a/lib/util.c
+++ b/lib/util.c
@@ -281,9 +281,6 @@ msp_strerror_internal(int err)
         case MSP_ERR_POPULATION_PREVIOUSLY_ACTIVE:
             ret = "Attempt to set a previously active population to active";
             break;
-        case MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE:
-            ret = "All ancestral populations in admixture must already be active";
-            break;
         case MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE:
             ret = "The derived population in an admixture must be active";
             break;

--- a/lib/util.h
+++ b/lib/util.h
@@ -118,10 +118,9 @@
 #define MSP_ERR_POPULATION_INACTIVE_MOVE                            -74
 #define MSP_ERR_POPULATION_INACTIVE_SAMPLE                          -75
 #define MSP_ERR_POPULATION_PREVIOUSLY_ACTIVE                        -76
-#define MSP_ERR_ADMIX_ANCESTRAL_NOT_ACTIVE                          -77
-#define MSP_ERR_SPLIT_DERIVED_NOT_ACTIVE                            -78
-#define MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE                            -79
-#define MSP_ERR_POP_SIZE_ZERO_SAMPLE                                -80
+#define MSP_ERR_SPLIT_DERIVED_NOT_ACTIVE                            -77
+#define MSP_ERR_ADMIX_DERIVED_NOT_ACTIVE                            -78
+#define MSP_ERR_POP_SIZE_ZERO_SAMPLE                                -79
 
 /* clang-format on */
 /* This bit is 0 for any errors originating from tskit */

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -458,8 +458,11 @@ class Demography(collections.abc.Mapping):
         ancestral population(s), an admixture has the following additional
         effects:
 
-        - All derived populations are set to
+        - The derived population is set to
           :ref:`inactive<sec_demography_populations_life_cycle>`.
+        - The ancestral populations are set to
+          :ref:`active<sec_demography_populations_life_cycle>`, if they are
+          not already active.
         - All migration rates to and from the derived population are set to 0.
         - Population sizes and growth rates for the derived population are set
           to 0, and the poulation is marked as inactive.
@@ -947,10 +950,10 @@ class Demography(collections.abc.Mapping):
         Returns a copy of this model. If the ``populations`` argument is
         specified, the populations in the copied model will be in this order.
 
-        @param list populations: A list of population identifiers defining the
+        :param list populations: A list of population identifiers defining the
             order of the populations in the new model. If not specified, the
             current order is used.
-        @return A copy of this Demography.
+        :return: A copy of this Demography.
         """
         if populations is None:
             populations = range(self.num_populations)

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -942,6 +942,74 @@ class Demography(collections.abc.Mapping):
                 population.initially_active = True
         return resolved
 
+    def copy(self, populations: Union[List[str], None] = None) -> Demography:
+        """
+        Returns a copy of this model. If the ``populations`` argument is
+        specified, the populations in the copied model will be in this order.
+
+        @param list populations: A list of population identifiers defining the
+            order of the populations in the new model. If not specified, the
+            current order is used.
+        @return A copy of this Demography.
+        """
+        if populations is None:
+            populations = range(self.num_populations)
+        if len(populations) != self.num_populations:
+            raise ValueError("populations must have Demography.num_populations entries")
+        copy_demog = Demography()
+        for identifier in populations:
+            pop = self[identifier]
+            copy_demog.add_population(
+                initial_size=pop.initial_size,
+                growth_rate=pop.growth_rate,
+                name=pop.name,
+                description=pop.description,
+                extra_metadata=pop.extra_metadata,
+                default_sampling_time=pop.default_sampling_time,
+                initially_active=pop.initially_active,
+            )
+        for copy_p1, copy_p2 in itertools.combinations(copy_demog.populations, 2):
+            self_p1 = self[copy_p1.name].id
+            self_p2 = self[copy_p2.name].id
+            copy_demog.migration_matrix[copy_p1.id, copy_p2.id] = self.migration_matrix[
+                self_p1, self_p2
+            ]
+            copy_demog.migration_matrix[copy_p2.id, copy_p1.id] = self.migration_matrix[
+                self_p2, self_p1
+            ]
+
+        def remap(identifier):
+            if identifier == -1:
+                return -1
+            return self[identifier].name
+
+        for event in self.events:
+            copy_event = copy.deepcopy(event)
+            if isinstance(event, (MassMigration, MigrationRateChange)):
+                copy_event.source = remap(event.source)
+                copy_event.dest = remap(event.dest)
+            elif isinstance(event, PopulationSplit):
+                copy_event.derived = [remap(pop) for pop in event.derived]
+                copy_event.ancestral = remap(event.ancestral)
+            elif isinstance(event, Admixture):
+                copy_event.ancestral = [remap(pop) for pop in event.ancestral]
+                copy_event.derived = remap(event.derived)
+            elif isinstance(
+                event,
+                (PopulationParametersChange, SimpleBottleneck, InstantaneousBottleneck),
+            ):
+                copy_event.population = remap(event.population)
+            elif isinstance(event, SymmetricMigrationRateChange):
+                copy_event.populations = [remap(pop) for pop in event.populations]
+            elif isinstance(event, CensusEvent):
+                # Census has no population
+                pass
+            else:
+                raise AssertionError("Event class not implemented in copy")
+            copy_demog.add_event(copy_event)
+
+        return copy_demog
+
     def sort_events(self):
         # Sort demographic events by time. Sorting is stable so the relative
         # order of events at the same time will be preserved.
@@ -1753,6 +1821,93 @@ class Demography(collections.abc.Mapping):
                 demographic_events,
                 population_map,
             )
+
+    @staticmethod
+    def from_demes(graph):
+        def get_growth_rate(epoch):
+            ret = 0
+            if epoch.size_function not in ["constant", "exponential"]:
+                raise ValueError(
+                    "msprime only supports constant exponentially changing "
+                    "population sizes"
+                )
+            if epoch.end_size != epoch.start_size:
+                ret = -math.log(epoch.start_size / epoch.end_size) / epoch.time_span
+            return ret
+
+        graph = graph.in_generations()
+
+        demography = Demography()
+        for deme in graph.demes:
+            initial_size = 0
+            growth_rate = 0
+            last_epoch = deme.epochs[-1]
+            if last_epoch.end_time == 0:
+                initial_size = last_epoch.end_size
+                growth_rate = get_growth_rate(last_epoch)
+            demography.add_population(
+                name=deme.name,
+                description=deme.description,
+                growth_rate=growth_rate,
+                initial_size=initial_size,
+                default_sampling_time=deme.end_time,
+            )
+            for epoch in deme.epochs:
+                new_initial_size = None
+                if initial_size != epoch.end_size:
+                    new_initial_size = epoch.end_size
+                new_growth_rate = None
+                alpha = get_growth_rate(epoch)
+                if growth_rate != alpha:
+                    new_growth_rate = alpha
+                if new_growth_rate is not None or new_initial_size is not None:
+                    demography.add_population_parameters_change(
+                        population=deme.name,
+                        time=epoch.end_time,
+                        initial_size=new_initial_size,
+                        growth_rate=new_growth_rate,
+                    )
+                    initial_size = new_initial_size
+                    growth_rate = new_growth_rate
+
+        events = dict(graph.discrete_demographic_events())
+        for split in events.pop("splits"):
+            demography.add_population_split(
+                time=split.time, ancestral=split.parent, derived=split.children
+            )
+        for pulse in events.pop("pulses"):
+            assert False
+        for branch in events.pop("branches"):
+            demography.add_mass_migration(
+                time=branch.time, source=branch.child, dest=branch.parent, proportion=1
+            )
+        for merger in events.pop("mergers"):
+            assert False
+        for admixture in events.pop("admixtures"):
+            assert False
+        assert len(events) == 0
+
+        for migration in graph.migrations:
+            if migration.end_time == 0:
+                demography.set_migration_rate(
+                    source=migration.dest, dest=migration.source, rate=migration.rate
+                )
+            else:
+                demography.add_migration_rate_change(
+                    time=migration.end_time,
+                    source=migration.dest,
+                    dest=migration.source,
+                    rate=migration.rate,
+                )
+            if not math.isinf(migration.start_time):
+                demography.add_migration_rate_change(
+                    time=migration.start_time,
+                    source=migration.dest,
+                    dest=migration.source,
+                    rate=0,
+                )
+        demography.sort_events()
+        return demography
 
     @staticmethod
     def from_tree_sequence(

--- a/requirements/CI-complete/requirements.txt
+++ b/requirements/CI-complete/requirements.txt
@@ -1,6 +1,7 @@
 bintrees==2.1.0
 codecov==2.1.10
 daiquiri==3.0.0
+demes=0.1.1
 mypy==0.812 
 newick==1.2.0
 numpy==1.20.2

--- a/requirements/CI-complete/requirements.txt
+++ b/requirements/CI-complete/requirements.txt
@@ -1,7 +1,7 @@
 bintrees==2.1.0
 codecov==2.1.10
 daiquiri==3.0.0
-demes=0.1.1
+demes==0.1.1
 mypy==0.812 
 newick==1.2.0
 numpy==1.20.2

--- a/requirements/CI-docs/requirements.txt
+++ b/requirements/CI-docs/requirements.txt
@@ -1,5 +1,6 @@
 docutils==0.15  # issue with 0.17, https://github.com/tskit-dev/msprime/issues/1625
 daiquiri==2.1.1
+demes=0.1.1
 setuptools-scm==4.1.2
 sphinx==3.3.1
 sphinx-argparse==0.2.5

--- a/requirements/CI-docs/requirements.txt
+++ b/requirements/CI-docs/requirements.txt
@@ -1,6 +1,6 @@
 docutils==0.15  # issue with 0.17, https://github.com/tskit-dev/msprime/issues/1625
 daiquiri==2.1.1
-demes=0.1.1
+demes==0.1.1
 setuptools-scm==4.1.2
 sphinx==3.3.1
 sphinx-argparse==0.2.5

--- a/requirements/CI-tests-conda/requirements.txt
+++ b/requirements/CI-tests-conda/requirements.txt
@@ -1,3 +1,4 @@
 gsl
 tskit==0.3.5
 stdpopsim==0.1.2
+demes==0.1.1

--- a/requirements/CI-tests-pip/requirements.txt
+++ b/requirements/CI-tests-pip/requirements.txt
@@ -1,5 +1,6 @@
 bintrees==2.1.0
 daiquiri==3.0.0
+demes==0.1.1
 newick==1.2.0
 numpy==1.20.2
 pytest==6.2.3

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,7 +4,7 @@ bintrees
 codecov
 coverage
 daiquiri
-demes
+demes>=0.1.0
 flake8
 matplotlib>=3.4.0
 mock

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,6 +4,7 @@ bintrees
 codecov
 coverage
 daiquiri
+demes
 flake8
 matplotlib>=3.4.0
 mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     numpy
     newick 
     tskit>=0.3.5
+    demes
 setup_requires =
     numpy
     setuptools

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -1,0 +1,208 @@
+#
+# Copyright (C) 2021 University of Oxford
+#
+# This file is part of msprime.
+#
+# msprime is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# msprime is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with msprime.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Test cases for demes support.
+"""
+import textwrap
+
+import demes
+import numpy as np
+import pytest
+
+import msprime
+
+
+class TestDemes:
+    def test_ooa_example(self):
+        b = demes.Builder(
+            description="Gutenkunst et al. (2009) three-population model.",
+            doi=["10.1371/journal.pgen.1000695"],
+            time_units="years",
+            generation_time=25,
+        )
+        b.add_deme("ANC", epochs=[dict(end_time=220e3, start_size=7300)])
+        b.add_deme(
+            "AMH",
+            ancestors=["ANC"],
+            epochs=[dict(end_time=140e3, start_size=12300)],
+        )
+        b.add_deme(
+            "OOA", ancestors=["AMH"], epochs=[dict(end_time=21.2e3, start_size=2100)]
+        )
+        b.add_deme("YRI", ancestors=["AMH"], epochs=[dict(start_size=12300)])
+        # Use floating point values here to make the comparisons simpler.
+        b.add_deme(
+            "CEU",
+            ancestors=["OOA"],
+            epochs=[dict(start_size=1000, end_size=29725.34354)],
+        )
+        b.add_deme(
+            "CHB",
+            ancestors=["OOA"],
+            epochs=[dict(start_size=510, end_size=54090.33108)],
+        )
+        b.add_migration(demes=["YRI", "OOA"], rate=25e-5)
+        b.add_migration(demes=["YRI", "CEU"], rate=3e-5)
+        b.add_migration(demes=["YRI", "CHB"], rate=1.9e-5)
+        b.add_migration(demes=["CEU", "CHB"], rate=9.6e-5)
+
+        g = b.resolve()
+
+        ooa1 = msprime.Demography.from_demes(g)
+        ooa2 = msprime.Demography._ooa_model().copy([d.name for d in g.demes])
+        ooa2.assert_equivalent(ooa1)
+
+
+class TestYamlExamples:
+    def from_yaml(self, yaml):
+        graph = demes.loads(textwrap.dedent(yaml))
+        return msprime.Demography.from_demes(graph)
+
+    def test_one_pop_two_epoch(self):
+        yaml = """\
+        description: Single-population two-epoch demography.
+        time_units: generations
+        demes:
+
+        - name: deme0
+          description: A deme that doubles in size 100 generations ago.
+          epochs:
+          - start_size: 1000
+            end_time: 100
+          - start_size: 2000
+            end_time: 0
+        """
+        d = self.from_yaml(yaml)
+        assert d.num_populations == 1
+        assert d.populations[0].name == "deme0"
+        dbg = d.debug()
+        assert dbg.num_epochs == 2
+        assert dbg.epochs[0].populations[0].start_size == 2000
+        assert dbg.epochs[1].populations[0].start_size == 1000
+        assert dbg.epochs[1].start_time == 100
+
+    def test_zigzag(self):
+        yaml = """\
+        time_units: generations
+        demes:
+          - name: generic
+            epochs:
+            - {end_time: 34133.31, start_size: 7156}
+            - {end_time: 8533.33, end_size: 71560}
+            - {end_time: 2133.33, end_size: 7156}
+            - {end_time: 533.33, end_size: 71560}
+            - {end_time: 133.33, end_size: 7156}
+            - {end_time: 33.333, end_size: 71560}
+            - {end_time: 0, end_size: 71560}
+        """
+        d = self.from_yaml(yaml)
+        assert d.num_populations == 1
+        dbg = d.debug()
+        assert dbg.epochs[0].populations[0].start_size == pytest.approx(71560)
+        assert dbg.epochs[1].populations[0].start_size == pytest.approx(71560)
+        assert dbg.epochs[2].populations[0].start_size == pytest.approx(7156)
+        assert dbg.epochs[3].populations[0].start_size == pytest.approx(71560)
+        assert dbg.epochs[4].populations[0].start_size == pytest.approx(7156)
+        assert dbg.epochs[5].populations[0].start_size == pytest.approx(71560)
+        assert dbg.epochs[6].populations[0].start_size == pytest.approx(7156)
+        assert dbg.epochs[0].start_time == 0
+        assert dbg.epochs[1].start_time == pytest.approx(33.333)
+        assert dbg.epochs[2].start_time == pytest.approx(133.33)
+        assert dbg.epochs[3].start_time == pytest.approx(533.33)
+        assert dbg.epochs[4].start_time == pytest.approx(2133.33)
+        assert dbg.epochs[5].start_time == pytest.approx(8533.33)
+        assert dbg.epochs[6].start_time == pytest.approx(34133.31)
+
+    def test_split(self):
+        yaml = """\
+        time_units: generations
+        demes:
+          - name: X
+            epochs:
+              - end_time: 1000
+                start_size: 2000
+          - name: A
+            ancestors:
+              - X
+            epochs:
+              - start_size: 2000
+          - name: B
+            ancestors:
+              - X
+            epochs:
+              - start_size: 2000
+        """
+        d = self.from_yaml(yaml)
+        assert d.num_populations == 3
+        assert d.populations[0].name == "X"
+        assert d.populations[1].name == "A"
+        assert d.populations[2].name == "B"
+        assert d.populations[0].initial_size == 0
+        assert d.populations[1].initial_size == 2000
+        assert d.populations[2].initial_size == 2000
+        assert d.num_events == 2
+        assert isinstance(d.events[1], msprime.demography.PopulationSplit)
+
+        dbg = d.debug()
+        assert dbg.num_epochs == 2
+        epoch = dbg.epochs[0]
+        assert not epoch.populations[0].active
+        assert epoch.populations[1].active
+        assert epoch.populations[1].start_size == 2000
+        assert epoch.populations[2].active
+        assert epoch.populations[2].start_size == 2000
+
+        epoch = dbg.epochs[1]
+        assert epoch.start_time == 1000
+        assert epoch.populations[0].active
+        assert epoch.populations[0].start_size == 2000
+        assert not epoch.populations[1].active
+        assert not epoch.populations[2].active
+
+        x = dbg.possible_lineage_locations(["A", "B"])
+        assert len(x) == 2
+        assert list(x[(0, 1000)]) == [False, True, True]
+        assert list(x[(1000, np.inf)]) == [True, False, False]
+
+    def test_branch(self):
+        yaml = """\
+        time_units: generations
+        demes:
+          - name: X
+            epochs:
+              - start_size: 2000
+          - name: A
+            ancestors: [X]
+            start_time: 1000
+            epochs:
+              - start_size: 2000
+        """
+        d = self.from_yaml(yaml)
+        assert d.num_populations == 2
+
+        dbg = d.debug()
+        assert dbg.num_epochs == 2
+        for epoch in dbg.epochs:
+            assert epoch.populations[0].start_size == 2000
+            assert epoch.populations[1].start_size == 2000
+
+        x = dbg.possible_lineage_locations(["X", "A"])
+        assert len(x) == 2
+        assert list(x[(0, 1000)]) == [True, True]
+        assert list(x[(1000, np.inf)]) == [True, False]

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -4597,6 +4597,99 @@ class TestDemographyObject:
         assert not validated["C"].initially_active
 
 
+class TestDemographyCopy:
+    def test_empty(self):
+        d1 = msprime.Demography()
+        d2 = d1.copy()
+        assert d1 is not d2
+        d1.assert_equal(d2)
+
+    def test_all_events(self):
+        d1 = all_events_example_demography(integer_ids=False)
+        d1.assert_equal(d1)
+        d2 = d1.copy()
+        d1.assert_equal(d2)
+
+    def test_all_events_permute(self):
+        d1 = all_events_example_demography(integer_ids=False)
+        populations = [pop.name for pop in d1.populations]
+        d2 = d1.copy(populations=populations[::-1])
+        assert d1 != d2
+        d2 = d2.copy(populations=populations)
+        d1.assert_equal(d2)
+
+    def test_migration_matrix(self):
+        d1 = msprime.Demography.isolated_model([10] * 5)
+        d1.migration_matrix[:] = np.arange(25).reshape(5, 5)
+        np.fill_diagonal(d1.migration_matrix, 0)
+        d1.assert_equal(d1)
+        d2 = d1.copy()
+        d1.assert_equal(d2)
+
+    def test_migration_matrix_permutation(self):
+        d1 = msprime.Demography.isolated_model([10] * 5)
+        d1.migration_matrix[:] = np.arange(25).reshape(5, 5)
+        np.fill_diagonal(d1.migration_matrix, 0)
+        d1.assert_equal(d1)
+        populations = [pop.name for pop in d1.populations]
+        d2 = d1.copy(populations[::-1])
+        assert d1 != d2
+        d2 = d2.copy(populations)
+        d1.assert_equal(d2)
+
+    def test_population_attrs(self):
+        d1 = msprime.Demography()
+        d1.add_population(
+            name="asr",
+            initial_size=1234,
+            growth_rate=0.234,
+            description="ASDF",
+            extra_metadata={"a": "B", "c": 1234},
+            default_sampling_time=0.2,
+            initially_active=True,
+        )
+        d2 = d1.copy()
+        d1.assert_equal(d2)
+
+    def test_populations_remap(self):
+        d1 = msprime.Demography()
+        d1.add_population(initial_size=1, name="A")
+        d1.add_population(initial_size=2, name="B")
+        d2 = d1.copy(["B", "A"])
+        assert d2.populations[0].name == "B"
+        assert d2.populations[0].initial_size == 2
+        assert d2.populations[1].name == "A"
+        assert d2.populations[1].initial_size == 1
+
+    def test_populations_remap_integers(self):
+        d1 = msprime.Demography()
+        d1.add_population(initial_size=1, name="A")
+        d1.add_population(initial_size=2, name="B")
+        d2 = d1.copy([1, 0])
+        assert d2.populations[0].name == "B"
+        assert d2.populations[0].initial_size == 2
+        assert d2.populations[1].name == "A"
+        assert d2.populations[1].initial_size == 1
+
+    def test_bad_populations_arg(self):
+        d1 = msprime.Demography()
+        d1.add_population(initial_size=1, name="A")
+        d1.add_population(initial_size=1, name="B")
+        with pytest.raises(ValueError):
+            d1.copy([])
+        with pytest.raises(ValueError, match="Duplicate"):
+            d1.copy(["A", "A"])
+        with pytest.raises(KeyError, match="not found"):
+            d1.copy(["A", "C"])
+
+    def test_unknown_event_error(self):
+        d1 = msprime.Demography()
+        d1.add_population(initial_size=1, name="A")
+        d1.events.append(None)
+        with pytest.raises(AssertionError, match="not implemented"):
+            d1.copy()
+
+
 class TestMissingPopulation:
     def test_add_population_split(self):
         demography = msprime.Demography()


### PR DESCRIPTION
This takes this PR #1656 and adds some functionality and tests. It also addresses #1657 so that inactive populations are activated when they are ancestral populations in an admixture event.

Sorry for the duplicate @jeromekelleher ... wasn't able to figure out how to add and push to your PR, so copied it to work on it further.