### PR TITLE
Revert "Initial pass at single node recombination"

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -1381,8 +1381,9 @@ class Simulator:
         self.set_segment_mass(alpha)
         self.P[alpha.population].add(alpha, label)
         if self.full_arg:
-            self.store_node(lhs_tail.population, flags=msprime.NODE_IS_RECOMBINANT)
+            self.store_node(lhs_tail.population, flags=msprime.NODE_IS_RE_EVENT)
             self.store_arg_edges(lhs_tail)
+            self.store_node(alpha.population, flags=msprime.NODE_IS_RE_EVENT)
             self.store_arg_edges(alpha)
         ret = None
         if return_heads:
@@ -1799,7 +1800,7 @@ class Simulator:
                 z = alpha
         if self.full_arg:
             if not coalescence:
-                self.store_node(pop_id, flags=msprime.NODE_IS_NONGENETIC_CA)
+                self.store_node(pop_id, flags=msprime.NODE_IS_CA_EVENT)
             self.store_arg_edges(z)
         if defrag_required:
             self.defrag_segment_chain(z)
@@ -1936,7 +1937,7 @@ class Simulator:
 
         if self.full_arg:
             if not coalescence:
-                self.store_node(population_index, flags=msprime.NODE_IS_NONGENETIC_CA)
+                self.store_node(population_index, flags=msprime.NODE_IS_CA_EVENT)
             self.store_arg_edges(z)
         if defrag_required:
             self.defrag_segment_chain(z)

--- a/lib/likelihood.c
+++ b/lib/likelihood.c
@@ -152,7 +152,7 @@ msp_log_likelihood_arg(tsk_treeseq_t *ts, double r, double Ne, double *r_lik)
         parent = edges->parent[edge];
         lik -= rate * (nodes->time[parent] - sim_time);
         sim_time = nodes->time[parent];
