### PR TITLE
Implement multiple populations in ped sim

### DIFF
--- a/lib/tests/test_pedigrees.c
+++ b/lib/tests/test_pedigrees.c
@@ -105,7 +105,8 @@ verify_complete_pedigree_simulation(
 
 static void
 verify_pedigree(double recombination_rate, unsigned long seed,
-    tsk_size_t num_individuals, tsk_id_t *parents, double *time, tsk_flags_t *is_sample)
+    tsk_size_t num_individuals, tsk_id_t *parents, double *time, tsk_flags_t *is_sample,
+    tsk_id_t *population)
 {
     int ret;
     int ploidy = 2;
@@ -117,8 +118,8 @@ verify_pedigree(double recombination_rate, unsigned long seed,
     gsl_rng *rng = safe_rng_alloc();
     bool coalescence = false;
 
-    ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_individuals, parents, time, is_sample);
+    ret = build_pedigree_sim(&msp, &tables, rng, 100, ploidy, num_individuals, parents,
+        time, is_sample, population);
     /* tsk_table_collection_print_state(&tables, stdout); */
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     num_nodes = msp.tables->nodes.num_rows;
@@ -176,7 +177,7 @@ test_trio(void)
     tsk_id_t parents[] = { -1, -1, -1, -1, 0, 1 };
     double time[] = { 1, 1, 0 };
 
-    verify_pedigree(0, 1, 3, parents, time, NULL);
+    verify_pedigree(0, 1, 3, parents, time, NULL, NULL);
 }
 
 static void
@@ -185,8 +186,8 @@ test_three_generations(void)
     tsk_id_t parents[] = { -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4, 5 };
     double time[] = { 2, 2, 2, 2, 1, 1, 0 };
 
-    verify_pedigree(0, 1234, 7, parents, time, NULL);
-    verify_pedigree(0.1, 1234, 7, parents, time, NULL);
+    verify_pedigree(0, 1234, 7, parents, time, NULL, NULL);
+    verify_pedigree(0.1, 1234, 7, parents, time, NULL, NULL);
 }
 
 static void
@@ -197,8 +198,8 @@ test_sibs(void)
     int seed;
 
     for (seed = 1; seed < 10; seed++) {
-        verify_pedigree(1, seed, 4, parents, time, NULL);
-        verify_pedigree(0, seed, 4, parents, time, NULL);
+        verify_pedigree(1, seed, 4, parents, time, NULL, NULL);
+        verify_pedigree(0, seed, 4, parents, time, NULL, NULL);
     }
 }
 
@@ -211,8 +212,8 @@ test_ancient_sample(void)
     int seed;
 
     for (seed = 1; seed < 10; seed++) {
-        verify_pedigree(0.1, seed, 4, parents, time, is_sample);
-        verify_pedigree(0, seed, 4, parents, time, is_sample);
+        verify_pedigree(0.1, seed, 4, parents, time, is_sample, NULL);
+        verify_pedigree(0, seed, 4, parents, time, is_sample, NULL);
     }
 }
 
@@ -223,8 +224,8 @@ test_large_family(void)
     size_t n = sizeof(large_family_time) / sizeof(*large_family_time);
 
     for (seed = 1; seed < 10; seed++) {
-        verify_pedigree(1, seed, n, large_family_parents, large_family_time, NULL);
-        verify_pedigree(0, seed, n, large_family_parents, large_family_time, NULL);
+        verify_pedigree(1, seed, n, large_family_parents, large_family_time, NULL, NULL);
+        verify_pedigree(0, seed, n, large_family_parents, large_family_time, NULL, NULL);
     }
 }
 
@@ -234,8 +235,8 @@ test_unrelated_n3(void)
     tsk_id_t parents[] = { -1, -1, -1, -1, -1, -1 };
     double time[] = { 0.0, 0.0, 0.0 };
 
-    verify_pedigree(0, 1, 3, parents, time, NULL);
-    verify_pedigree(0.1, 1, 3, parents, time, NULL);
+    verify_pedigree(0, 1, 3, parents, time, NULL, NULL);
+    verify_pedigree(0.1, 1, 3, parents, time, NULL, NULL);
 }
 
 static void
