### PR TITLE
clarify units of `initial_size`

### DIFF
--- a/docs/demography.md
+++ b/docs/demography.md
@@ -303,8 +303,11 @@ and makes it easier to avoid
 
 #### Initial size
 
-The `initial_size` of a population is its size at the start of a simulation
+The `initial_size` of a population is its size, as a number of individuals,
+at the start of a simulation
 (looking {ref}`backwards in time<sec_demography_direction_of_time>`).
+In other words, an initial size of ``n`` means that the population had
+``n * ploidy`` chromosomes at the most recent time.
 If the population's
 {ref}`sec_demography_populations_growth_rate` is zero, then
 the population will have the same size for all time (unless there are

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1060,7 +1060,7 @@ def sim_ancestry(
         greater than or equal to 1. For continuous genomes the tract lengths are
         exponentially distributed with mean ``gene_conversion_tract_length``,
         which must be larger than 0.
-    :param population_size: The size of the default single population
+    :param population_size: The number of individuals of the default single population
         :class:`.Demography`. If not specified, defaults to 1. Cannot be specified
         along with the ``demography`` parameter. See the :ref:`sec_demography`
         section for more details on demographic models and population sizes

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -234,9 +234,9 @@ class Demography(collections.abc.Mapping):
         to ``"pop_{id}"``. An :ref:`sec_demography_populations_initial_size`
         value must be specified (but may be zero).
 
-        :param float initial_size: The size of the population at time zero.
-            See the :ref:`sec_demography_populations_initial_size` section
-            for more details and examples.
+        :param float initial_size: The number of individuals of the population
+            at time zero.  See the :ref:`sec_demography_populations_initial_size`
+            section for more details and examples.
         :param float growth_rate: The exponential growth rate of the
             population. See the :ref:`sec_demography_populations_growth_rate`
             section for more details and examples.
@@ -621,7 +621,7 @@ class Demography(collections.abc.Mapping):
 
         :param float time: The length of time ago at which this event
             occurred.
-        :param float initial_size: The absolute size of the population
+        :param float initial_size: The number of individuals in the population
             at the beginning of the time slice starting at ``time``. If None,
             the initial_size of the population is computed according to
             the initial population size and growth rate over the preceding
@@ -1467,8 +1467,8 @@ class Demography(collections.abc.Mapping):
 
         :param str tree: The tree string in Newick format, with named leaves and branch
             lengths.
-        :param initial_size: Each population's initial_size. May be a single number
-            or a mapping from population names to their sizes.
+        :param initial_size: Each population's initial_size, in numbers of individuals.
+            May be a single number or a mapping from population names to their sizes.
         :param growth_rate: Each population's growth_rate. May be a single number
             or a mapping from population names to their exponential growth rates.
             Defaults to zero.
@@ -2015,7 +2015,7 @@ class Demography(collections.abc.Mapping):
         :param tskit.TreeSequence ts: The tree sequence
             to extract population information from.
         :param float initial_size: The default initial size for the newly
-            added populations (Default=0).
+            added populations, as a number of individuals (Default=0).
         :return: A Demography object representing the populations in the
             specified tree sequence.
         :rtype: .Demography


### PR DESCRIPTION
There's a number of places where we just say "population size" without reminding the reader it's in units of individuals (i.e., multiplied by ploidy). Maybe this makes things more clear?