### PR TITLE
fix typos in ancestry.py and intervals.py

### DIFF
--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -530,7 +530,7 @@ def simulate(
         samples, and cannot be used in conjunction with the ``sample_size``
         parameter. Each sample is a (``population``, ``time``) pair
         such that the sample in position ``j`` in the list of samples
-        is drawn in the specified population at the specfied time. Time
+        is drawn in the specified population at the specified time. Time
         is measured in generations ago, as elsewhere.
     :param int random_seed: The random seed. If this is `None`, a
         random seed will be automatically generated. Valid random
@@ -1366,7 +1366,7 @@ class Simulator(_msprime.Simulator):
         while ret == ExitReason.MAX_EVENTS:
             ret = ExitReason(super().run(end_time, event_chunk))
             if self.time > end_time:
-                # Currently the Pedigree and Sweeps models are "non-rentrant"
+                # Currently the Pedigree and Sweeps models are "non-reentrant"
                 # We can change this to an assertion once these have been fixed.
                 raise RuntimeError(
                     f"Model {self.model['name']} does not support interruption. "
@@ -1485,7 +1485,7 @@ class Simulator(_msprime.Simulator):
 @dataclasses.dataclass
 class SampleSet:
     """
-    Specify a set of exchangable sample individuals with a given ploidy
+    Specify a set of exchangeable sample individuals with a given ploidy
     value from a population at a given time. See the
     :ref:`sec_ancestry_samples` section for details and examples.
     """
@@ -1568,7 +1568,7 @@ class AncestryModel:
     """
     name: ClassVar[str]
 
-    # We have to define an __init__ to enfore keyword-only behaviour
+    # We have to define an __init__ to enforce keyword-only behaviour
     def __init__(self, *, duration=None):
         self.duration = duration
 

--- a/msprime/intervals.py
+++ b/msprime/intervals.py
@@ -89,7 +89,7 @@ class RateMap(collections.abc.Mapping):
         # It's really the sum of the mass up to but not including the current
         # interval, which is a bit confusing. Probably best to just leave
         # it as a function, so that people can sample at regular positions
-        # along the genome anyway, empasising that it's a continuous function,
+        # along the genome anyway, emphasising that it's a continuous function,
         # not a step function like the other interval attributes.
         self._cumulative_mass = np.insert(np.nancumsum(self.mass), 0, 0)
         assert self._cumulative_mass[0] == 0
@@ -583,7 +583,7 @@ class RateMap(collections.abc.Mapping):
         if sequence_length is not None:
             if sequence_length < end:
                 raise ValueError(
-                    "The sequence_length cannot be less that the last physical position "
+                    "The sequence_length cannot be less than the last physical position "
                     f" ({physical_positions[-1]})"
                 )
             if sequence_length > end:


### PR DESCRIPTION
Fixes some typos in the code and docs that I've come across a few times (I closed my the previous PR with these changes since my branch was messed up).

By the way, this is my second PR with typo fixes and I'm conscious that this might be noisy for others. Perhaps it would be better to keep a running list of typos and fix them all in one big PR?