### PR TITLE
More helpful record_full_arg errors

### DIFF
--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -901,6 +901,16 @@ def _parse_sim_ancestry(
     is_dtwf = isinstance(models[0], DiscreteTimeWrightFisher)
     is_pedigree = any(isinstance(model, FixedPedigree) for model in models)
 
+    if record_full_arg:
+        if is_dtwf:
+            raise ValueError(
+                "Full ARG recording not supported in DiscreteTimeWrightFisher simulation"
+            )
+        if is_pedigree:
+            raise ValueError(
+                "Full ARG recording not supported in FixedPedigree simulation"
+            )
+
     if is_pedigree:
         if demography is not None:
             raise ValueError("Cannot specify demography for FixedPedigree simulation")
@@ -918,10 +928,6 @@ def _parse_sim_ancestry(
         if gene_conversion_map.total_mass != 0:
             raise ValueError(
                 "Gene conversion not supported in FixedPedigree simulation"
-            )
-        if record_full_arg:
-            raise ValueError(
-                "Full ARG recording not supported in FixedPedigree simulation"
             )
         if record_migrations:
             raise ValueError(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -560,6 +560,20 @@ class TestUnsupportedFullArg:
 
     def test_dtwf(self):
         for model in [msprime.DiscreteTimeWrightFisher()]:
+            with pytest.raises(
+                ValueError, match="not supported in DiscreteTimeWrightFisher"
+            ):
+                msprime.sim_ancestry(
+                    10,
+                    model=model,
+                    record_full_arg=True,
+                )
+
+    def test_dtwf_simulate(self):
+        """
+        Old "simulate" command gives a less descriptive error message
+        """
+        for model in [msprime.DiscreteTimeWrightFisher()]:
             with pytest.raises(_msprime.LibraryError):
                 msprime.simulate(
                     10,


### PR DESCRIPTION
There are a few cases (e.g. the DTWF) where full_arg recording is not possible. We should give slightly more informative error messages when this is attempted. This PR should make it easy to add extra error messages for different cases like this.