### PR TITLE
Initial proposal for demes CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.2] - 2021-06-XX
+
+**New features**:
+
+- Support for Demes input and logging in the msp simulate CLI
+  ({pr}`1716`, {user}`jeromekelleher`).
+
 ## [1.0.1] - 2021-05-10
 
 Minor feature release with experimental Demes support.


### PR DESCRIPTION
Here's a proposal for simulating demographic models from the command line, allowing us to do stuff like
```
$ msp ancestry YRI:10 CHB:10 -d ooa.yaml -o tmp.trees
```
ie., sample 10 individuals from the YRI population and 10 from the CHB population, directly corresponding to the mapping form of the ``samples`` argument (and kind-of sharing notation, by using ":" as the separator).

It pains me to have substructure that we have to parse out of the command line args, but I think this form is about as good as it's going to get. 

Thoughts? @apragsdale @grahamgower @molpopgen @petrelharp

(If we like this CLI notation, then I'd suggest we update stdpopsim to use the same approach)