### PR TITLE
new additional_nodes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   sequence that has no recombination nodes (({issue}`2123`, {pr}`2124`,
   {user}`hyanwong`)
 
+- Add ability to record specific node types with the `additional_nodes`
+  flag as well as record edges for coalescing nodes along non-coalescing segments. ({issue}`2128`, {issue}`2132`, {pr}`2162`,
+  {user}`GertjanBisschop`)
+
 ## [1.2.0] - 2022-05-18
 
 **New features**

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,6 +87,26 @@ for discussion and examples of individual features.
     :members:
 ```
 
+```{eval-rst}
+.. autoclass:: msprime.NodeType
+    :members:
+
+    .. autoattribute:: RECOMBINANT
+         :annotation: = NodeType(1<<17)
+
+    .. autoattribute:: COMMON_ANCESTOR
+         :annotation: = NodeType(1<<18)
+
+    .. autoattribute:: MIGRANT
+         :annotation: = NodeType(1<<19)
+
+    .. autoattribute:: GENE_CONVERSION
+         :annotation: = NodeType(1<<21)
+
+    .. autoattribute:: PASS_THROUGH
+         :annotation: = NodeType(1<<22)
+```
+
 #### Models
 
 ```{eval-rst}

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -57,6 +57,7 @@
 #define MSP_NODE_IS_MIG_EVENT (1u << 19)
 #define MSP_NODE_IS_CEN_EVENT (1u << 20)
 #define MSP_NODE_IS_GC_EVENT (1u << 21)
+#define MSP_NODE_IS_PASS_THROUGH (1u << 22)
 
 /* Flags for verify */
 #define MSP_VERIFY_BREAKPOINTS (1 << 1)
@@ -195,7 +196,8 @@ typedef struct _msp_t {
     simulation_model_t model;
     bool store_migrations;
     bool store_full_arg;
-    bool store_unary;
+    uint32_t additional_nodes;
+    bool coalescing_segments_only;
     double sequence_length;
     bool discrete_genome;
     rate_map_t recomb_map;
@@ -430,7 +432,8 @@ int msp_set_simulation_model_sweep_genic_selection(msp_t *self, double position,
 int msp_set_start_time(msp_t *self, double start_time);
 int msp_set_store_migrations(msp_t *self, bool store_migrations);
 int msp_set_store_full_arg(msp_t *self, bool store_full_arg);
-int msp_set_store_unary(msp_t *self, bool store_unary);
+int msp_set_additional_nodes(msp_t *self, uint32_t additional_nodes);
+int msp_set_coalescing_segments_only(msp_t *self, bool coalescing_segments_only);
 int msp_set_ploidy(msp_t *self, int ploidy);
 int msp_set_recombination_map(msp_t *self, size_t size, double *position, double *rate);
 int msp_set_recombination_rate(msp_t *self, double rate);

--- a/msprime/__init__.py
+++ b/msprime/__init__.py
@@ -46,6 +46,7 @@ from msprime.ancestry import (
     SweepGenicSelection,
     FixedPedigree,
     TimeUnitsMismatchWarning,
+    NodeType,
 )
 
 from msprime.core import __version__
@@ -138,6 +139,7 @@ __all__ = [
     "NODE_IS_MIG_EVENT",
     "NODE_IS_RE_EVENT",
     "NODE_IS_GC_EVENT",
+    "NodeType",
     "NUCLEOTIDES",
     "PAM",
     "PedigreeBuilder",

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1766,9 +1766,9 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
         "population_configuration", "migration_matrix",
         "demographic_events", "model", "avl_node_block_size", "segment_block_size",
         "node_mapping_block_size", "store_migrations", "start_time",
-        "store_full_arg", "store_unary", "num_labels", "gene_conversion_rate",
-        "gene_conversion_tract_length", "discrete_genome",
-        "ploidy", NULL};
+        "additional_nodes", "coalescing_segments_only",
+        "num_labels", "gene_conversion_rate", "gene_conversion_tract_length", 
+        "discrete_genome", "ploidy", NULL};
     PyObject *migration_matrix = NULL;
     PyObject *population_configuration = NULL;
     PyObject *demographic_events = NULL;
@@ -1783,8 +1783,8 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     Py_ssize_t num_labels = 1;
     Py_ssize_t num_populations = 1;
     int store_migrations = false;
-    int store_full_arg = false;
-    int store_unary = false;
+    unsigned long additional_nodes = 0;
+    int coalescing_segments_only = true;
     int discrete_genome = true;
     double start_time = -1;
     double gene_conversion_rate = 0;
@@ -1794,7 +1794,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     self->sim = NULL;
     self->random_generator = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-            "O!O!|O!O!OO!O!nnnidiinddii", kwlist,
+            "O!O!|O!O!OO!O!nnnidkinddii", kwlist,
             &LightweightTableCollectionType, &tables,
             &RandomGeneratorType, &random_generator,
             /* optional */
@@ -1805,7 +1805,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             &PyDict_Type, &py_model,
             &avl_node_block_size, &segment_block_size,
             &node_mapping_block_size, &store_migrations, &start_time,
-            &store_full_arg, &store_unary, &num_labels,
+            &additional_nodes, &coalescing_segments_only, &num_labels,
             &gene_conversion_rate, &gene_conversion_tract_length,
             &discrete_genome, &ploidy)) {
         goto out;
@@ -1926,9 +1926,9 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             goto out;
         }
     }