@@ -243,8 +244,8 @@ test_very_deep_n2(void)
 {
     size_t n = sizeof(very_deep_n2_time) / sizeof(*very_deep_n2_time);
 
-    verify_pedigree(0, 1, n, very_deep_n2_parents, very_deep_n2_time, NULL);
-    verify_pedigree(0.1, 1, n, very_deep_n2_parents, very_deep_n2_time, NULL);
+    verify_pedigree(0, 1, n, very_deep_n2_parents, very_deep_n2_time, NULL, NULL);
+    verify_pedigree(0.1, 1, n, very_deep_n2_parents, very_deep_n2_time, NULL, NULL);
 }
 
 static void
@@ -252,8 +253,8 @@ test_two_pedigrees(void)
 {
     size_t n = sizeof(two_pedigrees_time) / sizeof(*two_pedigrees_time);
 
-    verify_pedigree(0, 1, n, two_pedigrees_parents, two_pedigrees_time, NULL);
-    verify_pedigree(0.1, 1, n, two_pedigrees_parents, two_pedigrees_time, NULL);
+    verify_pedigree(0, 1, n, two_pedigrees_parents, two_pedigrees_time, NULL, NULL);
+    verify_pedigree(0.1, 1, n, two_pedigrees_parents, two_pedigrees_time, NULL, NULL);
 }
 
 static void
@@ -263,8 +264,8 @@ test_deep_n2(void)
         = { -1, -1, -1, -1, 0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 8, 9, 8, 9 };
     double time[] = { 5.0, 5.0, 4.0, 4.0, 3.0, 3.0, 2.0, 2.0, 1.0, 1.0, 0.0, 0.0 };
 
-    verify_pedigree(0, 1, 12, parents, time, NULL);
-    verify_pedigree(0.1, 1, 12, parents, time, NULL);
+    verify_pedigree(0, 1, 12, parents, time, NULL, NULL);
+    verify_pedigree(0.1, 1, 12, parents, time, NULL, NULL);
 }
 
 static void
@@ -272,8 +273,8 @@ test_deep_n10(void)
 {
     size_t n = sizeof(deep_n10_time) / sizeof(*deep_n10_time);
 
-    verify_pedigree(0, 1, n, deep_n10_parents, deep_n10_time, NULL);
-    verify_pedigree(0.1, 1, n, deep_n10_parents, deep_n10_time, NULL);
+    verify_pedigree(0, 1, n, deep_n10_parents, deep_n10_time, NULL, NULL);
+    verify_pedigree(0.1, 1, n, deep_n10_parents, deep_n10_time, NULL, NULL);
 }
 
 static void
@@ -316,8 +317,8 @@ test_shallow_n100(void)
     size_t n = sizeof(time) / sizeof(*time);
 
     for (int seed = 1; seed < 5; seed++) {
-        verify_pedigree(0, seed, n, parents, time, NULL);
-        verify_pedigree(0.1, seed, n, parents, time, NULL);
+        verify_pedigree(0, seed, n, parents, time, NULL, NULL);
+        verify_pedigree(0.1, seed, n, parents, time, NULL, NULL);
     }
 }
 
@@ -333,10 +334,10 @@ test_event_by_event(void)
     int ret;
 
     ret = build_pedigree_sim(&msp1, &tables1, rng1, 100, ploidy, num_inds,
-        deep_n10_parents, deep_n10_time, NULL);
+        deep_n10_parents, deep_n10_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = build_pedigree_sim(&msp2, &tables2, rng2, 100, ploidy, num_inds,
-        deep_n10_parents, deep_n10_time, NULL);
+        deep_n10_parents, deep_n10_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = msp_initialise(&msp1);
@@ -378,10 +379,10 @@ test_generation_by_generation(void)
     int ret;
 
     ret = build_pedigree_sim(&msp1, &tables1, rng1, 100, ploidy, num_inds,
-        deep_n10_parents, deep_n10_time, NULL);
+        deep_n10_parents, deep_n10_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = build_pedigree_sim(&msp2, &tables2, rng2, 100, ploidy, num_inds,
-        deep_n10_parents, deep_n10_time, NULL);
+        deep_n10_parents, deep_n10_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = msp_initialise(&msp1);
@@ -426,7 +427,7 @@ test_replicates(void)
     int j, ret;
 
     ret = build_pedigree_sim(&msp, &tables, rng, 100, ploidy, num_inds,
-        large_family_parents, large_family_time, NULL);
+        large_family_parents, large_family_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = msp_initialise(&msp);
@@ -486,7 +487,7 @@ test_replicates_ancient_samples(void)
     int j, ret;
 
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = msp_initialise(&msp);
@@ -538,7 +539,7 @@ test_replicates_early_exit(void)
     int j, k, ploid, ret;
 
     ret = build_pedigree_sim(&msp, &tables, rng, 100, ploidy, num_inds,
-        large_family_parents, large_family_time, NULL);
+        large_family_parents, large_family_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = msp_initialise(&msp);
@@ -596,7 +597,7 @@ test_replicates_exit_coalescence(void)
     int j, ret;
 
     ret = build_pedigree_sim(&msp, &tables, rng, 100, ploidy, num_inds,
-        very_deep_n2_parents, very_deep_n2_time, NULL);
+        very_deep_n2_parents, very_deep_n2_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     ret = msp_initialise(&msp);
@@ -638,18 +639,19 @@ test_errors(void)
     tsk_id_t parents[] = { -1, -1, -1, -1, 0, 0, 1, 1 };
     double time[] = { 1, 1, 0, 0 };
     tsk_flags_t is_sample[] = { 0, 0, 1, 1 };
