### PR TITLE
first pass store unary

### DIFF
--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -195,6 +195,7 @@ typedef struct _msp_t {
     simulation_model_t model;
     bool store_migrations;
     bool store_full_arg;
+    bool store_unary;
     double sequence_length;
     bool discrete_genome;
     rate_map_t recomb_map;
@@ -429,6 +430,7 @@ int msp_set_simulation_model_sweep_genic_selection(msp_t *self, double position,
 int msp_set_start_time(msp_t *self, double start_time);
 int msp_set_store_migrations(msp_t *self, bool store_migrations);
 int msp_set_store_full_arg(msp_t *self, bool store_full_arg);
+int msp_set_store_unary(msp_t *self, bool store_unary);
 int msp_set_ploidy(msp_t *self, int ploidy);
 int msp_set_recombination_map(msp_t *self, size_t size, double *position, double *rate);
 int msp_set_recombination_rate(msp_t *self, double rate);

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -658,6 +658,42 @@ test_multi_locus_bottleneck_arg(void)
     tsk_table_collection_free(&tables);
 }
 
+static void
+test_multi_locus_store_unary_simple(void)
+{
+    int ret;
+    uint32_t n = 10;
+    msp_t msp;
+    gsl_rng *rng = safe_rng_alloc();
+    tsk_table_collection_t tables;
+    tsk_size_t num_edges, num_edges_simple;
+
+    ret = build_sim(&msp, &tables, rng, 100, 1, NULL, n);
+    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 10), 0);
+    ret = msp_set_store_unary(&msp, true);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_initialise(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+
+    ret = msp_run(&msp, DBL_MAX, UINT32_MAX);
+    CU_ASSERT_EQUAL(ret, 0);
+    msp_verify(&msp, 0);
+
+    CU_ASSERT_TRUE(msp_get_num_breakpoints(&msp) > 0);
+    // verify whether there is at least one unary node
+    num_edges = tables.edges.num_rows;
+    ret = tsk_table_collection_simplify(&tables, NULL, 0, 0, NULL);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    num_edges_simple = tables.edges.num_rows;
+    CU_ASSERT_TRUE(num_edges_simple < num_edges);
+
+    ret = msp_free(&msp);
+    CU_ASSERT_EQUAL(ret, 0);
+    gsl_rng_free(rng);
+    tsk_table_collection_free(&tables);
+}
+
 static int
 get_num_children(size_t node, tsk_edge_table_t *edges)
 {
@@ -3533,6 +3569,7 @@ main(int argc, char **argv)
 
         { "test_multi_locus_simulation", test_multi_locus_simulation },
         { "test_multi_locus_bottleneck_arg", test_multi_locus_bottleneck_arg },
+        { "test_multi_locus_store_unary_simple", test_multi_locus_store_unary_simple },
 
         { "test_dtwf_single_locus_simulation", test_dtwf_single_locus_simulation },
         { "test_dtwf_multi_locus_simulation", test_dtwf_multi_locus_simulation },

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1766,7 +1766,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
         "population_configuration", "migration_matrix",
         "demographic_events", "model", "avl_node_block_size", "segment_block_size",
         "node_mapping_block_size", "store_migrations", "start_time",
-        "store_full_arg", "num_labels", "gene_conversion_rate",
+        "store_full_arg", "store_unary", "num_labels", "gene_conversion_rate",
         "gene_conversion_tract_length", "discrete_genome",
         "ploidy", NULL};
     PyObject *migration_matrix = NULL;
@@ -1784,6 +1784,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     Py_ssize_t num_populations = 1;
     int store_migrations = false;
     int store_full_arg = false;
+    int store_unary = false;
     int discrete_genome = true;
     double start_time = -1;
     double gene_conversion_rate = 0;
@@ -1793,7 +1794,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     self->sim = NULL;
     self->random_generator = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-            "O!O!|O!O!OO!O!nnnidinddii", kwlist,
+            "O!O!|O!O!OO!O!nnnidiinddii", kwlist,
             &LightweightTableCollectionType, &tables,
             &RandomGeneratorType, &random_generator,
             /* optional */
@@ -1804,7 +1805,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             &PyDict_Type, &py_model,
             &avl_node_block_size, &segment_block_size,
             &node_mapping_block_size, &store_migrations, &start_time,
-            &store_full_arg, &num_labels,
+            &store_full_arg, &store_unary, &num_labels,
             &gene_conversion_rate, &gene_conversion_tract_length,
             &discrete_genome, &ploidy)) {
         goto out;
@@ -1926,6 +1927,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
         }
     }
     msp_set_store_full_arg(self->sim, store_full_arg);
