### PR TITLE
add tree fixation using newick string and TreeSequence object

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -911,7 +911,7 @@ class Simulator:
         self.fixed_coalescent_events = False
         self.coalescent_events = []
 
-        if coalescent_events is not None:
+        if coalescent_events:
             self.fixed_coalescent_events = True
             self.parse_nwk(coalescent_events)
             self.coalescent_events.sort()

--- a/algorithms.py
+++ b/algorithms.py
@@ -1,7 +1,6 @@
 """
 Python version of the simulation algorithm.
 """
-
 import argparse
 import heapq
 import itertools
@@ -850,7 +849,7 @@ class Simulator:
         gene_conversion_rate=0.0,
         gene_conversion_length=1,
         discrete_genome=True,
-        coalescent_events=[],
+        coalescent_events=None,
     ):
         # Must be a square matrix.
         N = len(migration_matrix)
@@ -912,7 +911,7 @@ class Simulator:
         self.fixed_coalescent_events = False
         self.coalescent_events = []
 
-        if coalescent_events:
+        if coalescent_events is not None:
             self.fixed_coalescent_events = True
             self.parse_nwk(coalescent_events)
             self.coalescent_events.sort()
@@ -1093,7 +1092,7 @@ class Simulator:
         next=None,  # noqa: A002
         label=0,
         hull=None,
-        origin=set(),
+        origin=None,
     ):
         """
         Pops a new segment off the stack and sets its properties.
@@ -1107,7 +1106,7 @@ class Simulator:
         s.prev = prev
         s.label = label
         s.hull = hull
-        s.origin = origin
+        s.origin = origin if origin is not None else set()
         return s
 
     def copy_segment(self, segment):
@@ -1380,7 +1379,8 @@ class Simulator:
                         # Add epsilon as two events can't happen simultaneously.
                         self.t = prev_time + 0.00000001
                     else:
-                        # Reset to time of ce event and add epsilon to avoid colission with leaf nodes.
+                        # Reset to time of ce event and add epsilon to avoid
+                        # collision with leaf nodes.
                         self.t = ce[0] + 0.00000001
 
                     self.common_ancestor_event(
@@ -2431,7 +2431,7 @@ class Simulator:
         # Stricter version
         # return any(ancestor.origin.issubset(j) for j in ceA + ceB)
 
-        # Relevant Common Ancestor Events for that the selected ancestor could be required
+        # Relevant Common Ancestor events
         ca_events = [j for j in ceA + ceB if ancestor.origin.issubset(j)]
 
         if not ca_events:
@@ -2460,7 +2460,8 @@ class Simulator:
     ):
         """
         Implements a coancestry event.
-        If lineage_a and lineage_b are set, only lines emerged from those will be selected.
+        If lineage_a and lineage_b are set, only lineages emerged from those
+        will be selected. Raises an error if only one lineage is provided.
         """
         pop = self.P[population_index]
 
@@ -2733,7 +2734,7 @@ class Simulator:
         right_node = right_node[:-1] if right_node.endswith(")") else right_node
 
         # Check if left node is a leaf
-        if not "," in left_node:
+        if "," not in left_node:
             if left_node in self.leaf_mapping:
                 # Replace leaf name with mapped id
                 node_id = self.leaf_mapping[left_node]
@@ -2745,7 +2746,7 @@ class Simulator:
             left_time = left_time + sub_left_time
 
         # Check if left node is a leaf
-        if not "," in right_node:
+        if "," not in right_node:
             if right_node in self.leaf_mapping:
                 # Replace leaf name with mapped id
                 node_id = self.leaf_mapping[right_node]

--- a/algorithms.py
+++ b/algorithms.py
@@ -2517,12 +2517,21 @@ class Simulator:
 
             else:
                 # Get all lineages that emerged from lineage_a and lineage_b
-                lineage_ids = pop.get_emerged_from_lineage(lineage_a, label)
-                i = random.choice(lineage_ids)
-                x = pop.remove(i, label)
+                lineage_ids_a = pop.get_emerged_from_lineage(lineage_a, label)
+                lineage_ids_b = pop.get_emerged_from_lineage(lineage_b, label)
 
-                lineage_ids = pop.get_emerged_from_lineage(lineage_b, label)
-                j = random.choice(lineage_ids)
+                if len(lineage_ids_a) == 1 and lineage_ids_a == lineage_ids_b:
+                    return
+
+                i = None
+                j = None
+                while i == j:
+                    i = random.choice(lineage_ids_a)
+                    j = random.choice(lineage_ids_b)
+
+                x = pop.remove(i, label)
+                if i < j:
+                    j -= 1
                 y = pop.remove(j, label)
 
         self.merge_two_ancestors(population_index, label, x, y)

--- a/algorithms.py
+++ b/algorithms.py
@@ -1001,8 +1001,8 @@ class Simulator:
         # Insert the segment chains into the algorithm state.
         for node in range(ts.num_nodes):
             seg = root_segments_head[node]
-            seg.origin = {seg.node}
             if seg is not None:
+                seg.origin = {seg.node}
                 left_end = seg.left
                 pop = seg.population
                 label = seg.label
@@ -1093,7 +1093,7 @@ class Simulator:
         next=None,  # noqa: A002
         label=0,
         hull=None,
-        origin={},
+        origin=set(),
     ):
         """
         Pops a new segment off the stack and sets its properties.


