### PR TITLE
Clamp recomb rates to > 0 in sweep model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-Minor bugfix release.
-
 ## [1.2.0] - 2022-04-XX
 
 UPCOMING
+
+**Bug fixes**:
+- Fix rare assertion trip in the single sweep model caused by numerical jitter.
+  ({issue}`1966`, {pr}`2038`, {user}`jeromekelleher `, {user}`molpopgen`)
 
 ## [1.1.1] - 2022-02-10
 


### PR DESCRIPTION
Looks like #1966 is one of those rare numerical annoyances that just needs to be worked around.

I can't see how clamping recombination rates to be >= 0 can have any detrimental effects?

Can I get your eyes on this please @molpopgen and @andrewkern?

Closes #1966