-        if (nodes->flags[parent] & MSP_NODE_IS_RECOMBINANT) {
+        if (nodes->flags[parent] & MSP_NODE_IS_RE_EVENT) {
             if (r <= 0) {
                 *r_lik = -DBL_MAX;
                 ret = 0;

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -2328,14 +2328,20 @@ msp_store_arg_recombination(msp_t *self, segment_t *lhs_tail, segment_t *rhs)
 {
     int ret = 0;
 
-    /* Store a node for the recombinant child */
+    /* Store the edges for the LHS */
     ret = msp_store_node(
-        self, MSP_NODE_IS_RECOMBINANT, self->time, lhs_tail->population, TSK_NULL);
+        self, MSP_NODE_IS_RE_EVENT, self->time, lhs_tail->population, TSK_NULL);
     if (ret < 0) {
         goto out;
     }
     ret = msp_store_arg_edges(self, lhs_tail);
     if (ret != 0) {
+        goto out;
+    }
+    /* Store the edges for the RHS */
+    ret = msp_store_node(
+        self, MSP_NODE_IS_RE_EVENT, self->time, rhs->population, TSK_NULL);
+    if (ret < 0) {
         goto out;
     }
     ret = msp_store_arg_edges(self, rhs);
@@ -2923,7 +2929,7 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
     if (self->store_full_arg) {
         if (!coalescence) {
             ret = msp_store_node(
-                self, MSP_NODE_IS_NONGENETIC_CA, self->time, population_id, TSK_NULL);
+                self, MSP_NODE_IS_CA_EVENT, self->time, population_id, TSK_NULL);
             if (ret < 0) {
                 goto out;
             }
@@ -3157,7 +3163,7 @@ msp_merge_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
     if (self->store_full_arg) {
         if (!coalescence) {
             ret = msp_store_node(
-                self, MSP_NODE_IS_NONGENETIC_CA, self->time, population_id, individual);
+                self, MSP_NODE_IS_CA_EVENT, self->time, population_id, individual);
             if (ret < 0) {
                 goto out;
             }

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -52,9 +52,8 @@
 #define MSP_EXIT_MAX_TIME 2
 #define MSP_EXIT_MODEL_COMPLETE 3
 
-#define MSP_NODE_IS_RECOMBINANT (1u << 16)
-//#define MSP_NODE_IS_RE_EVENT (1u << 17)
-#define MSP_NODE_IS_NONGENETIC_CA (1u << 18)
+#define MSP_NODE_IS_RE_EVENT (1u << 17)
+#define MSP_NODE_IS_CA_EVENT (1u << 18)
 #define MSP_NODE_IS_MIG_EVENT (1u << 19)
 #define MSP_NODE_IS_CEN_EVENT (1u << 20)
 #define MSP_NODE_IS_GC_EVENT (1u << 21)

--- a/lib/tests/test_likelihood.c
+++ b/lib/tests/test_likelihood.c
@@ -164,29 +164,34 @@ test_likelihood_three_leaves(void)
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 3, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 3, 2, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 4, 2, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.1, 0, TSK_NULL, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 4, 1, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 5, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 4, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 5, 3, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.25, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 5, 0, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 6, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 6, 4, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.5, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 6, 4, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 7, 5, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 6, 5, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 7, 6, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -204,7 +209,7 @@ test_likelihood_three_leaves(void)
         &tables.mutations, 3, 0, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 4, 4, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 4, 5, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_site_table_add_row(&tables.sites, 0.1, "A", 1, NULL, 0);
@@ -270,28 +275,38 @@ test_likelihood_two_mrcas(void)
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 2, 1, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 2, 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 3, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.1, 0, TSK_NULL, NULL, 0);
-    CU_ASSERT_FATAL(ret >= 0);
-
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 3, 0, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.15, 0, TSK_NULL, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 4, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 4, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 4, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 6, 2, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 6, 4, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.5, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 7, 3, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 7, 5, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -300,10 +315,10 @@ test_likelihood_two_mrcas(void)
         &tables.mutations, 0, 1, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 1, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 1, 4, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 2, 2, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 2, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_site_table_add_row(&tables.sites, 0.1, "A", 1, NULL, 0);
@@ -364,35 +379,45 @@ test_likelihood_material_overhang(void)
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 2, 1, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 2, 1, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 3, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.1, 0, TSK_NULL, NULL, 0);
-    CU_ASSERT_FATAL(ret >= 0);
-
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 3, 0, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.15, 0, TSK_NULL, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 4, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.7, 4, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.7, 4, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.7, 1, 5, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.15, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.5, 6, 2, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.7, 6, 4, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.5, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 7, 3, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.7, 1, 5, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.7, 1, 7, 5, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 0.7, 6, 4, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 0.7, 8, 6, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 0.7, 6, 5, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 0.7, 8, 7, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 1.3, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -401,10 +426,10 @@ test_likelihood_material_overhang(void)
         &tables.mutations, 0, 1, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 1, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 1, 4, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 2, 2, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 2, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_site_table_add_row(&tables.sites, 0.1, "A", 1, NULL, 0);
@@ -466,37 +491,47 @@ test_likelihood_material_gap(void)
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 2, 0, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 2, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 3, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.1, 0, TSK_NULL, NULL, 0);
-    CU_ASSERT_FATAL(ret >= 0);
-
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 3, 2, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.2, 0, TSK_NULL, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 4, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 4, 3, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 4, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 3, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 6, 2, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 6, 5, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.3, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 5, 1, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 7, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 5, 4, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 7, 6, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 4, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 7, 6, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.4, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 6, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 8, 4, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 6, 5, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 8, 7, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.5, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -505,16 +540,16 @@ test_likelihood_material_gap(void)
         &tables.mutations, 0, 2, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 1, 2, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 1, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 2, 5, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 2, 7, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 3, 4, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 3, 6, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 4, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 4, 5, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_site_table_add_row(&tables.sites, 0.1, "A", 1, NULL, 0);
@@ -579,50 +614,63 @@ test_likelihood_recombination_in_material_gap(void)
         &tables.nodes, TSK_NODE_IS_SAMPLE, 0.0, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 2, 0, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 2, 0, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 3, 0, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.1, 0, TSK_NULL, NULL, 0);
-    CU_ASSERT_FATAL(ret >= 0);
-
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 3, 2, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.2, 0, TSK_NULL, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.1, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 4, 2, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 4, 3, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 4, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 3, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.2, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 6, 2, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 6, 5, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.3, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 5, 4, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 7, 6, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 5, 4, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 8, 6, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(
-        &tables.nodes, MSP_NODE_IS_RECOMBINANT, 0.4, 0, TSK_NULL, NULL, 0);
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.4, 0, TSK_NULL, NULL, 0);
+    CU_ASSERT_FATAL(ret >= 0);
+    ret = tsk_node_table_add_row(
+        &tables.nodes, MSP_NODE_IS_RE_EVENT, 0.4, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 6, 3, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 0.5, 9, 4, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 6, 5, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.5, 1, 9, 8, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.5, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 7, 1, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 1, 10, 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 7, 5, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0, 0.3, 10, 7, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.6, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 8, 6, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 11, 9, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
-    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 8, 7, NULL, 0);
+    ret = tsk_edge_table_add_row(&tables.edges, 0.3, 1, 11, 10, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_node_table_add_row(&tables.nodes, 0, 0.7, 0, TSK_NULL, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
@@ -631,13 +679,13 @@ test_likelihood_recombination_in_material_gap(void)
         &tables.mutations, 0, 2, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 1, 2, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 1, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 2, 4, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 2, 6, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
     ret = tsk_mutation_table_add_row(
-        &tables.mutations, 3, 3, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
+        &tables.mutations, 3, 5, -1, TSK_UNKNOWN_TIME, "C", 1, NULL, 0);
     CU_ASSERT_FATAL(ret >= 0);
 
     ret = tsk_site_table_add_row(&tables.sites, 0.1, "A", 1, NULL, 0);

--- a/lib/tests/test_likelihood.c
+++ b/lib/tests/test_likelihood.c
@@ -137,9 +137,6 @@ test_likelihood_zero_edges(void)
     tsk_table_collection_free(&tables);
 }
 
-/* Skipping these tests until the likelihood function is fixed
- * for dealing with single-node RE events */
-#if 0
 static void
 test_likelihood_three_leaves(void)
 {
@@ -680,24 +677,21 @@ test_likelihood_recombination_in_material_gap(void)
     tsk_treeseq_free(&ts);
     tsk_table_collection_free(&tables);
 }
-#endif
 
 int
 main(int argc, char **argv)
 {
-    CU_TestInfo tests[]
-        = { { "test_likelihood_errors", test_likelihood_errors },
-              { "test_likelihood_zero_edges", test_likelihood_zero_edges },
-#if 0
+    CU_TestInfo tests[] = {
+        { "test_likelihood_errors", test_likelihood_errors },
+        { "test_likelihood_zero_edges", test_likelihood_zero_edges },
         { "test_likelihood_three_leaves", test_likelihood_three_leaves },
         { "test_likelihood_two_mrcas", test_likelihood_two_mrcas },
         { "test_likelihood_material_overhang", test_likelihood_material_overhang },
         { "test_likelihood_material_gap", test_likelihood_material_gap },
         { "test_likelihood_recombination_in_material_gap",
             test_likelihood_recombination_in_material_gap },
-#endif
-              CU_TEST_INFO_NULL,
-          };
+        CU_TEST_INFO_NULL,
+    };
 
     return test_main(tests, argc, argv);
 }

--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -27,9 +27,9 @@ for more information.
 
 from msprime._msprime import (
     NODE_IS_CEN_EVENT,
-    NODE_IS_NONGENETIC_CA,
+    NODE_IS_CA_EVENT,
     NODE_IS_MIG_EVENT,
-    NODE_IS_RECOMBINANT,
+    NODE_IS_RE_EVENT,
     NODE_IS_GC_EVENT,
 )
 
@@ -125,10 +125,10 @@ __all__ = [
     "MatrixMutationModel",
     "MigrationRateChange",
     "MutationModel",
-    "NODE_IS_NONGENETIC_CA",
+    "NODE_IS_CA_EVENT",
     "NODE_IS_CEN_EVENT",
     "NODE_IS_MIG_EVENT",
-    "NODE_IS_RECOMBINANT",
+    "NODE_IS_RE_EVENT",
     "NODE_IS_GC_EVENT",
     "NUCLEOTIDES",
     "PAM",

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -3330,8 +3330,8 @@ PyInit__msprime(void)
     Py_INCREF(MsprimeLibraryError);
     PyModule_AddObject(module, "LibraryError", MsprimeLibraryError);
 
-    PyModule_AddIntConstant(module, "NODE_IS_NONGENETIC_CA", MSP_NODE_IS_NONGENETIC_CA);
-    PyModule_AddIntConstant(module, "NODE_IS_RECOMBINANT", MSP_NODE_IS_RECOMBINANT);
+    PyModule_AddIntConstant(module, "NODE_IS_CA_EVENT", MSP_NODE_IS_CA_EVENT);
+    PyModule_AddIntConstant(module, "NODE_IS_RE_EVENT", MSP_NODE_IS_RE_EVENT);
     PyModule_AddIntConstant(module, "NODE_IS_GC_EVENT", MSP_NODE_IS_GC_EVENT);
     PyModule_AddIntConstant(module, "NODE_IS_MIG_EVENT", MSP_NODE_IS_MIG_EVENT);
     PyModule_AddIntConstant(module, "NODE_IS_CEN_EVENT", MSP_NODE_IS_CEN_EVENT);

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -78,8 +78,8 @@ class TestAlgorithms:
         ts = self.run_script("30 -L 200 --full-arg")
         assert ts.num_trees > 1
         node_flags = ts.tables.nodes.flags
-        assert np.sum(node_flags == msprime.NODE_IS_RECOMBINANT) > 0
-        assert np.sum(node_flags == msprime.NODE_IS_NONGENETIC_CA) > 0
+        assert np.sum(node_flags == msprime.NODE_IS_RE_EVENT) > 0
+        assert np.sum(node_flags == msprime.NODE_IS_CA_EVENT) > 0
 
     def test_migration_full_arg(self):
         ts = self.run_script("10 -p 3 -g 0.1 --full-arg")

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -103,12 +103,13 @@ class TestFullArg:
         flags = tree_sequence.tables.nodes.flags
         time = tree_sequence.tables.nodes.time
         # TODO add checks for migrations.
-        re_nodes = np.where(flags == msprime.NODE_IS_RECOMBINANT)[0]
-        ca_nodes = np.where(flags == msprime.NODE_IS_NONGENETIC_CA)[0]
+        re_nodes = np.where(flags == msprime.NODE_IS_RE_EVENT)[0]
+        ca_nodes = np.where(flags == msprime.NODE_IS_CA_EVENT)[0]
         gc_nodes = np.where(flags == msprime.NODE_IS_GC_EVENT)[0]
         coal_nodes = np.where(flags == 0)[0]
-        # There should be one recombination node for every event
-        assert re_nodes.shape[0] == sim.num_recombination_events
+        # There should be two recombination nodes for every event
+        assert np.array_equal(time[re_nodes[::2]], time[re_nodes[1::2]])  # Odd indexes
+        assert re_nodes.shape[0] / 2 == sim.num_recombination_events
         # There should be two gene conversion nodes for every effective event
         assert np.array_equal(time[gc_nodes[::2]], time[gc_nodes[1::2]])  # Odd indexes
         assert (
@@ -125,12 +126,13 @@ class TestFullArg:
         ts_simplified = tree_sequence.simplify()
         new_flags = ts_simplified.tables.nodes.flags
         new_time = ts_simplified.tables.nodes.time
-        assert np.sum(new_flags == msprime.NODE_IS_RECOMBINANT) == 0
-        assert np.sum(new_flags == msprime.NODE_IS_NONGENETIC_CA) == 0
+        assert np.sum(new_flags == msprime.NODE_IS_RE_EVENT) == 0
+        assert np.sum(new_flags == msprime.NODE_IS_CA_EVENT) == 0
         assert np.sum(new_flags == msprime.NODE_IS_GC_EVENT) == 0
         # All coal nodes from the original should be identical to the originals
         assert np.array_equal(time[coal_nodes], new_time[new_flags == 0])
         assert ts_simplified.num_nodes <= tree_sequence.num_nodes
+        assert ts_simplified.num_edges <= tree_sequence.num_edges
         return tree_sequence
 
     def test_no_recombination(self):
@@ -1907,7 +1909,7 @@ class TestSimAncestryInterface:
             record_full_arg=True,
         )
         flags = ts.tables.nodes.flags
-        assert np.sum(flags == msprime.NODE_IS_RECOMBINANT) > 0
+        assert np.sum(flags == msprime.NODE_IS_RE_EVENT) > 0
         for record_full_arg in [None, False]:
             ts = msprime.sim_ancestry(
                 4,
@@ -1917,7 +1919,7 @@ class TestSimAncestryInterface:
                 record_full_arg=record_full_arg,
             )
             flags = ts.tables.nodes.flags
-            assert np.sum(flags == msprime.NODE_IS_RECOMBINANT) == 0
+            assert np.sum(flags == msprime.NODE_IS_RE_EVENT) == 0
 
     def test_initial_tables_recapitate(self):
         # Simple recapitate scenario
@@ -2243,7 +2245,7 @@ class TestUnknownGenomeRegions:
         assert tree.interval == (0, 1)
         assert tree.num_roots == ts.num_samples
         flags = ts.tables.nodes.flags
-        assert np.sum(flags == msprime.NODE_IS_RECOMBINANT) > 0
+        assert np.sum(flags == msprime.NODE_IS_RE_EVENT) > 0
 
     def test_sim_ancestry_unknown_mid(self):
         rate_map = msprime.RateMap(position=[0, 1, 9, 10], rate=[0, np.nan, 0])

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -54,7 +54,7 @@ def log_arg_likelihood(arg, recombination_rate, Ne=1):
         ret -= rate * (tables.nodes[parent].time - time)
         time = tables.nodes[parent].time
         child = tables.edges[edge].child
-        if tables.nodes[parent].flags == msprime.NODE_IS_RECOMBINANT:
+        if tables.nodes[parent].flags == msprime.NODE_IS_RE_EVENT:
             if recombination_rate == 0:
                 ret = -float("inf")
                 break
@@ -110,28 +110,32 @@ class TestKnownExamples:
             flags=tskit.NODE_IS_SAMPLE, population=0, individual=-1, time=0
         )
 
-        tables.edges.add_row(left=0, right=1, parent=3, child=2)
+        tables.edges.add_row(left=0, right=0.5, parent=3, child=2)
+        tables.edges.add_row(left=0.5, right=1, parent=4, child=2)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.1
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
         )
 
