### PR TITLE
clean up of microsatellite documentation and defaults

### DIFF
--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -758,6 +758,49 @@ plt.ylabel('Variance in repeat number');
 So here we are seeing a clear relationship between the variance
 in repeat number and mutation rate, as expected. 🔥🔥🔥
 
+#### A more complicated microsatellite model
+In the 1990s a lot of work went in to describing patterns of
+mutation at microsatellite loci, and a number of models were
+put forward described various biases in expansion vs contraction,
+mutistep mutations, and mutation rate biases. We have implemented 
+a general parameterization of microsatellite mutation models
+developed in [Sainudiin et al. (2004)](https://doi.org/10.1534/genetics.103.022665) that allows users fine grained control of microsatellite mutation.
+
+One such model is the equal rate, linear biased, two-phase
+mutation model of [Garza et al. (1995)](https://doi.org/10.1093/oxfordjournals.molbev.a040239)
+that we have implemented in {class}`.EL2`. Let's simulate large
+samples under this model with different strengths of linear bias, 
+and compare the distribution of allele sizes we get back.
+
+```{code-cell} python
+from matplotlib import pyplot as plt
+from scipy import stats
+
+biases = np.logspace(-7, 1, num=9)
+ts = msprime.sim_ancestry(1000, random_seed=2, sequence_length=1, population_size=100_000)
+for v in biases:
+    model = msprime.EL2(
+            # these are values of m and u from Sainudiin et al. (2004)
+            m=0.01,
+            u=0.68,
+            v=v,
+        )
+    mts = msprime.sim_mutations(ts, rate=1e-3, model=model)
+    C = copy_number_matrix(mts)
+    kde = stats.gaussian_kde(C.flatten())
+    x = np.linspace(2, 51)
+    plt.plot(x, kde(x), label=f'v={v}')
+plt.xlabel('copy number')
+plt.ylabel('frequency')
+plt.legend()
+plt.show();
+```
+From these simulations we can see that the linear bias parameter `v`
+has a strong effect on the distribution of allele frequencies we
+might expect from our model. Care should be taken when choosing
+parameters for your own simulations. Potentially appropriate
+values for dinucleotide repeats in humans and chimp could be taken
+from Table 2 of [Sainudiin et al. (2004)](https://doi.org/10.1534/genetics.103.022665), but we offer no guarantees and your mileage may vary. 
 ### Infinite Alleles Mutation Models
 
 You can also use a model of *infinite alleles* mutation: where each new mutation produces a unique,

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -93,9 +93,6 @@ for more information.
 {class}`.BinaryMutationModel` (Binary ancestral/derived)
 : Binary mutation model with two flip-flopping alleles: "0" and "1".
 
-{class}`.MatrixMutationModel` (General finite state model)
-: Superclass of mutation models with a finite set of states
-
 {class}`.SMM` (Microsatellites)
 : Stepwise mutation model for microsatellites
 
@@ -110,6 +107,9 @@ for more information.
 
 {class}`.SLiMMutationModel` (Integers)
 : An infinite-alleles model producing SLiM-style mutations
+
+{class}`.MatrixMutationModel` (General finite state model)
+: Superclass of mutation models with a finite set of states
 
 ---
 
@@ -501,7 +501,7 @@ in these models see {ref}`sec_mutations_matrix_mutation_models_details`.
 
 (sec_mutations_matrix_mutation_models_details)=
 
-### Mutation Matrix Models Details
+#### Mutation Matrix Models Details
 
 Mutation matrix models are specified by three things: an alphabet,
 a root distribution, and a transition matrix.
@@ -522,7 +522,7 @@ You can define your own, but you probably don't need to:
 there are several mutation matrix models already implemented in `msprime`,
 using binary (0/1), nucleotide, or amino acid alphabets:
 
-### Defining your own finite-sites model
+#### Defining your own finite-sites model
 
 If you want to define your own {class}`.MatrixMutationModel`, you have a good
 deal of freedom. For instance, here's a "decomposition/growth/disturbance"
@@ -560,7 +560,7 @@ for v in mts.variants():
 
 (sec_mutations_matrix_mutation_theory)=
 
-### Parameterisation of Matrix Mutation Models
+#### Parameterisation of Matrix Mutation Models
 
 Mutation matrix models are specified by three things: an alphabet,
 a root distribution, and a transition matrix.
@@ -668,7 +668,8 @@ print(f"Genetic diversity: {theta}.")
 
 That's pretty close to 0.001! The difference is within statistical error.
 
-(sec_mutations_mutation_infinite_alleles)=
+
+(sec_mutations_microsats)=
 
 ### Microsatellite Mutation Models
 
@@ -678,7 +679,8 @@ The basic idea here is that the number of copies of a given repeat is
 tracked, and its evolution over time subject to one of a number of potential
 biases.
 
-Consider the [Combined DNA Index System](https://en.wikipedia.org/wiki/Combined_DNA_Index_System) (CODIS), a US National database
+Consider the [Combined DNA Index System](https://en.wikipedia.org/wiki/Combined_DNA_Index_System) 
+(CODIS), a US National database
 of genotypes maintained by the justice system for use in forensic DNA analysis.
 The CODIS system relies on 20 core microsatellite loci, that are unlinked across
 the human genome. Let's simulate a sample of 5 individuals at 20 unlinked loci,
@@ -759,14 +761,17 @@ So here we are seeing a clear relationship between the variance
 in repeat number and mutation rate, as expected. 🔥🔥🔥
 
 #### A more complicated microsatellite model
-In the 1990s a lot of work went in to describing patterns of
-mutation at microsatellite loci, and a number of models were
-put forward described various biases in expansion vs contraction,
-mutistep mutations, and mutation rate biases. We have implemented 
-a general parameterization of microsatellite mutation models
-developed in [Sainudiin et al. (2004)](https://doi.org/10.1534/genetics.103.022665) that allows users fine grained control of microsatellite mutation.
 
-One such model is the equal rate, linear biased, two-phase
+In the 1990s a lot of work went in to describing patterns of
+mutation at microsatellite loci, and several models were
+put forward describing various biases in expansion vs contraction,
+mutistep mutations, and mutation rate biases. The 
+{class}`.MicrosatMutationModel` implements the general parameterization 
+of microsatellite mutation models developed in 
+[Sainudiin et al. (2004)](https://doi.org/10.1534/genetics.103.022665),
+allowing users fine grained control of microsatellite mutation.
+
+One concrete instance of this general model is the equal rate, linear biased, two-phase
 mutation model of [Garza et al. (1995)](https://doi.org/10.1093/oxfordjournals.molbev.a040239)
 that we have implemented in {class}`.EL2`. Let's simulate large
 samples under this model with different strengths of linear bias, 
@@ -777,14 +782,11 @@ from matplotlib import pyplot as plt
 from scipy import stats
 
 biases = np.logspace(-7, 1, num=9)
-ts = msprime.sim_ancestry(1000, random_seed=2, sequence_length=1, population_size=100_000)
+ts = msprime.sim_ancestry(
+    1000, random_seed=2, sequence_length=1, population_size=100_000)
 for v in biases:
-    model = msprime.EL2(
-            # these are values of m and u from Sainudiin et al. (2004)
-            m=0.01,
-            u=0.68,
-            v=v,
-        )
+    # these are values of m and u from Sainudiin et al. (2004)
+    model = msprime.EL2(m=0.01, u=0.68, v=v)
     mts = msprime.sim_mutations(ts, rate=1e-3, model=model)
     C = copy_number_matrix(mts)
     kde = stats.gaussian_kde(C.flatten())
@@ -800,7 +802,10 @@ has a strong effect on the distribution of allele frequencies we
 might expect from our model. Care should be taken when choosing
 parameters for your own simulations. Potentially appropriate
 values for dinucleotide repeats in humans and chimp could be taken
-from Table 2 of [Sainudiin et al. (2004)](https://doi.org/10.1534/genetics.103.022665), but we offer no guarantees and your mileage may vary. 
+from Table 2 of [Sainudiin et al. (2004)](https://doi.org/10.1534/genetics.103.022665), 
+but we offer no guarantees and your mileage may vary. 
+
+(sec_mutations_mutation_infinite_alleles)=
 ### Infinite Alleles Mutation Models
 
 You can also use a model of *infinite alleles* mutation: where each new mutation produces a unique,

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -311,6 +311,9 @@ class MicrosatMutationModel(MatrixMutationModel):
     to the model of
     `Sainudiin et al. (2004) <https://doi.org/10.1534/genetics.103.022665>`_
 
+    .. seealso:: See the :ref:`sec_mutations_microsats` section for more details
+       and examples.
+
     Concretely, mutation rates under this model are computed as follows.
     Let ``qij`` be the transition rate from equation (3) in Sainudiin et al,
     and let ``M`` be the largest row sum of the matrix whose i,j-th entry
@@ -322,10 +325,12 @@ class MicrosatMutationModel(MatrixMutationModel):
     and are unrelated to repeat length
     (e.g., the repeat itself can be dinucleotide, tri-nucleotide, etcetera).
 
-    The default values for ``lo`` and ``hi`` are chosen based on
-    nothing particular, other than repeat number need be greater than 1,
-    for geneticists to declare them a repeat. Be sure to set ``lo`` and ``hi``
-    to the correct values for your organism / locus of interest.
+    .. warning::
+        The default values for ``lo`` and ``hi`` are chosen arbitrarily.
+        The default of ``lo=2`` is chosed because repeat number need be greater
+        than for it to be considered a repeat. Please ensure
+        that you set ``lo`` and ``hi``
+        to the appropriate values for your organism / locus of interest.
 
     :param float s: strength of length dependence on mutation rate.
         Defaults to 0, i.e., no length dependence.
@@ -446,10 +451,6 @@ class TPM(MicrosatMutationModel):
     """
 
     def __init__(self, *, p, m, lo=None, hi=None, root_distribution=None):
-        if p is None:
-            raise ValueError("p must be specified")
-        if m is None:
-            raise ValueError("m must be specified")
         if not (0 < p < 1.0):
             raise ValueError("p must be between 0 and 1")
         if not (0 < m < 1.0):
@@ -500,13 +501,6 @@ class EL2(MicrosatMutationModel):
     """
 
     def __init__(self, *, m, u, v, lo=None, hi=None, root_distribution=None):
-
-        if m is None:
-            raise ValueError("m must be specified")
-        if u is None:
-            raise ValueError("u must be specified")
-        if v is None:
-            raise ValueError("v must be specified")
         if not (0 < m < 1.0):
             raise ValueError("m must be between 0 and 1")
         if not (0 < u < 1.0):

--- a/msprime/mutations.py
+++ b/msprime/mutations.py
@@ -323,7 +323,9 @@ class MicrosatMutationModel(MatrixMutationModel):
     (e.g., the repeat itself can be dinucleotide, tri-nucleotide, etcetera).
 
     The default values for ``lo`` and ``hi`` are chosen based on
-    FIXME.
+    nothing particular, other than repeat number need be greater than 1,
+    for geneticists to declare them a repeat. Be sure to set ``lo`` and ``hi``
+    to the correct values for your organism / locus of interest.
 
     :param float s: strength of length dependence on mutation rate.
         Defaults to 0, i.e., no length dependence.
@@ -431,12 +433,10 @@ class TPM(MicrosatMutationModel):
     This is a :class:`.MicrosatMutationModel` with alleles ``[lo, .. , hi]``.
     For a precise definition of the mutation rates, see :class:`.MicrosatMutationModel`
     with ``s=0``, ``u=0.5``, and ``v=0``.
-    Default values for ``p`` and ``m``
-    are those estimated by
-    `Sainudiin et al. (2004) <https://doi.org/10.1534/genetics.103.022665>`_
+    See :class:`.MicrosatMutationModel` for further details of parameterization.
 
-    :param float p: Probability of a single step mutation. (Default=0.9)
-    :param float m: Success prob of truncated gamma distribution. (Default=0.93)
+    :param float p: Probability of a single step mutation.
+    :param float m: Success prob of truncated gamma distribution.
     :param int lo: Repeat number lower bound. See the documentation for
         :class:`.MicrosatMutationModel` for details.
     :param int hi: Repeat number upper bound. See the documentation for
@@ -445,9 +445,11 @@ class TPM(MicrosatMutationModel):
         :class:`.MicrosatMutationModel` for details.
     """
 
-    def __init__(self, *, p=None, m=None, lo=None, hi=None, root_distribution=None):
-        p = 0.9 if p is None else p
-        m = 0.93 if m is None else m
+    def __init__(self, *, p, m, lo=None, hi=None, root_distribution=None):
+        if p is None:
+            raise ValueError("p must be specified")
+        if m is None:
+            raise ValueError("m must be specified")
         if not (0 < p < 1.0):
             raise ValueError("p must be between 0 and 1")
         if not (0 < m < 1.0):
@@ -466,11 +468,17 @@ class EL2(MicrosatMutationModel):
 
     This models evolution of microsatellite repeat number in a manner
     that allows for multi-step mutations in copy number.
-    This is parameterized by `p` the probability of a single step mutation,
-    and `m` the success probability of the truncated gamma distribution
+    This is parameterized by `m` the success probability of
+    the truncated gamma distribution
     describing the distribution of longer steps, such that the
-    mean multi-step mutation is length `1/m`.
-    For this model both `p` and `m` need to be set to < 1.0.
+    mean multi-step mutation is length `1/m`. `u` the constant
+    bias parameter which determines bias (if any) in expansion or
+    contraction of the repeat number, and `v` the linear bias
+    parameter which determines mutation rate variation associated
+    with repeat number.
+    For this model `m` need to be set to < 1.0,
+    and `u` needs to be set to between 0 and 1.
+    and `v` can take any real, positive or negative value.
 
     See :class:`.MicrosatMutationModel` for details on the  constant
     bias parameter `u` and a linear bias parameter `v`.
@@ -478,12 +486,11 @@ class EL2(MicrosatMutationModel):
     This is a :class:`.MicrosatMutationModel` with alleles ``[lo, .. , hi]``
     For a precise definition of the mutation rates,
     see :class:`.MicrosatMutationModel`
-    with ``s=0``. Default values for ``m``, ``u`` and ``v``
-    are those estimated by Sainudiin et al. (2004).
+    with ``s=0``.
 
-    :param float m: Success prob of truncated gamma distribution (0.43).
-    :param float u: Constant bias parameter (Default=0.68).
-    :param float v: Linear bias parameter (Default=0.037).
+    :param float m: Success prob of truncated gamma distribution.
+    :param float u: Constant bias parameter.
+    :param float v: Linear bias parameter.
     :param int lo: Repeat number lower bound. See the documentation for
         :class:`.MicrosatMutationModel` for details.
     :param int hi: Repeat number upper bound. See the documentation for
@@ -492,12 +499,14 @@ class EL2(MicrosatMutationModel):
         :class:`.MicrosatMutationModel` for details.
     """
 
-    def __init__(
-        self, *, m=None, u=None, v=None, lo=None, hi=None, root_distribution=None
-    ):
-        m = 0.43 if m is None else m
-        u = 0.68 if u is None else u
-        v = 0.037 if v is None else v
+    def __init__(self, *, m, u, v, lo=None, hi=None, root_distribution=None):
+
+        if m is None:
+            raise ValueError("m must be specified")
+        if u is None:
+            raise ValueError("u must be specified")
+        if v is None:
+            raise ValueError("v must be specified")
         if not (0 < m < 1.0):
             raise ValueError("m must be between 0 and 1")
         if not (0 < u < 1.0):

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -479,16 +479,13 @@ class TestMicrosatModels:
         with pytest.raises(ValueError, match="m must be"):
             msprime.TPM(m=1.1, p=0.9)
 
-    @pytest.mark.parametrize(
-        "m, p",
-        [
-            (0.9, None),
-            (None, 0.9),
-        ],
-    )
-    def test_bad_TMP_missing_defaults(self, m, p):
-        with pytest.raises(ValueError):
-            msprime.TPM(m=m, p=p)
+    def test_bad_TPM_missing_m(self):
+        with pytest.raises(TypeError):
+            msprime.TPM(p=0.1)
+
+    def test_bad_TPM_missing_p(self):
+        with pytest.raises(TypeError):
+            msprime.TPM(m=0.1)
 
     def test_bad_EL2_m_value(self):
         with pytest.raises(ValueError, match="m must be"):
@@ -498,17 +495,17 @@ class TestMicrosatModels:
         with pytest.raises(ValueError, match="u must be"):
             msprime.EL2(m=0.9, u=1.1, v=0.6)
 
-    @pytest.mark.parametrize(
-        "m, u, v",
-        [
-            (0.9, 0.9, None),
-            (0.9, None, 0.9),
-            (None, 0.9, 0.9),
-        ],
-    )
-    def test_bad_EL2_missing_defaults(self, m, u, v):
-        with pytest.raises(ValueError):
-            msprime.EL2(m=m, u=u, v=v)
+    def test_bad_EL2_missing_m(self):
+        with pytest.raises(TypeError):
+            msprime.EL2(u=0.6, v=0.5)
+
+    def test_bad_EL2_missing_u(self):
+        with pytest.raises(TypeError):
+            msprime.EL2(m=0.6, v=0.5)
+
+    def test_bad_EL2_missing_v(self):
+        with pytest.raises(TypeError):
+            msprime.EL2(m=0.6, u=0.5)
 
     @pytest.mark.parametrize("v", [np.inf, np.nan])
     def test_bad_EL2_v_value(self, v):

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -381,7 +381,11 @@ class TestMatrixMutationModel:
                 assert np.isclose(exp, obs)
 
     def test_EL2(self):
-        model = msprime.EL2()
+        model = msprime.EL2(
+            m=0.43,
+            u=0.68,
+            v=0.037,
+        )
         self.validate_model(model)
         self.validate_stationary(model)
 
@@ -391,7 +395,7 @@ class TestMatrixMutationModel:
         u = 0.68
         v = 0.037
         p = 0
-        model = msprime.EL2(lo=lo, hi=hi)
+        model = msprime.EL2(lo=lo, hi=hi, m=m, u=u, v=v)
         for i in range(lo, hi + 1):
             if lo < i < hi:
                 ii = i - lo
@@ -469,24 +473,47 @@ class TestMicrosatModels:
 
     def test_bad_TPM_p_value(self):
         with pytest.raises(ValueError, match="p must be"):
-            msprime.TPM(p=1.1)
+            msprime.TPM(m=0.9, p=1.1)
 
     def test_bad_TPM_m_value(self):
         with pytest.raises(ValueError, match="m must be"):
-            msprime.TPM(m=1.1)
+            msprime.TPM(m=1.1, p=0.9)
+
+    @pytest.mark.parametrize(
+        "m, p",
+        [
+            (0.9, None),
+            (None, 0.9),
+        ],
+    )
+    def test_bad_TMP_missing_defaults(self, m, p):
+        with pytest.raises(ValueError):
+            msprime.TPM(m=m, p=p)
 
     def test_bad_EL2_m_value(self):
         with pytest.raises(ValueError, match="m must be"):
-            msprime.EL2(m=1.1)
+            msprime.EL2(m=1.1, u=0.6, v=0.3)
 
     def test_bad_EL2_u_value(self):
         with pytest.raises(ValueError, match="u must be"):
-            msprime.EL2(u=1.1)
+            msprime.EL2(m=0.9, u=1.1, v=0.6)
+
+    @pytest.mark.parametrize(
+        "m, u, v",
+        [
+            (0.9, 0.9, None),
+            (0.9, None, 0.9),
+            (None, 0.9, 0.9),
+        ],
+    )
+    def test_bad_EL2_missing_defaults(self, m, u, v):
+        with pytest.raises(ValueError):
+            msprime.EL2(m=m, u=u, v=v)
 
     @pytest.mark.parametrize("v", [np.inf, np.nan])
     def test_bad_EL2_v_value(self, v):
         with pytest.raises(ValueError, match="finite"):
-            msprime.EL2(v=v)
+            msprime.EL2(v=v, m=0.9, u=0.6)
 
 
 class TestMutateRateMap:


### PR DESCRIPTION
here is a PR to clean up a number of issues in documentation and the default values of the microsatellites.

what i've tried to do here is:
- strip out defaults from the microsatellite models so that people are forced to think about parameterization #2075  
- clean up the documentation on the TPM model #2075 
- clean up the conflict in documentation on the EL2 model #2077 
- explain the `lo` and `hi` default values #2078 

