### PR TITLE
Time units and refseq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-**New features**:
+## [1.1.0] - 2021-12-14
 
+**New features**
+
+- Add support for tree sequence ``time_units`` field. The ``time_units`` will
+  be set to "generations" for the output of ``sim_ancestry`` (and ``simulate``),
+  unless the ``initial_state`` argument is used. In this case, the
+  ``time_units`` value will be inherited from the input.
+  ({pr}`1953`, {issue}`1951`, {issue}`1877`, {issue}`1948`, {user}`jeromekelleher`).
 
 **Bug fixes**:
 
@@ -17,6 +24,10 @@
 - Read the population name from PopulationConfiguration ``metadata`` in
   ``Demography.from_old_style`` ({issue}`1950`, {pr}`1954`,
   {user}`jeromekelleher`)
+
+**Maintenance **:
+
+- Update tskit to Python 0.4.0 and C 0.99.15.
 
 ## [1.0.4] - 2021-12-01
 

--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -45,6 +45,7 @@ from msprime.ancestry import (
     StandardCoalescent,
     SweepGenicSelection,
     FixedPedigree,
+    TimeUnitsMismatchWarning,
 )
 
 from msprime.core import __version__

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -1356,6 +1356,11 @@ def sim_mutations(
     if not isinstance(rate_map, intervals.RateMap):
         raise TypeError("rate must be a float or a RateMap")
 
+    if tables.time_units == tskit.TIME_UNITS_UNCALIBRATED:
+        raise ValueError(
+            "Simulating mutations doesn't make sense when time is uncalibrated"
+        )
+
     start_time = -sys.float_info.max if start_time is None else float(start_time)
     end_time = sys.float_info.max if end_time is None else float(end_time)
     if start_time > end_time:

--- a/msprime/pedigrees.py
+++ b/msprime/pedigrees.py
@@ -31,6 +31,7 @@ class PedigreeBuilder:
             demography = demog_mod.Demography.isolated_model([1])
         self.demography = demography
         self.tables = tskit.TableCollection(0)
+        self.tables.time_units = "generations"
         demography.insert_populations(self.tables)
 
         assert len(self.tables.individuals) == 0

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -524,6 +524,18 @@ class TestSimMutations(MutateMixin):
                 for mutation in site.mutations:
                     assert mutation.derived_state == alleles[1]
 
+    @pytest.mark.parametrize("rate", [0, 1])
+    def test_uncalibrated_time_units(self, rate):
+        ts = msprime.sim_ancestry(8, random_seed=2)
+        tables = ts.dump_tables()
+        tables.time_units = "uncalibrated"
+        ts = tables.tree_sequence()
+        with pytest.raises(ValueError, match="uncalibrated"):
+            msprime.sim_mutations(ts, rate=rate, random_seed=1)
+        # Make sure also works on legacy interface
+        with pytest.raises(ValueError, match="uncalibrated"):
+            msprime.mutate(ts, rate=rate, random_seed=1)
+
     def test_zero_mutation_rate(self):
         ts = msprime.sim_ancestry(10, random_seed=1)
         mutated = msprime.sim_mutations(ts, 0)

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -2168,3 +2168,37 @@ class TestDeprecatedApis:
         assert ts.num_sites == 0
         mts = msprime.mutate(ts, rate=1, random_seed=3)
         assert mts.num_sites > 0
+
+
+class TestInputUnmodified:
+    """
+    Check that things that shouldn't be touched by sim_mutations, aren't.
+    """
+
+    def test_refseq_just_data(self):
+        ts1 = msprime.sim_ancestry(2, sequence_length=10, random_seed=1)
+        tables = ts1.dump_tables()
+        tables.reference_sequence.data = "A" * 10
+        ts2 = msprime.sim_mutations(tables.tree_sequence(), rate=1, random_seed=2)
+        assert ts2.reference_sequence.data == "A" * 10
+        tables.reference_sequence.assert_equals(ts2.reference_sequence)
+
+    def test_refseq_all_fields(self):
+        ts1 = msprime.sim_ancestry(2, sequence_length=10, random_seed=1)
+        tables = ts1.dump_tables()
+        tables.reference_sequence.data = "A"
+        tables.reference_sequence.metadata_schema = (
+            tskit.MetadataSchema.permissive_json()
+        )
+        tables.reference_sequence.metadata = {"a": 1, "b": 2}
+        tables.reference_sequence.url = "http://stuff.stuff"
+        ts2 = msprime.sim_mutations(tables.tree_sequence(), rate=1, random_seed=2)
+        tables.reference_sequence.assert_equals(ts2.reference_sequence)
+
+    @pytest.mark.parametrize("time_units", ["", "generations", "mya"])
+    def test_time_units(self, time_units):
+        ts1 = msprime.sim_ancestry(2, sequence_length=10, random_seed=1)
+        tables = ts1.dump_tables()
+        tables.time_units = time_units
+        ts2 = msprime.sim_mutations(tables.tree_sequence(), rate=1, random_seed=2)
+        assert ts2.time_units == time_units

--- a/tests/test_pedigree.py
+++ b/tests/test_pedigree.py
@@ -266,6 +266,7 @@ class TestPedigreeSimulation:
             num_generations=10,
         )
         tc = tskit.TableCollection(1)