-        tables.edges.add_row(left=0, right=1, parent=4, child=1)
-        tables.edges.add_row(left=0, right=0.5, parent=4, child=3)
+        tables.edges.add_row(left=0, right=1, parent=5, child=1)
+        tables.edges.add_row(left=0, right=0.5, parent=5, child=3)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.25)
 
-        tables.edges.add_row(left=0, right=1, parent=5, child=0)
-        tables.edges.add_row(left=0.5, right=1, parent=5, child=3)
+        tables.edges.add_row(left=0, right=1, parent=6, child=0)
+        tables.edges.add_row(left=0.5, right=1, parent=6, child=4)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.5)
 
-        tables.edges.add_row(left=0, right=1, parent=6, child=4)
-        tables.edges.add_row(left=0, right=1, parent=6, child=5)
+        tables.edges.add_row(left=0, right=1, parent=7, child=5)
+        tables.edges.add_row(left=0, right=1, parent=7, child=6)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=1)
 
         tables.mutations.add_row(site=0, node=0, derived_state="1")
         tables.mutations.add_row(site=1, node=1, derived_state="1")
         tables.mutations.add_row(site=2, node=3, derived_state="1")
         tables.mutations.add_row(site=3, node=0, derived_state="1")
-        tables.mutations.add_row(site=4, node=4, derived_state="1")
+        tables.mutations.add_row(site=4, node=5, derived_state="1")
 
         tables.sites.add_row(0.1, "0")
         tables.sites.add_row(0.2, "0")
