### PR TITLE
Experimental yaml input format

### DIFF
--- a/msprime/json_input.py
+++ b/msprime/json_input.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2021 University of Oxford
+#
+# This file is part of msprime.
+#
+# msprime is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# msprime is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with msprime.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+Define formats used for simulation input as JSON and related formats.
+"""
+from __future__ import annotations
+
+import copy
+import json
+
+import demes
+from ruamel.yaml import YAML
+
+import msprime
+
+
+def parse_ancestry_json(data):
+    data = copy.deepcopy(data)
+    if "start_time" in data or "end_time" in data:
+        raise ValueError(
+            "specifying time values not currently supported as too confusing"
+        )
+    if "demography" in data:
+        demes_dict = data["demography"]
+        # TODO nasty going back to JSON here - can we make a demes.fromdict()
+        # function to do this directly?
+        demes_model = demes.loads(json.dumps(demes_dict), format="json")
+        data["demography"] = msprime.Demography.from_demes(demes_model)
+    return data
+
+
+def parse_ancestry_yaml(text):
+
+    yaml = YAML(typ="safe")
+    return parse_ancestry_json(yaml.load(text))


### PR DESCRIPTION
This is an experiment to see what a yaml/json input format (building on demes) would look like. It mostly works I think, except for the basic confusion about the direction of time. We can easily imagine adding to this to allow for things like recombination maps.

Here's an example input file:

```yaml
demography:
  # This is an **embedded** Demes yaml model.
  time_units: generations
  demes:
    - name: X
      epochs: [{end_time: 1000, start_size: 2000}]
    - name: A
      ancestors: [X]
      epochs: [{start_size: 2000}]
    - name: B
      ancestors: [X]
      epochs: [{start_size: 2000}]

# Note: We are **referring** to the Demes model here.
samples: {A: 100, B: 100}
sequence_length: 100000
recombination_rate: 1e-8
ploidy: 1
model: hudson
```

The idea is that we *embed* the Demes yaml description within the larger simulation configuration context. When we're parsing the input yaml, we just hand-off the parsing of the ``demography`` object to ``demes-python`` which will do all the hard work for us. 

I'm not suggesting this as a general specification for popgen simulations, I just want to illustrate the power that we get from keeping making Demes simple and self-contained.  To me, the ability to make a simple configuration file for a specific simulator like this is a powerful argument for not over-specifying the standard.

Any thoughts @molpopgen @grahamgower @apragsdale? I've been talking about simulation configurations being able to "refer" to elements of the Demes model for a while, and this is an attempt to make things concrete. (I guess we shouldn't get into detailed discussions about Demes itself here though: if someone wants to follow up, maybe create an issue on the spec repo to discuss?)