### PR TITLE
Handle pulses in demes 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.4] - 2021-12-01
+
+**New features**:
+
+- Support for Demes 0.2.0, which introduces a change to how pulse
+  sources and proportions are specified.
+  ({pr}`1936`, {issue}`1930`, {user}`apragsdale`)
+
 ## [1.0.3] - 2021-11-12
 
 This is a bugfix release recommended for all users.

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -1982,12 +1982,14 @@ class Demography(collections.abc.Mapping):
         # Add pulses in reverse order, so that pulses with the same time
         # correspond to the correct backwards-time mass migration ordering.
         for pulse in reversed(events.pop("pulses")):
-            demography.add_mass_migration(
-                time=pulse.time,
-                source=pulse.dest,
-                dest=pulse.source,
-                proportion=pulse.proportion,
-            )
+            sequential_props = _proportions_to_sequential(pulse.proportions)
+            for prop, source in zip(sequential_props, pulse.sources):
+                demography.add_mass_migration(
+                    time=pulse.time,
+                    source=pulse.dest,
+                    dest=source,
+                    proportion=prop,
+                )
         for merger in events.pop("mergers"):
             demography.add_admixture(
                 time=merger.time,
@@ -2710,9 +2712,9 @@ class Demography(collections.abc.Mapping):
             for lm in lineage_movements:
                 if (lm.source, lm.dest, lm.proportion) in pulses:
                     b.add_pulse(
-                        source=resolved[lm.dest].name,
+                        sources=[resolved[lm.dest].name],
                         dest=resolved[lm.source].name,
-                        proportion=lm.proportion,
+                        proportions=[lm.proportion],
                         time=time,
                     )
 

--- a/requirements/CI-complete/requirements.txt
+++ b/requirements/CI-complete/requirements.txt
@@ -1,7 +1,7 @@
 bintrees==2.2.0
 codecov==2.1.12
 daiquiri==3.0.1
-demes==0.1.2
+demes==0.2.0
 hypothesis==6.23.2
 mypy==0.910 
 newick==1.3.1

--- a/requirements/CI-docs/requirements.txt
+++ b/requirements/CI-docs/requirements.txt
@@ -1,6 +1,6 @@
 daiquiri==3.0.1
-demes==0.1.2
-demesdraw==0.1.4
+demes==0.2.0
+demesdraw==0.2.0
 jupyter-book==0.12.1
 matplotlib==3.5.0
 newick==1.3.1

--- a/requirements/CI-tests-conda/requirements.txt
+++ b/requirements/CI-tests-conda/requirements.txt
@@ -5,4 +5,4 @@ jsonschema<4.0
 gsl
 tskit==0.3.7
 stdpopsim==0.1.2
-demes==0.1.2
+demes==0.2.0

--- a/requirements/CI-tests-pip/requirements.txt
+++ b/requirements/CI-tests-pip/requirements.txt
@@ -1,6 +1,6 @@
 bintrees==2.2.0
 daiquiri==3.0.1
-demes==0.1.2
+demes==0.2.0
 hypothesis==6.29.0
 newick==1.3.0
 numpy==1.21.4

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,7 +4,7 @@ bintrees
 codecov
 coverage
 daiquiri
-demes>=0.1.2
+demes>=0.2.0
 demesdraw
 flake8
 hypothesis

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     numpy
     newick>=1.3.0
     tskit>=0.3.5
-    demes<0.2
+    demes>=0.2
 setup_requires =
     numpy
     setuptools


### PR DESCRIPTION
See #1930.

Here, pulses with multiple sources are parsed into individual mass migration events. Here, I haven't worried about trying to collapse simultaneous pulses back into a single event with multiple sources when calling `to_demes()`, since demes also maintains the convention of apply pulses that occur at the same time in the order that they are specified.