@@ -174,27 +178,35 @@ class TestKnownExamples:
             flags=tskit.NODE_IS_SAMPLE, population=0, individual=-1, time=0
         )
 
-        tables.edges.add_row(left=0, right=1, parent=2, child=1)
+        tables.edges.add_row(left=0, right=0.5, parent=2, child=1)
+        tables.edges.add_row(left=0.5, right=1, parent=3, child=1)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.1
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
         )
 
-        tables.edges.add_row(left=0, right=1, parent=3, child=0)
+        tables.edges.add_row(left=0, right=0.5, parent=4, child=0)
+        tables.edges.add_row(left=0.5, right=1, parent=5, child=0)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.15
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.15
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.15
         )
 
-        tables.edges.add_row(left=0, right=0.5, parent=4, child=2)
-        tables.edges.add_row(left=0, right=0.5, parent=4, child=3)
+        tables.edges.add_row(left=0, right=0.5, parent=6, child=2)
+        tables.edges.add_row(left=0, right=0.5, parent=6, child=4)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.5)
 
-        tables.edges.add_row(left=0.5, right=1, parent=5, child=2)
-        tables.edges.add_row(left=0.5, right=1, parent=5, child=3)
+        tables.edges.add_row(left=0.5, right=1, parent=7, child=3)
+        tables.edges.add_row(left=0.5, right=1, parent=7, child=5)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=1)
 
         tables.mutations.add_row(site=0, node=1, derived_state="1")
