### PR TITLE
Fix setuptools_scm issue in docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
             python setup.py sdist
             python setup.py check
             python -m twine check dist/*.tar.gz --strict
+            rm dist/*
             python -m build
 
       - run:

--- a/.github/workflows/docker/buildwheel.sh
+++ b/.github/workflows/docker/buildwheel.sh
@@ -15,6 +15,11 @@ make -j 2
 make install
 cd ..
 
+# We're running as root in the docker container so git commands issued by
+# setuptools_scm will fail without this:
+git config --global --add safe.directory /project
+# Fetch the full history as we'll be missing tags otherwise.
+git fetch --unshallow
 for V in "${PYTHON_VERSIONS[@]}"; do
     PYBIN=/opt/python/$V/bin
     rm -rf build/       # Avoid lib build by narrow Python is used by wide python

--- a/.github/workflows/docker/buildwheel.sh
+++ b/.github/workflows/docker/buildwheel.sh
@@ -22,12 +22,11 @@ git config --global --add safe.directory /project
 git fetch --unshallow
 for V in "${PYTHON_VERSIONS[@]}"; do
     PYBIN=/opt/python/$V/bin
-    rm -rf build/       # Avoid lib build by narrow Python is used by wide python
-    # Instead of letting setup.py install a newer numpy we install it here
-    # using the oldest supported version for ABI compatibility
-    $PYBIN/pip install oldest-supported-numpy
-    $PYBIN/python setup.py build_ext --inplace
-    $PYBIN/python setup.py bdist_wheel
+    rm -rf build/       # Avoid lib build by one Python is used by another
+    $PYBIN/python -m venv env
+    source env/bin/activate
+    python -m pip install --upgrade build
+    SETUPTOOLS_SCM_DEBUG=1 python -m build
 done
 
 cd dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,19 +28,10 @@ jobs:
       - name: Install deps
         run: |
           brew install gsl
-          # Upgrade pip to get bdist_wheel
-          pip install --upgrade pip
-          pip install setuptools wheel
-          # Instead of letting setup.py install a newer numpy we install it here
-          # using the oldest supported version for ABI compatibility
-          pip install oldest-supported-numpy
-      - name: Build C extension
-        run: |
-          python -VV
-          python setup.py build_ext --inplace
+          pip install --upgrade pip build
       - name: Build Wheel
         run: |
-          python setup.py bdist_wheel
+          python -m build --wheel
       - name: Delocate to bundle dynamic libs
         run: |
           pip install delocate
@@ -65,7 +56,8 @@ jobs:
       - name: Build sdist
         shell: bash
         run: |
-          python setup.py sdist
+          pip install --upgrade pip build
+          python -m build --sdist
       - name: Upload sdist
         uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,11 @@
 [build-system]
 requires = [
     "setuptools>=42",
+    "setuptools_scm",
     "wheel",
     "oldest-supported-numpy"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "msprime/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,6 @@ install_requires =
     newick>=1.3.0
     tskit>=0.4.0
     demes>=0.2
-setup_requires =
-    numpy
-    setuptools
-    setuptools_scm
 
 [options.entry_points]
 console_scripts = 


### PR DESCRIPTION
Yikes, seems that running as the user in the docker container upsets git which setuptools_scm was using.
As part of fixing this I switch the build to use the now recommended `build` module.