### PR TITLE
Update sphinx developer requirements.

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -24,7 +24,7 @@ scipy
 # TODO we're pinning the version here because of problems on Travis.
 # versions weren't correctly being set for v1.12.1
 setuptools_scm == 1.11.1
-sphinx==3.3.1
+sphinx<4
 sphinx-argparse
 sphinx-issues
 jupyter-book


### PR DESCRIPTION
Following updates to union types in #1742, only newer versions of sphinx 3.x
can build the docs successfully.

Closes #1793.