+        tc.time_units = "generations"
         tc.individuals.metadata_schema = tb.metadata_schema
         for row in tb:
             tc.individuals.append(row)

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -598,6 +598,7 @@ class BaseEquivalanceMixin:
             model=self.model,
         )
         tables = tskit.TableCollection(ts1.sequence_length)
+        tables.time_units = "generations"
         tables.populations.add_row()
         for _ in range(n):
             tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, time=0, population=0)
@@ -658,6 +659,7 @@ class BaseEquivalanceMixin:
             random_seed=seed,
         )
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.add_row()
         tables.populations.add_row()
         for _ in range(n):
@@ -952,6 +954,7 @@ class TestSimAncestryInterface:
 
     def test_extra_pops_no_metadata(self):
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.add_row()
         tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, population=0)
         tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, population=0)
@@ -970,6 +973,7 @@ class TestSimAncestryInterface:
 
     def test_extra_pops_struct_metadata(self):
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.metadata_schema = tskit.MetadataSchema(
             {
                 "codec": "struct",
@@ -999,6 +1003,7 @@ class TestSimAncestryInterface:
 
     def test_extra_pops_missing_name_metadata(self):
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.metadata_schema = tskit.MetadataSchema(
             {
                 "codec": "json",
@@ -1028,6 +1033,7 @@ class TestSimAncestryInterface:
 
     def test_extra_pops_missing_description_metadata(self):
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.metadata_schema = tskit.MetadataSchema(
             {
                 "codec": "json",
@@ -1057,6 +1063,7 @@ class TestSimAncestryInterface:
 
     def test_extra_pops_minimal_schema(self):
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.metadata_schema = tskit.MetadataSchema.permissive_json()
         tables.populations.add_row(metadata={"name": "X"})
         tables.nodes.add_row(flags=tskit.NODE_IS_SAMPLE, population=0)
@@ -1109,6 +1116,7 @@ class TestSimAncestryInterface:
 
     def test_extra_pops_set_extra_metadata(self):
         tables = tskit.TableCollection(1)
+        tables.time_units = "generations"
         tables.populations.metadata_schema = tskit.MetadataSchema(
             {
                 "codec": "json",

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -1162,6 +1162,30 @@ class TestSimAncestryInterface:
         ts3 = msprime.sim_ancestry(2, population_size=100, random_seed=2)
         assert ts2.equals(ts3, ignore_provenance=True)
 
+    def test_refseq_just_data_maintained(self):
+        ts1 = msprime.sim_ancestry(2, end_time=0, sequence_length=10, random_seed=1)
+        tables = ts1.dump_tables()
+        tables.reference_sequence.data = "A" * 10
+        ts2 = msprime.sim_ancestry(
+            initial_state=tables, population_size=100, random_seed=2
+        )
+        assert ts2.reference_sequence.data == "A" * 10
+        tables.reference_sequence.assert_equals(ts2.reference_sequence)
+
+    def test_refseq_all_fields_maintained(self):
+        ts1 = msprime.sim_ancestry(2, end_time=0, sequence_length=10, random_seed=1)
+        tables = ts1.dump_tables()
+        tables.reference_sequence.data = "A"
+        tables.reference_sequence.metadata_schema = (
+            tskit.MetadataSchema.permissive_json()
+        )
+        tables.reference_sequence.metadata = {"a": 1, "b": 2}
+        tables.reference_sequence.url = "http://stuff.stuff"
+        ts2 = msprime.sim_ancestry(
+            initial_state=tables, population_size=100, random_seed=2
+        )
+        tables.reference_sequence.assert_equals(ts2.reference_sequence)
+
 
 class TestSlimOutput:
     """


### PR DESCRIPTION
Adds support for the new top-level info to msprime. Basics:

- sim_mutations doesn't alter the value. 
- The output of sim_ancestry has time_units = "generations", except when recapitating.

Errors/warnings:
- sim_mutations and sim_ancestry will error if inputs have time_units="uncalibrated". (This seems fine, you have to specifically go out of your way to set the time_units to uncalibrated, and it's just intended for things like tsinfer where the time units really are pretty weird)
- Currently, sim_ancestry issues a warning if time_units != "generations". Maybe this is premature though?

Pinging @petrelharp @molpopgen @hyanwong @grahamgower @bhaller for opinions here.