### PR DESCRIPTION
This PR will add an option (`--ce-from-nwk`) to provide a tree in newick format that will be respected during simulation (hudson model).

The aim is to make sure that the given tree is present and that regular simulation (gene conversion and recombination) is still possible.  The main idea is that each segment has an origin set (in the beginning only the id of the leaf), which is passed through and merged with the origins of the other segment at each coalescence event.  When a regular event occurs, the algorithm checks if the selected segment is needed later, if so, the event is ignored.

## Changes:

The following structural changes will be made:

### General
- Add a newick parser that creates a list of coalescence events (`Tuple[float, set, set]`). Each tuple represents the time and two lineages to coalesce.

### Segment class
- Add an "origin" set that keeps track of which segments this is created from.

### Population class
- Add a method `get_emerged_from_lineage` that returns the indices of the lineages that have emerged from a given one. 

### Simulator class
- Adapt `alloc_segment` and `copy_segment` to use the `origin` attribute.
- Adapt `hudson_simulate`.
     - Add an if clause to check if the time has exceeded the next fixed coalescent event (`self.coalescent_events[0][0] < self.t`)
     - Reset the time to the coalescence event time with a possible epsilon as no two events can happen at the same time.
- Add `is_blocked_ancestor` method to check if a lineage id is used in a later fixed coalescence event.
    - If the lineage is required, but another lineage with identical origin exists. the lineage is not considered to be blocked. 
- Adapt `common_ancestor_event`
    - If it's a fixed coalescence event, select all the lineages that emerged from lineage_a and lineage_b, and merge one at random (for each lineage a and lineage b).
    - If not, proceed regularly by selecting two random ones.

## Example:
The command
```bash
py algorithms.py --recombination-rate 0 --gene-conversion-rate 0 1 --sequence-length 10000 10 out --discrete --ce-events "((((A:0.005, B:0.005):0.01, (C:0.005, D:0.005):0.01):0.1,((E:0.005, F:0.005):0.01, (G:0.005, H:0.005):0.01):0.01):0.01, (I:0.005, J:0.005):0.01)" 
```

will produce following tree:

| ts.draw_text() | tskit_arg_visualizer |
|-------| ------|
| <img src="https://github.com/tskit-dev/msprime/assets/25013642/8f75a2f9-044d-4fc3-ba05-9ba3900fb5bd" height=300></img> | <img src="https://github.com/tskit-dev/msprime/assets/25013642/784e0d5e-1fe8-4d71-96be-a6b83cda5ebb" height=300></img> | 

 Event though the first coalescence events (at Node 10-14) should happen at the same time (0.005), the events are slightly postponed as no two events can happen at the same time.
 

## Todo / Open Tasks
- Add tests