-        tables.mutations.add_row(site=1, node=3, derived_state="1")
-        tables.mutations.add_row(site=2, node=2, derived_state="1")
+        tables.mutations.add_row(site=1, node=4, derived_state="1")
+        tables.mutations.add_row(site=2, node=3, derived_state="1")
 
         tables.sites.add_row(0.1, "0")
         tables.sites.add_row(0.2, "0")
@@ -234,31 +246,39 @@ class TestKnownExamples:
             flags=tskit.NODE_IS_SAMPLE, population=0, individual=-1, time=0
         )
 
-        tables.edges.add_row(left=0, right=1, parent=2, child=1)
+        tables.edges.add_row(left=0, right=0.5, parent=2, child=1)
+        tables.edges.add_row(left=0.5, right=1, parent=3, child=1)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.1
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
         )
 
-        tables.edges.add_row(left=0, right=1, parent=3, child=0)
+        tables.edges.add_row(left=0, right=0.7, parent=4, child=0)
+        tables.edges.add_row(left=0.7, right=1, parent=5, child=0)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.15
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.15
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.15
         )
 
-        tables.edges.add_row(left=0, right=0.5, parent=4, child=2)
-        tables.edges.add_row(left=0, right=0.7, parent=4, child=3)
+        tables.edges.add_row(left=0, right=0.5, parent=6, child=2)
+        tables.edges.add_row(left=0, right=0.7, parent=6, child=4)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.5)
 
