### PR TITLE
Update Python version of simulator to use tables as input

### DIFF
--- a/tests/test_pedigree.py
+++ b/tests/test_pedigree.py
@@ -250,6 +250,7 @@ def simulate_pedigree(
             for _ in range(num_children):
                 ind_id = add_individual(generation, parents=parents.astype(np.int32))
                 curr_gen.append(ind_id)
+    tables.build_index()
     return tables
 
 


### PR DESCRIPTION
These are minimal changes needed to get the pedigree simulator working with the new specification of pedigrees, i.e., via the information in a TableCollection.

To simulate a simple pedigree, we can now do:
```
python3 tests/test_pedigree.py 10 10 > pedigree.trees
```
This writes out a tree sequence containing pedigree information (10 founders for 10 generations). I've udpated this simulator to output node information also, so that the times and locations etc of individuals are stored in the node properties, ``time``, ``population``, ``flags`` etc.

Then, we can provide this pedigree as input to algorithms.py via 
```
python3 algorithms.py 0 -r 0.1 --model=wf_ped -F pedigree.trees tmp.trees -v 
```

The advantage here is that we can completely specify the required state of the simulation with existing data structures, and there's a clear path towards making things more complex, e.g., via multiple populations etc.

There's still a fair bit of refactoring to do, but at least this gets the code working.

Closes #1739