+    msp_set_store_unary(self->sim, store_unary);
 
     sim_ret = msp_initialise(self->sim);
     if (sim_ret != 0) {

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -249,6 +249,7 @@ def _parse_simulate(
     start_time=None,
     end_time=None,
     record_full_arg=False,
+    record_unary=False,
     num_labels=None,
     random_seed=None,
 ):
@@ -361,6 +362,7 @@ def _parse_simulate(
         models=models,
         store_migrations=record_migrations,
         store_full_arg=record_full_arg,
+        store_unary=record_unary,
         start_time=start_time,
         end_time=end_time,
         num_labels=num_labels,
@@ -427,6 +429,7 @@ def simulate(
     start_time=None,
     end_time=None,
     record_full_arg=False,
+    record_unary=False,
     num_labels=None,
     record_provenance=True,
 ):
@@ -529,6 +532,8 @@ def simulate(
         arising from common ancestor and recombination events in the output
         tree sequence. This will result in unary nodes (i.e., nodes in marginal
         trees that have only one child). Defaults to False.
+    :param bool record_unary: If True, retain all ancestry for any nodes that
+        are coalescent nodes anywhere in the sequence. Defaults to False.
     :param model: The simulation model to use.
         This can either be a string (e.g., ``"smc_prime"``) or an instance of
         a ancestry model class (e.g, ``msprime.DiscreteTimeWrightFisher()``.
@@ -568,6 +573,7 @@ def simulate(
             start_time=start_time,
             end_time=end_time,
             record_full_arg=record_full_arg,
+            record_unary=record_unary,
             num_labels=num_labels,
             random_seed=random_seed,
             # num_replicates is excluded as provenance is per replicate
@@ -622,6 +628,7 @@ def simulate(
         start_time=start_time,
         end_time=end_time,
         record_full_arg=record_full_arg,
+        record_unary=record_unary,
         num_labels=num_labels,
         random_seed=random_seed,
     )
@@ -790,6 +797,7 @@ def _parse_sim_ancestry(
     end_time=None,
     record_migrations=None,
     record_full_arg=None,
+    record_unary=None,
     num_labels=None,
     random_seed=None,
     init_for_debugger=False,
@@ -806,6 +814,7 @@ def _parse_sim_ancestry(
     end_time = math.inf if end_time is None else float(end_time)
     discrete_genome = core._parse_flag(discrete_genome, default=True)
     record_full_arg = core._parse_flag(record_full_arg, default=False)
+    record_unary = core._parse_flag(record_unary, default=False)
     record_migrations = core._parse_flag(record_migrations, default=False)
 
     if initial_state is not None:
@@ -1018,6 +1027,7 @@ def _parse_sim_ancestry(
         models=models,
         store_migrations=record_migrations,
         store_full_arg=record_full_arg,
+        store_unary=record_unary,
         start_time=start_time,
         end_time=end_time,
         num_labels=num_labels,
@@ -1042,6 +1052,7 @@ def sim_ancestry(
     end_time=None,
     record_migrations=None,
     record_full_arg=None,
+    record_unary=None,
     num_labels=None,
     random_seed=None,
     num_replicates=None,
@@ -1125,6 +1136,8 @@ def sim_ancestry(
         tree sequence. This will result in unary nodes (i.e., nodes in marginal
         trees that have only one child). Defaults to False.
         See the :ref:`sec_ancestry_full_arg` section for examples.
+    :param bool record_unary: If True, retain all ancestry for any nodes that
+        are coalescent nodes anywhere in the sequence. Defaults to False.
     :param bool record_migrations: If True, record all migration events
         that occur in the :ref:`tskit:sec_migration_table_definition` of
         the output tree sequence. Defaults to False.
@@ -1198,6 +1211,7 @@ def sim_ancestry(
             end_time=end_time,
             record_migrations=record_migrations,
             record_full_arg=record_full_arg,
+            record_unary=record_unary,
             num_labels=num_labels,
             random_seed=random_seed,
             # num_replicates is excluded as provenance is per replicate
@@ -1220,6 +1234,7 @@ def sim_ancestry(
         end_time=end_time,
         record_migrations=record_migrations,
         record_full_arg=record_full_arg,
+        record_unary=record_unary,
         num_labels=num_labels,
         random_seed=random_seed,
     )
@@ -1283,6 +1298,7 @@ class Simulator(_msprime.Simulator):
         models=None,
         store_migrations=False,
         store_full_arg=False,
+        store_unary=False,
         start_time=None,
         end_time=None,
         num_labels=None,
@@ -1325,6 +1341,7 @@ class Simulator(_msprime.Simulator):
             demographic_events=ll_demographic_events,
             store_migrations=store_migrations,
             store_full_arg=store_full_arg,
+            store_unary=store_unary,
             num_labels=num_labels,
             segment_block_size=segment_block_size,
             avl_node_block_size=avl_node_block_size,

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -228,6 +228,36 @@ class TestFullArg:
         self.verify(sim)
 
 
+class TestStoreUnary:
+    def test_recombination_n25(self):
+        ts = msprime.sim_ancestry(
+            samples=25,
+            sequence_length=100,
+            recombination_rate=1,
+            record_unary=True,
+        )
+        self.verify_store_unary(ts)
+
+    def verify_store_unary(self, ts):
+        min_children = np.zeros(ts.num_nodes, dtype=int)
+        max_children = np.zeros_like(min_children)
+
+        for tree in ts.trees():
+            for i in range(ts.num_nodes):
+                n = tree.num_children_array[i]
+                if n > 0:
+                    if min_children[i] > 0:
+                        min_children[i] = min(min_children[i], n)
+                    else:
+                        min_children[i] = n
+                    max_children[i] = max(max_children[i], n)
+
+        assert np.any(min_children == 1)
+        for minc, maxc in zip(min_children, max_children):
+            if minc == 1:
+                assert maxc >= 2
+
+
 class TestSimulator:
     """
     Runs tests on the underlying Simulator object.


### PR DESCRIPTION
First pass at adding an option to keep unary nodes (#2128). Unit tests are very basic at the moment. 
I went with the option to explicitly pass the `parent_node_id` to `store_arg_edges()`. This seems to make sense going forward with different options of `keep_unary` but might be wrong here. 
Also, I stuck with the `store_full_arg`, `keep_full_arg` naming conventions for  now.  