+    tsk_id_t population[] = { 0, 0, 0, 0 };
     msp_t msp;
     tsk_table_collection_t tables;
     gsl_rng *rng = safe_rng_alloc();
 
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     tsk_table_collection_free(&tables);
     msp_free(&msp);
 
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, 1, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, 1, num_inds, parents, time, is_sample, population);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
@@ -658,14 +660,14 @@ test_errors(void)
     msp_free(&msp);
 
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, 0, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, 0, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_EMPTY_PEDIGREE);
     tsk_table_collection_free(&tables);
     msp_free(&msp);
 
     /* Any demographic events during the pedigree sim are errors */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_add_population_parameters_change(&msp, 0.5, 0, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -678,7 +680,7 @@ test_errors(void)
 
     /* Record full ARG is an error */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_set_store_full_arg(&msp, true);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -691,7 +693,7 @@ test_errors(void)
 
     /* non-zero GC rate is an error */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_set_gene_conversion_rate(&msp, 1);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -704,7 +706,7 @@ test_errors(void)
 
     parents[0] = -2;
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, msp_set_tsk_error(TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS));
     ret = msp_initialise(&msp);
     tsk_table_collection_free(&tables);
@@ -712,7 +714,7 @@ test_errors(void)
 
     parents[0] = 100;
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, msp_set_tsk_error(TSK_ERR_INDIVIDUAL_OUT_OF_BOUNDS));
     ret = msp_initialise(&msp);
     tsk_table_collection_free(&tables);
@@ -722,7 +724,7 @@ test_errors(void)
     is_sample[2] = 0;
     is_sample[3] = 0;
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_INSUFFICIENT_SAMPLES);
     tsk_table_collection_free(&tables);
     msp_free(&msp);
@@ -731,7 +733,7 @@ test_errors(void)
 
     /* Different times for two nodes in an individual */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     msp_free(&msp);
     tables.nodes.time[0] = 0.001;
@@ -744,7 +746,7 @@ test_errors(void)
 
     /* Different populations for two nodes in an individual */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     msp_free(&msp);
     tsk_population_table_add_row(&tables.populations, NULL, 0);
@@ -758,7 +760,7 @@ test_errors(void)
 
     /* non diploid individuals is an error */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     msp_free(&msp);
     tables.nodes.individual[0] = TSK_NULL;
@@ -771,7 +773,7 @@ test_errors(void)
 
     /* not having two parents is an error */
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     msp_free(&msp);
     tsk_individual_table_add_row(&tables.individuals, 0, NULL, 0, NULL, 0, NULL, 0);
@@ -784,7 +786,7 @@ test_errors(void)
 
     time[2] = 1;
     ret = build_pedigree_sim(
-        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample);
+        &msp, &tables, rng, 100, ploidy, num_inds, parents, time, is_sample, population);
     CU_ASSERT_EQUAL_FATAL(ret, MSP_ERR_PEDIGREE_TIME_TRAVEL);
     time[2] = 0;
     tsk_table_collection_free(&tables);
@@ -804,7 +806,8 @@ test_internal_samples(void)
     tsk_table_collection_t tables;
     gsl_rng *rng = safe_rng_alloc();
 
-    ret = build_pedigree_sim(&msp, &tables, rng, 100, 2, 3, parents, time, is_sample);
+    ret = build_pedigree_sim(
+        &msp, &tables, rng, 100, 2, 3, parents, time, is_sample, NULL);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
@@ -826,7 +829,7 @@ test_combined_with_other_models(void)
     int ret;
 
     ret = build_pedigree_sim(&msp, &tables, rng, 100, ploidy, num_inds,
-        large_family_parents, large_family_time, NULL);
+        large_family_parents, large_family_time, NULL, NULL);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(msp.model.type, MSP_MODEL_WF_PED);
 