-        tables.edges.add_row(left=0.5, right=1, parent=5, child=2)
-        tables.edges.add_row(left=0.7, right=1, parent=5, child=3)
+        tables.edges.add_row(left=0.5, right=1, parent=7, child=3)
+        tables.edges.add_row(left=0.7, right=1, parent=7, child=5)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=1)
 
-        tables.edges.add_row(left=0.5, right=0.7, parent=6, child=4)
-        tables.edges.add_row(left=0.5, right=0.7, parent=6, child=5)
+        tables.edges.add_row(left=0.5, right=0.7, parent=8, child=6)
+        tables.edges.add_row(left=0.5, right=0.7, parent=8, child=7)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=1.3)
 
         tables.mutations.add_row(site=0, node=1, derived_state="1")
-        tables.mutations.add_row(site=1, node=3, derived_state="1")
-        tables.mutations.add_row(site=2, node=2, derived_state="1")
+        tables.mutations.add_row(site=1, node=4, derived_state="1")
+        tables.mutations.add_row(site=2, node=3, derived_state="1")
 
         tables.sites.add_row(0.1, "0")
         tables.sites.add_row(0.6, "0")
@@ -300,34 +320,42 @@ class TestKnownExamples:
             flags=tskit.NODE_IS_SAMPLE, population=0, individual=-1, time=0
         )
 
