### PR TITLE
Do not use inspect to generate provenance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.3] - 2021-XX-XX
+## [1.0.3] - 2021-11-12
 
 **New features**:
 
@@ -12,6 +12,10 @@
 - Fix bug in full ARG simulation with missing regions of the genome,
   where ARG nodes were not correctly returned. ({issue}`1893`,
   {user}`jeromekelleher`, {user}`hyl317`)
+
+- Fix memory leak when running ``sim_ancestry`` in a loop
+  ({pr}`1904`, {issue}`1899`, {user}`jeromekelleher`, {user}`grahamgower`).
+
 
 ## [1.0.2] - 2021-06-29
 

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -25,7 +25,6 @@ import collections.abc
 import copy
 import dataclasses
 import enum
-import inspect
 import json
 import logging
 import math
@@ -411,28 +410,6 @@ def _parse_replicate_index(*, replicate_index, random_seed, num_replicates):
     return replicate_index
 
 
-def _build_provenance(command, random_seed, frame):
-    """
-    Builds a provenance dictionary suitable for use as the basis
-    of tree sequence provenance in replicate simulations. Uses the
-    specified stack frame to determine the values of the arguments
-    passed in, with a few exceptions.
-    """
-    argspec = inspect.getargvalues(frame)
-    # num_replicates is excluded as provenance is per replicate
-    # replicate index is excluded as it is inserted for each replicate
-    parameters = {
-        "command": command,
-        **{
-            arg: argspec.locals[arg]
-            for arg in argspec.args
-            if arg not in ["num_replicates", "replicate_index"]
-        },
-    }
-    parameters["random_seed"] = random_seed
-    return provenance.get_provenance_dict(parameters)
-
-
 def simulate(
     sample_size=None,
     *,
@@ -579,8 +556,31 @@ def simulate(
     random_seed = _parse_random_seed(random_seed)
     provenance_dict = None
     if record_provenance:
-        frame = inspect.currentframe()
-        provenance_dict = _build_provenance("simulate", random_seed, frame)
+        parameters = dict(
+            command="simulate",
+            sample_size=sample_size,
+            Ne=Ne,
+            length=length,
+            recombination_rate=recombination_rate,
+            recombination_map=recombination_map,
+            mutation_rate=mutation_rate,
+            population_configurations=population_configurations,
+            pedigree=pedigree,
+            migration_matrix=migration_matrix,
+            demographic_events=demographic_events,
+            samples=samples,
+            model=model,
+            record_migrations=record_migrations,
+            from_ts=from_ts,
+            start_time=start_time,
+            end_time=end_time,
+            record_full_arg=record_full_arg,
+            num_labels=num_labels,
+            random_seed=random_seed,
+            # num_replicates is excluded as provenance is per replicate
+            # replicate index is excluded as it is inserted for each replicate
+        )
+        provenance_dict = provenance.get_provenance_dict(parameters)
 
     if mutation_generator is not None:
         # This error was added in version 0.6.1.
@@ -1138,8 +1138,29 @@ def sim_ancestry(
     random_seed = _parse_random_seed(random_seed)
     provenance_dict = None
     if record_provenance:
-        frame = inspect.currentframe()
-        provenance_dict = _build_provenance("sim_ancestry", random_seed, frame)
+        parameters = dict(
+            command="sim_ancestry",
+            samples=samples,
+            demography=demography,
+            sequence_length=sequence_length,
+            discrete_genome=discrete_genome,
+            recombination_rate=recombination_rate,
+            gene_conversion_rate=gene_conversion_rate,
+            gene_conversion_tract_length=gene_conversion_tract_length,
+            population_size=population_size,
+            ploidy=ploidy,
+            model=model,
+            initial_state=initial_state,
+            start_time=start_time,
+            end_time=end_time,
+            record_migrations=record_migrations,
+            record_full_arg=record_full_arg,
+            num_labels=num_labels,
+            random_seed=random_seed,
+            # num_replicates is excluded as provenance is per replicate
+            # replicate index is excluded as it is inserted for each replicate
+        )
+        provenance_dict = provenance.get_provenance_dict(parameters)
     sim = _parse_sim_ancestry(
         samples=samples,
         sequence_length=sequence_length,

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1331,6 +1331,21 @@ def sim_mutations(
     else:
         seed = int(seed)
 
+    parameters = dict(
+        command="sim_mutations",
+        tree_sequence=tree_sequence,
+        rate=rate,
+        model=model,
+        start_time=start_time,
+        end_time=end_time,
+        discrete_genome=discrete_genome,
+        keep=keep,
+        random_seed=seed,
+    )
+    encoded_provenance = provenance.json_encode_provenance(
+        provenance.get_provenance_dict(parameters)
+    )
+
     if rate is None:
         rate = 0
     try:
@@ -1349,17 +1364,6 @@ def sim_mutations(
     keep = core._parse_flag(keep, default=True)
 
     model = mutation_model_factory(model)
-
-    argspec = inspect.getargvalues(inspect.currentframe())
-    parameters = {
-        "command": "sim_mutations",
-        **{arg: argspec.locals[arg] for arg in argspec.args},
-    }
-    parameters["random_seed"] = seed
-    encoded_provenance = provenance.json_encode_provenance(
-        provenance.get_provenance_dict(parameters)
-    )
-
     rng = _msprime.RandomGenerator(seed)
     lwt = _msprime.LightweightTableCollection()
     lwt.fromdict(tables.asdict())


### PR DESCRIPTION
Closes #1899

Turns out to be much easier to just remove the calls to inspect and put in some simple dictionary code. I changed around some tests for sim_mutations, because there didn't seem to be much reason to make the semantics different to sim_ancestry (which stores almost all parameters as passed in).

@benjeffery, does this look OK to you?

Confirming this fixes the memory leak:

![fixed](https://user-images.githubusercontent.com/2664569/141360537-f45f4830-5cad-4d5e-a22d-db097afe659c.png)


