### PR TITLE
Update tskit requirement for Tree.num_children_array

### DIFF
--- a/requirements/CI-complete/requirements.txt
+++ b/requirements/CI-complete/requirements.txt
@@ -14,5 +14,5 @@ jsonschema<4.0
 python_jsonschema_objects==0.4.1
 scipy==1.7.3
 stdpopsim==0.1.2
-tskit==0.5.0
+tskit==0.5.3
 kastore==0.3.2

--- a/requirements/CI-docs/requirements.txt
+++ b/requirements/CI-docs/requirements.txt
@@ -7,5 +7,5 @@ matplotlib==3.5.0
 newick==1.3.1
 sphinx-argparse==0.3.1
 sphinx-issues==1.2.0
-tskit==0.4.0
+tskit==0.5.3
 tskit-book-theme==0.3.2

--- a/requirements/CI-tests-conda/requirements.txt
+++ b/requirements/CI-tests-conda/requirements.txt
@@ -3,6 +3,6 @@
 # but demes will pull in the latest so we pin here.
 jsonschema<4.0
 gsl
-tskit==0.5.0
+tskit==0.5.3
 stdpopsim==0.1.2
 demes==0.2.1

--- a/requirements/CI-tests-pip/requirements.txt
+++ b/requirements/CI-tests-pip/requirements.txt
@@ -9,4 +9,4 @@ pytest-xdist==2.4.0
 jsonschema<5.0
 python_jsonschema_objects==0.4.1
 scipy==1.7.3
-tskit==0.5.0
+tskit==0.5.3

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -17,7 +17,7 @@ pre-commit
 pytest
 pytest-cov
 pytest-xdist
-tskit>=0.4.0
+tskit>=0.5.2
 tskit-book-theme
 stdpopsim>=0.1.2 # Make sure we have correct version of OOA model
 scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ include_package_data = True
 install_requires =
     numpy
     newick>=1.3.0
-    tskit>=0.4.0
+    tskit>=0.5.2
     demes>=0.2
 
 [options.entry_points]


### PR DESCRIPTION
Fixes #2115 

PR #2114 uses the new `Tree.num_children_array` from `tskit` 0.5.0. I've set the requirement in `setup.cfg` to `>=0.5.2` as there were important fixes in those point releases and it seems better to skip to 0.5.2 than specify 0.5.0.

Ideally this commit should be pulled into #2114 as it is nice to have requirements changes be part of the PR that needs them, but I guess it is also ok if this one is merged first if simpler.

@JereKoskela 