### PR TITLE
Improve performance in the lots-of-simulations case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Support for running full ARG simulations with gene conversion
   ({pr}`1801`, {issue}`1773`, {user}`JereKoskela`).
 
+- Improved performance when running many small simulations
+  ({pr}`1909`, {user}`jeromekelleher`.
+
 **Bug fixes**:
 
 - Fix bug in full ARG simulation with missing regions of the genome,

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -6651,3 +6651,15 @@ class TestStdpopsimModels:
             if len(pop_map) == 1:
                 assert np.all(epoch_local.migration_matrix == 0)
                 assert np.all(epoch_sps.migration_matrix == 0)
+
+
+def test_lru_cache():
+    # Very basic test, as this is pulled directly from Python docs.
+    d = demog_mod.LruCache(2)
+    d[0] = 0
+    assert len(d) == 1
+    d[1] = 1
+    assert len(d) == 2
+    d[2] = 2
+    assert len(d) == 2
+    assert 0 not in d


### PR DESCRIPTION
Second pass at this - in retropect, hacking in dodgy hash definitions is a terrible idea. It's not worth the convenience of the lru_cache decorator.

@grahamgower, can you take a quick look please? Performance is the same as the other version.