-        tables.edges.add_row(left=0, right=1, parent=2, child=0)
+        tables.edges.add_row(left=0, right=0.3, parent=2, child=0)
+        tables.edges.add_row(left=0.3, right=1, parent=3, child=0)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.1
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
         )
 
-        tables.edges.add_row(left=0.3, right=1, parent=3, child=2)
+        tables.edges.add_row(left=0.3, right=0.5, parent=4, child=3)
+        tables.edges.add_row(left=0.5, right=1, parent=5, child=3)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.2
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.2
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.2
         )
 
-        tables.edges.add_row(left=0, right=0.3, parent=4, child=2)
-        tables.edges.add_row(left=0.5, right=1, parent=4, child=3)
+        tables.edges.add_row(left=0, right=0.3, parent=6, child=2)
+        tables.edges.add_row(left=0.5, right=1, parent=6, child=5)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.3)
 
-        tables.edges.add_row(left=0, right=1, parent=5, child=1)
-        tables.edges.add_row(left=0, right=0.3, parent=5, child=4)
-        tables.edges.add_row(left=0.5, right=1, parent=5, child=4)
+        tables.edges.add_row(left=0, right=1, parent=7, child=1)
+        tables.edges.add_row(left=0, right=0.3, parent=7, child=6)
+        tables.edges.add_row(left=0.5, right=1, parent=7, child=6)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.4)
 
-        tables.edges.add_row(left=0.3, right=0.5, parent=6, child=3)
-        tables.edges.add_row(left=0.3, right=0.5, parent=6, child=5)
+        tables.edges.add_row(left=0.3, right=0.5, parent=8, child=4)
+        tables.edges.add_row(left=0.3, right=0.5, parent=8, child=7)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.5)
 
         tables.mutations.add_row(site=0, node=2, derived_state="1")
-        tables.mutations.add_row(site=1, node=2, derived_state="1")
-        tables.mutations.add_row(site=2, node=5, derived_state="1")
-        tables.mutations.add_row(site=3, node=4, derived_state="1")
-        tables.mutations.add_row(site=4, node=3, derived_state="1")
+        tables.mutations.add_row(site=1, node=3, derived_state="1")
+        tables.mutations.add_row(site=2, node=7, derived_state="1")
+        tables.mutations.add_row(site=3, node=6, derived_state="1")
+        tables.mutations.add_row(site=4, node=5, derived_state="1")
 
         tables.sites.add_row(0.1, "0")
         tables.sites.add_row(0.35, "0")
@@ -370,42 +398,53 @@ class TestKnownExamples:
             flags=tskit.NODE_IS_SAMPLE, population=0, individual=-1, time=0
         )
 
-        tables.edges.add_row(left=0, right=1, parent=2, child=0)
+        tables.edges.add_row(left=0, right=0.3, parent=2, child=0)
+        tables.edges.add_row(left=0.3, right=1, parent=3, child=0)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.1
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.1
         )
 