@@ -847,6 +850,28 @@ test_combined_with_other_models(void)
     tsk_table_collection_free(&tables);
     msp_free(&msp);
     gsl_rng_free(rng);
+}
+
+static void
+test_trio_same_pop(void)
+{
+
+    tsk_id_t parents[] = { -1, -1, -1, -1, 0, 1 };
+    double time[] = { 1, 1, 0 };
+    tsk_id_t population[] = { 2, 2, 2 };
+
+    verify_pedigree(0, 1, 3, parents, time, NULL, population);
+}
+
+static void
+test_trio_child_different_pop(void)
+{
+
+    tsk_id_t parents[] = { -1, -1, -1, -1, 0, 1 };
+    double time[] = { 1, 1, 0 };
+    tsk_id_t population[] = { 2, 2, 1 };
+
+    verify_pedigree(0, 1, 3, parents, time, NULL, population);
 }
 
 int
@@ -875,6 +900,8 @@ main(int argc, char **argv)
         { "test_errors", test_errors },
         { "test_combined_with_other_models", test_combined_with_other_models },
 
+        { "test_trio_same_pop", test_trio_same_pop },
+        { "test_trio_child_different_pop", test_trio_child_different_pop },
         CU_TEST_INFO_NULL,
     };
 

--- a/lib/tests/testlib.h
+++ b/lib/tests/testlib.h
@@ -57,7 +57,7 @@ int build_sim(msp_t *msp, tsk_table_collection_t *tables, gsl_rng *rng,
     size_t num_samples);
 int build_pedigree_sim(msp_t *msp, tsk_table_collection_t *tables, gsl_rng *rng,
     double sequence_length, size_t ploidy, size_t num_individuals, tsk_id_t *parents,
-    double *time, tsk_flags_t *is_sample);
+    double *time, tsk_flags_t *is_sample, tsk_id_t *population);
 gsl_rng *safe_rng_alloc(void);
 
 int test_main(CU_TestInfo *tests, int argc, char **argv);

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -781,6 +781,7 @@ class TestParseSimAncestry:
             msprime.sim_ancestry(initial_state=ts1, random_seed=2)
 
     def test_initial_state(self):
+
         ts = msprime.sim_ancestry(10, end_time=0.01, random_seed=2)
         # Same if we use either the tables or tree sequence object.
         sim = ancestry._parse_sim_ancestry(initial_state=ts, population_size=1)
@@ -803,6 +804,83 @@ class TestParseSimAncestry:
         tables.populations.add_row()
         with pytest.raises(ValueError):
             ancestry._parse_sim_ancestry(2, initial_state=tables)