-    msp_set_store_full_arg(self->sim, store_full_arg);
-    msp_set_store_unary(self->sim, store_unary);
-
+    msp_set_additional_nodes(self->sim, (uint32_t) additional_nodes);
+    msp_set_coalescing_segments_only(self->sim, coalescing_segments_only);
+    
     sim_ret = msp_initialise(self->sim);
     if (sim_ret != 0) {
         handle_input_error("initialise", sim_ret);
@@ -2069,17 +2069,16 @@ out:
 }
 
 static PyObject *
-Simulator_get_record_full_arg(Simulator *self, void *closure)
+Simulator_get_additional_nodes(Simulator *self, void *closure)
 {
     PyObject *ret = NULL;
     if (Simulator_check_sim(self) != 0) {
         goto out;
     }
-    ret = Py_BuildValue("i",  self->sim->store_full_arg);
+    ret = Py_BuildValue("k",  self->sim->additional_nodes);
 out:
     return ret;
 }
-
 
 static PyObject *
 Simulator_get_num_populations(Simulator *self, void *closure)
@@ -3010,9 +3009,9 @@ static PyGetSetDef Simulator_getsetters[] = {
     {"record_migrations",
             (getter) Simulator_get_record_migrations, NULL,
             "True if the simulator should store migration records." },
-    {"record_full_arg",
-            (getter) Simulator_get_record_full_arg, NULL,
-            "True if the simulator should store the full ARG." },
+    {"additional_nodes",
+            (getter) Simulator_get_additional_nodes, NULL,
+            "The numeric value of the stored NodeType." },
     {"discrete_genome",
             (getter) Simulator_get_discrete_genome, NULL,
             "True if the simulator has a discrete genome." },

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -3083,11 +3083,13 @@ class TestLikelihood:
     def get_arg(self):
         L = 20
         rate_map = uniform_rate_map(L=L, rate=2)
+        node_value = sum(2**i for i in (17, 18, 19, 21))
         sim = make_sim(
             samples=5,
             sequence_length=L,
             recombination_map=rate_map,
-            store_full_arg=True,
+            additional_nodes=node_value,
+            coalescing_segments_only=False,
         )
         sim.run()
         _msprime.sim_mutations(

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -2395,7 +2395,7 @@ class TestNonStandardTopologies:
             20,
             sequence_length=10,
             random_seed=2,
-            record_unary=True,
+            coalescing_segments_only=False,
             recombination_rate=1,
         )
         assert ts.num_trees > 1

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -291,6 +291,15 @@ class TestSimulateRoundTrip(TestRoundTrip):
         ts = msprime.simulate(from_ts=from_ts, random_seed=2)
         self.verify(ts)
 
+    def test_additional_nodes(self):
+        ts = msprime.sim_ancestry(
+            10,
+            random_seed=1234,
+            additional_nodes=msprime.NodeType(1 << 17),
+            coalescing_segments_only=False,
+        )
+        self.verify(ts)
+
 
 class TestMutateRoundTrip(TestRoundTrip):
     def test_mutate_round_trip(self):

--- a/tests/test_simulate_from.py
+++ b/tests/test_simulate_from.py
@@ -1295,7 +1295,7 @@ class TestNonStandardTopologies:
             random_seed=4,
             recombination_rate=0.1,
             population_size=1,
-            record_unary=True,
+            coalescing_segments_only=False,
         )
         assert rts.num_trees - ts.num_trees > 0
         rts_simplified = rts.simplify()


### PR DESCRIPTION
First pass at new `additional_nodes` API for Hudson, SMC, SMC' and multi-merger coalescents.
@benjeffery would you want to take a look at how I solved the `asdict` representation of ![NodeType](https://github.com/GertjanBisschop/msprime/blob/d847276a2aacee14a6550253f836d858d2cf1112/msprime/ancestry.py#L1326) as required for the provenance recording?
EDIT: ignore that Ben. I think I figured it out. Is this the way to do it?
```python
def asdict(self):
        return {"__class__": "msprime.NodeType", "value": self.value}
```