-        tables.edges.add_row(left=0.3, right=1, parent=3, child=2)
+        tables.edges.add_row(left=0.3, right=0.5, parent=4, child=3)
+        tables.edges.add_row(left=0.5, right=1, parent=5, child=3)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.2
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.2
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.2
         )
 
-        tables.edges.add_row(left=0, right=0.3, parent=4, child=2)
-        tables.edges.add_row(left=0.5, right=1, parent=4, child=3)
+        tables.edges.add_row(left=0, right=0.3, parent=6, child=2)
+        tables.edges.add_row(left=0.5, right=1, parent=6, child=5)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.3)
 
-        tables.edges.add_row(left=0, right=0.3, parent=5, child=4)
-        tables.edges.add_row(left=0.5, right=1, parent=5, child=4)
+        tables.edges.add_row(left=0, right=0.3, parent=7, child=6)
+        tables.edges.add_row(left=0.5, right=1, parent=8, child=6)
         tables.nodes.add_row(
-            flags=msprime.NODE_IS_RECOMBINANT, population=0, individual=-1, time=0.4
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.4
+        )
+        tables.nodes.add_row(
+            flags=msprime.NODE_IS_RE_EVENT, population=0, individual=-1, time=0.4
         )
 
-        tables.edges.add_row(left=0.3, right=0.5, parent=6, child=3)
-        tables.edges.add_row(left=0.5, right=1, parent=6, child=5)
+        tables.edges.add_row(left=0.3, right=0.5, parent=9, child=4)
+        tables.edges.add_row(left=0.5, right=1, parent=9, child=8)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.5)
 
-        tables.edges.add_row(left=0, right=1, parent=7, child=1)
-        tables.edges.add_row(left=0, right=0.3, parent=7, child=5)
+        tables.edges.add_row(left=0, right=1, parent=10, child=1)
+        tables.edges.add_row(left=0, right=0.3, parent=10, child=7)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.6)
 
-        tables.edges.add_row(left=0.3, right=1, parent=8, child=6)
-        tables.edges.add_row(left=0.3, right=1, parent=8, child=7)
+        tables.edges.add_row(left=0.3, right=1, parent=11, child=9)
+        tables.edges.add_row(left=0.3, right=1, parent=11, child=10)
         tables.nodes.add_row(flags=0, population=0, individual=-1, time=0.7)
 
         tables.mutations.add_row(site=0, node=2, derived_state="1")
-        tables.mutations.add_row(site=1, node=2, derived_state="1")
-        tables.mutations.add_row(site=2, node=4, derived_state="1")
-        tables.mutations.add_row(site=3, node=3, derived_state="1")
+        tables.mutations.add_row(site=1, node=3, derived_state="1")
+        tables.mutations.add_row(site=2, node=6, derived_state="1")
+        tables.mutations.add_row(site=3, node=5, derived_state="1")
 
         tables.sites.add_row(0.1, "0")
         tables.sites.add_row(0.35, "0")

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -92,7 +92,6 @@ def log_arg_likelihood(arg, recombination_rate, Ne=1):
     return ret
 
 
-@pytest.mark.skip("Currently broken")
 class TestKnownExamples:
     """
     Tests for likelihood evaluation with the full ARG in cases where we've
@@ -464,7 +463,6 @@ class TestSimulatedExamples(unittest.TestCase):
         self.verify(ts, recombination_rate=1, Ne=1)
         self.verify(ts, recombination_rate=1, Ne=2)
 
-    @pytest.mark.skip("Currently broken")
     def test_small_arg_no_mutation(self):
         ts = msprime.simulate(
             5, recombination_rate=1, random_seed=12, record_full_arg=True


### PR DESCRIPTION
Reverts tskit-dev/msprime#1982

Given that it's quite likely that two-node recombination is actually the correct thing to do, I think it's wise to revert this PR before the state of the repo moves on and it becomes messier.

If we decide to go back to the single-node recombination I'll make a new PR with the original commits cherry picked and rebased, so we won't have to redo the work.

Does this sound OK @JereKoskela?

Apologies for the chopping and changing @JereKoskela - this is all very tricky!