+
+
+class TestParseSimAncestryPedigree:
+    def test_pedigree_requires_initial_state(self):
+        with pytest.raises(ValueError, match="Must specify an input pedigree"):
+            ancestry._parse_sim_ancestry(model="wf_ped")
+
+    def test_pedigree_requires_no_demography(self):
+        demography = msprime.Demography.isolated_model([1])
+        with pytest.raises(ValueError, match="Cannot specify demography"):
+            ancestry._parse_sim_ancestry(model="wf_ped", demography=demography)
+
+    def test_pedigree_requires_no_population_size(self):
+        with pytest.raises(ValueError, match="Cannot specify population_size"):
+            ancestry._parse_sim_ancestry(model="wf_ped", population_size=1)
+
+    @pytest.mark.parametrize("ploidy", [1, 3])
+    def test_pedigree_requires_ploidy2(self, ploidy):
+        with pytest.raises(ValueError, match="must have ploidy=2"):
+            ancestry._parse_sim_ancestry(
+                model="wf_ped", initial_state=tskit.TableCollection(1), ploidy=ploidy
+            )
+
+    def test_pedigree_requires_no_samples(self):
+        with pytest.raises(ValueError, match="Cannot specify both samples and"):
+            ancestry._parse_sim_ancestry(
+                model="wf_ped", initial_state=tskit.TableCollection(1), samples=10
+            )
+
+    def test_pedigree_requires_no_gc(self):
+        pb = msprime.PedigreeBuilder()
+        with pytest.raises(ValueError, match="Gene conversion not supported"):
+            ancestry._parse_sim_ancestry(
+                model="wf_ped",
+                initial_state=pb.finalise(10),
+                gene_conversion_rate=1,
+                gene_conversion_tract_length=2,
+            )
+
+    def test_pedigree_requires_no_full_arg(self):
+        pb = msprime.PedigreeBuilder()
+        with pytest.raises(ValueError, match="Full ARG recording not supported"):
+            ancestry._parse_sim_ancestry(
+                model="wf_ped", initial_state=pb.finalise(10), record_full_arg=True
+            )
+
+    def test_pedigree_requires_no_record_migrations(self):
+        pb = msprime.PedigreeBuilder()
+        with pytest.raises(ValueError, match="Migration recording not supported"):
+            ancestry._parse_sim_ancestry(
+                model="wf_ped", initial_state=pb.finalise(10), record_migrations=True
+            )
+
+    def test_pedigree_requires_no_start_time(self):
+        pb = msprime.PedigreeBuilder()
+        with pytest.raises(ValueError, match="Cannot specify start_time"):
+            ancestry._parse_sim_ancestry(
+                model="wf_ped", initial_state=pb.finalise(10), start_time=1
+            )
+
+    def test_pedigree_with_following_model(self):
+        pb = msprime.PedigreeBuilder()
+        with pytest.raises(
+            ValueError, match="Cannot use FixedPedigree simulation in conjunction"
+        ):
+            ancestry._parse_sim_ancestry(
+                model=["wf_ped", "hudson"], initial_state=pb.finalise(10)
+            )
+
+    def test_pedigree_with_previous_model(self):
+        pb = msprime.PedigreeBuilder()
+        with pytest.raises(
+            ValueError, match="Cannot use FixedPedigree simulation in conjunction"
+        ):
+            ancestry._parse_sim_ancestry(
+                model=["hudson", "wf_ped"], initial_state=pb.finalise(10)
+            )
 
 
 class TestSimAncestrySamples:

--- a/tests/test_pedigree.py
+++ b/tests/test_pedigree.py
@@ -1124,6 +1124,22 @@ class TestSimulateThroughPedigreeMultiplePops:
         assert mrca.individual == -1
         assert mrca.population == 1
 
+    def test_trio_parents_different_pops_with_split(self):
+        tables = get_base_tables(100, num_populations=3)
+        parents = [
+            add_pedigree_individual(tables, time=2, population=j) for j in range(2)
+        ]
+        add_pedigree_individual(tables, time=0, parents=parents)
+        demography = msprime.Demography.isolated_model([10, 10, 10])
+        demography.add_population_split(time=10, derived=[0, 1], ancestral=2)
+
+        ts = msprime.sim_ancestry(
+            initial_state=tables, demography=demography, model="wf_ped", random_seed=1
+        )
+
+        # Should be able to coalesce due to the added population split
+        ts = msprime.sim_ancestry(initial_state=ts, demography=demography)
+
 
 @dataclasses.dataclass
 class FamEntry:

--- a/tests/test_pedigree.py
+++ b/tests/test_pedigree.py
@@ -1140,6 +1140,24 @@ class TestSimulateThroughPedigreeMultiplePops:
         # Should be able to coalesce due to the added population split
         ts = msprime.sim_ancestry(initial_state=ts, demography=demography)
 
+    def test_trio_parents_different_pops_with_migrations(self):
+        tables = get_base_tables(100, num_populations=2)
+        parents = [
+            add_pedigree_individual(tables, time=2, population=j) for j in range(2)
+        ]
+        add_pedigree_individual(tables, time=0, parents=parents)
+        demography = msprime.Demography.isolated_model([10, 10])
+        demography.add_symmetric_migration_rate_change(
+            time=0, populations=[0, 1], rate=0.1
+        )
+
+        ts = msprime.sim_ancestry(
+            initial_state=tables, demography=demography, model="wf_ped", random_seed=1
+        )
+
+        # Should be able to coalesce due to symmetric migration
+        ts = msprime.sim_ancestry(initial_state=ts, demography=demography)
+
 
 @dataclasses.dataclass
 class FamEntry:


### PR DESCRIPTION
Adds basic support for simulating through a fixed pedigree with multiple populations.

Each individual is assigned a population, and then we "migrate" the chunks of ancestry that come from different populations to this parent's population, if necessary.

@apragsdale, any chance you could take a look, or maybe try this out and see if the results make sense to you?

cc @sgravel @LukeAndersonTrocme