### PR TITLE
remove ll_representation argument

### DIFF
--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -3022,9 +3022,7 @@ class PopulationParametersChange(ParameterChangeEvent):
             raise ValueError("Cannot have a population size < 0")
         self.population = -1 if self.population is None else self.population
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.2 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         ret = {
             "type": "population_parameters_change",
             "time": self.time,
@@ -3102,9 +3100,7 @@ class MigrationRateChange(ParameterChangeEvent):
             self.source = self.matrix_index[0]
             self.dest = self.matrix_index[1]
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "migration_rate_change",
             "time": self.time,
@@ -3143,9 +3139,7 @@ class SymmetricMigrationRateChange(ParameterChangeEvent):
         default="Symmetric migration rate change", repr=False
     )
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "symmetric_migration_rate_change",
             "time": self.time,
@@ -3237,9 +3231,7 @@ class MassMigration(LineageMovementEvent):
         if self.destination is not None:
             self.dest = self.destination
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "mass_migration",
             "time": self.time,
@@ -3296,9 +3288,7 @@ class ActivatePopulationEvent(DemographicEvent):
         default="Activate population event", repr=False
     )
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "activate_population_event",
             "time": self.time,
@@ -3327,9 +3317,7 @@ class PopulationSplit(LineageMovementEvent):
 
     _type_str: ClassVar[str] = dataclasses.field(default="Population Split", repr=False)
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "population_split",
             "time": self.time,
@@ -3389,9 +3377,7 @@ class Admixture(LineageMovementEvent):
     def num_ancestral(self):
         return len(self.ancestral)
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "admixture",
             "time": self.time,
@@ -3444,9 +3430,7 @@ class SimpleBottleneck(StateChangeEvent):
     population: int
     proportion: float = 1.0
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "simple_bottleneck",
             "time": self.time,
@@ -3474,9 +3458,7 @@ class InstantaneousBottleneck(StateChangeEvent):
     population: int
     strength: float = 1.0
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "instantaneous_bottleneck",
             "time": self.time,
@@ -3517,9 +3499,7 @@ class CensusEvent(DemographicEvent):
 
     _type_str: ClassVar[str] = dataclasses.field(default="Census", repr=False)
 
-    def get_ll_representation(self, num_populations=None):
-        # We need to keep the num_populations argument until stdpopsim 0.1 is out
-        # https://github.com/tskit-dev/msprime/issues/1037
+    def get_ll_representation(self):
         return {
             "type": "census_event",
             "time": self.time,

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -315,30 +315,6 @@ class TestIntrospectionInterface:
         assert str(event) == repr_s
 
 
-class TestDemographicEventsHaveExtraLLParameter:
-    """
-    For legacy reasons the DemographicEvent.get_ll_representation took
-    a "num_populations" argument. In versions of stdpopsim using
-    msprime < 1.0, this parameter was specified when testing for
-    model equality (even though it did nothing). To ensure we're not
-    breaking older versions of stdpopsim, we keep this extra parameter
-    and test it here to make sure it works.
-
-    Since the functionality is only really used as a developer tool
-    in stdpopsim, we can get rid of the extra parameters once
-    stdpopsim 0.2 (which won't use this API) has been released.
-
-    See https://github.com/tskit-dev/msprime/issues/1037
-    """
-
-    def test_demographic_events_have_param(self):
-        demography = all_events_example_demography()
-        for event in demography.events:
-            ll_config1 = event.get_ll_representation()
-            ll_config2 = event.get_ll_representation(None)
-            assert ll_config1 == ll_config2
-
-
 class TestTimeTravelErrors:
     """
     It is possible to specify models in msprime that result in malformed


### PR DESCRIPTION
Removed argument of `DemographicEvent.get_ll_representation()`. Solves #1037 as this is no longer used by stdpopsim.
The [`TestLowLevelRepresentation`](https://github.com/GertjanBisschop/msprime/blob/7db7dce6aec6e605eff366b7e602315cc55b13ca/tests/test_demography.py#L560) test suite is marked as containing tests that were only needed to ensure compatibility with stdpopsim. I couldn't see any calls containing the optional argument. Are there any other tests I can remove @jeromekelleher?