### PR TITLE
Disallow unstable beta coalescents

### DIFF
--- a/docs/ancestry.md
+++ b/docs/ancestry.md
@@ -2381,6 +2381,13 @@ tree = ts.first()
 print(tree.tmrca(0,1))
 
 ```
+:::{important}
+Both the haploid and polyploid timescales collapse to zero as {math}`\alpha`
+approaches 2. For reasons of numerical stability, values above
+{math}`\alpha = 1.991` have been prohibited. The
+{ref}`Hudson coalescent<sec_ancestry_models_hudson>` provides a very good
+approximation for {math}`1.991 <= \alpha <= 2`.
+:::
 
 The Dirac-coalescent is simulated similarly in both the diploid case:
 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -7416,7 +7416,7 @@ msp_set_simulation_model_beta(msp_t *self, double alpha, double truncation_point
 {
     int ret = 0;
 
-    if (alpha <= 1.0 || alpha >= 2.0) {
+    if (alpha <= 1.0 || alpha > 1.991) {
         ret = MSP_ERR_BAD_BETA_MODEL_ALPHA;
         goto out;
     }

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -1590,7 +1590,7 @@ test_beta_coalescent_bad_parameters(void)
     int ret;
     msp_t msp;
     unsigned int n = 10;
-    double alphas[] = { -1e6, 0, 0.001, 1.0, 2.0, 1e6 };
+    double alphas[] = { -1e6, 0, 0.001, 1.0, 1.995, 1e6 };
     double truncation_points[] = { -1e6, 0 };
     gsl_rng *rng = safe_rng_alloc();
     tsk_table_collection_t tables;

--- a/lib/util.c
+++ b/lib/util.c
@@ -194,7 +194,7 @@ msp_strerror_internal(int err)
             ret = "Proportion values must have 0 <= x <= 1";
             break;
         case MSP_ERR_BAD_BETA_MODEL_ALPHA:
-            ret = "Bad alpha. Must have 1 < alpha < 2";
+            ret = "Bad alpha. Must have 1 < alpha <= 1.991";
             break;
         case MSP_ERR_BAD_TRUNCATION_POINT:
             ret = "Bad truncation_point. Must have 0 < truncation_point.";
@@ -682,7 +682,7 @@ fast_search_alloc(fast_search_t *self, const double *elements, size_t n_elements
      * of the array. The rest of the lookup element indexes point to (max_element *
      * query_multiplier) non-zero element values.
      */
-    self->num_lookups = 2 + (size_t)(max_element * self->query_multiplier);
+    self->num_lookups = 2 + (size_t) (max_element * self->query_multiplier);
 
     self->query_cutoff = ((double) self->num_lookups - 1) / self->query_multiplier;
 


### PR DESCRIPTION
Closes #2256 (again) by restricting the valid region of the Beta-coalescent alpha-parameter to `1 < alpha <= 1.991`.

I can't make the timescale near `alpha = 1` break even for values around `1 + 1e-15`. So I've left that boundary case as it is, restricted only by `alpha > 1`. I'm amazed that it's so robust!