### PR TITLE
PedigreeBuilder API

### DIFF
--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -56,6 +56,7 @@ from msprime.demography import (
     Population,
 )
 
+from msprime.pedigrees import PedigreeBuilder
 from msprime.intervals import RateMap
 from msprime.likelihood import log_arg_likelihood, log_mutation_likelihood
 
@@ -130,6 +131,7 @@ __all__ = [
     "NODE_IS_GC_EVENT",
     "NUCLEOTIDES",
     "PAM",
+    "PedigreeBuilder",
     "Population",
     "PopulationConfiguration",
     "PopulationParametersChange",


### PR DESCRIPTION
One of the major missing pieces for the fixed pedigree simulations is to decide on the user interface: how does the user input their pedigree, along with the information required for msprime to run the simulations? For the first iteration of the fixed pedigree simulations we need to know (a) the time of each individual; (b) its population (if this is ultimately a multi-population simulation); (c) whether this individual is a sample.

One option (considered in #1857) is to use an existing pedigree file format like the plink FAM file. However, FAM files are quite limited (fixed columns of FID, IID, PAT, MAT, SEX, PHENOTYPE). We could add some extra columns to the FAM file format, but then it becomes confusing: what do we do with the phenotype column? How do we validate the "POPULATION" column? 

Another option is to create our own text file format, say something like this:
```
# is_sample parent0 parent1 time    population  metadata
0   -1  -1  1.0 0   {"a": "b"}
0   -1  -1  1.0 0   {"a": "b"}
1   0   1   0.0 0   {"a": "b"}
```
This is a direct mapping into the tskit/msprime model of the pedigree (zero based IDs derived from the row number), with all the information we need and arbitrary JSON metadata associated with each individual. The problem with this approach is that users will have to write some code to parse the pedigree information they have in whatever format it's in, and produce the tskit model - this will require detailed documentation and explanation of what's required *and* it's a non-trivial piece of work to write the parser for this format (having the JSON metadata breaks np.loadtxt, e.g.). Also, the format is quite rigid, and would make it difficult to add a more columns in the future (e.g., ``sex``).

So, I suggest a middle ground - provide an API that will help users build an msprime pedigree model, and provide a framework for doing things the filling in missing times etc later. This is a first draft of what that API might look like.

Here's some example usage:
```python
demography = msprime.Demography.isolated_model([100])
builder = msprime.PedigreeBuilder(demography)
p0 = builder.add_individual(time=1, metadata={"whaever":"you want to store"})
p1 = builder.add_individual(time=1)
child = builder.add_individual(time=0,  parents=[p0, p1])
pedigree = builder.finalise(sequence_length=10)
```
First, we *require* a demography to be specified. This allows us to validate population ID/names (in a multi-population model) but also makes it clear that you *must* specify the demography. This isn't so much for the fixed pedigree simulation, but to define what happens *outside* the fixed pedigree. Requiring the demography to be specified up front is less obviously necessary here, but we'll see an example in a minute where it's useful. Then, we run it like this:

```python
ped_ts = msprime.sim_ancestry(
    initial_state=pedigree, demography=demography, random_seed=1, model="wf_ped"
)       
print(ped_ts.draw_text())    
recap_ts = msprime.sim_ancestry(  
    initial_state=ped_ts, demography=demography, random_seed=1
)
print(recap_ts.draw_text())
```
giving
```
1.00┊ 0 3 ┊                                                                                    
    ┊ ┃ ┃ ┊                                                                                    
0.00┊ 4 5 ┊                                                                                    
    0    10                                                                                    
                                                                                               
108.92┊  6  ┊                                  
      ┊ ┏┻┓ ┊                                  
1.00  ┊ 0 3 ┊                                  
      ┊ ┃ ┃ ┊                                  
0.00  ┊ 4 5 ┊                                  
      0    10                                  
```

Because we're specifying the ``initial_state`` in both cases, the ``demography`` argument is required. So, it's a good idea to make it a requirement through the whole process. (Recapitating like this might not be the best idea, but that's another question.)

## Population structure

Suppose we want to specify a more complex demography outside the pedigree, and state that various individuals come from different populations. We do this like:
```python
demography = msprime.Demography()
demography.add_population(name="A", initial_size=100)
demography.add_population(name="B", initial_size=100)
demography.add_population(name="C", initial_size=100)
demography.add_population_split(time=10, derived=["A", "B"], ancestral="C")

builder = msprime.PedigreeBuilder(demography)
p0 = builder.add_individual(time=1, population="A")
p1 = builder.add_individual(time=1, population="B")
child = builder.add_individual(time=0, is_sample=True, parents=[p0, p1], population="A")
pedigree = builder.finalise(sequence_length=10)
```
Note that we're using the population names here to make things less error prone, and that we can validate the populations at ``add_individual`` time so that users get better error messages. 

## Conclusion

I'm hoping that this API will help bridge the gap between the pedigree data that people have (which will be in a range of different formats) and the data model needed by msprime. To me, it's less work for users to learn and use this API that it would be to generate the custom text format that would be required, and it lets us provide error messages early.

Any thoughts @sgravel, @hyanwong @apragsdale @LukeAndersonTrocme ?