### PR TITLE
Smc(k) gene conversion

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -1344,7 +1344,10 @@ msp_insert_hull(msp_t *self, hull_t *hull)
 
     /* insert hullend into state */
     hullend = msp_alloc_hullend(self, hull->right, u->label);
-    tsk_bug_assert(hullend != NULL);
+    if (hullend == NULL) {
+        ret = MSP_ERR_NO_MEMORY;
+        goto out;
+    }
     node = msp_alloc_avl_node(self);
     if (node == NULL) {
         ret = MSP_ERR_NO_MEMORY;
@@ -3256,6 +3259,10 @@ msp_recombination_event(msp_t *self, label_id_t label, segment_t **lhs, segment_
 
         /* create new hull for alpha */
         rhs_hull = msp_alloc_hull(self, alpha->left, rhs_right, alpha);
+        if (rhs_hull == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
         ret = msp_insert_hull(self, rhs_hull);
         if (ret != 0) {
             goto out;
@@ -3499,6 +3506,10 @@ msp_gene_conversion_event(msp_t *self, label_id_t label)
                 self->sequence_length);
             hull = msp_alloc_hull(
                 self, tract_hull_left, tract_hull_right, new_individual_head);
+            if (hull == NULL) {
+                ret = MSP_ERR_NO_MEMORY;
+                goto out;
+            }
             ret = msp_insert_hull(self, hull);
             if (ret != 0) {
                 goto out;
@@ -3756,6 +3767,10 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
             r += self->model.params.smc_k_coalescent.hull_offset;
             hull = msp_alloc_hull(
                 self, merged_head->left, GSL_MIN(r, self->sequence_length), merged_head);
+            if (hull == NULL) {
+                ret = MSP_ERR_NO_MEMORY;
+                goto out;
+            }
             ret = msp_insert_hull(self, hull);
             if (ret != 0) {
                 goto out;
@@ -4189,6 +4204,10 @@ msp_insert_root_segments(msp_t *self, const segment_t *head, segment_t **new_hea
                 if (self->state != MSP_STATE_NEW) {
                     /* correct hull->right is set at the end */
                     hull = msp_alloc_hull(self, head->left, copy->right, copy);
+                    if (hull == NULL) {
+                        ret = MSP_ERR_NO_MEMORY;
+                        goto out;
+                    }
                 }
             }
         } else {
@@ -4528,7 +4547,10 @@ msp_hulls_init_counts(msp_t *self, population_id_t pop, label_id_t label)
 
         /* insert hullend into hulls_right */
         hullend = msp_alloc_hullend(self, hull->right, (label_id_t) label);
-        tsk_bug_assert(hullend != NULL);
+        if (hullend == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
         node_right = msp_alloc_avl_node(self);
         if (node_right == NULL) {
             ret = MSP_ERR_NO_MEMORY;
@@ -4574,7 +4596,10 @@ msp_initialise_smc_k(msp_t *self)
                 right += self->model.params.smc_k_coalescent.hull_offset;
                 right = GSL_MIN(right, self->sequence_length);
                 hull = msp_alloc_hull(self, left, right, head);
-                tsk_bug_assert(hull != NULL);
+                if (hull == NULL) {
+                    ret = MSP_ERR_NO_MEMORY;
+                    goto out;
+                }
                 h_node = msp_alloc_avl_node(self);
                 if (h_node == NULL) {
                     ret = MSP_ERR_NO_MEMORY;
@@ -5094,6 +5119,10 @@ msp_gene_conversion_left_event(msp_t *self, label_id_t label)
         // rhs
         tsk_bug_assert(alpha->left < lhs_old_right);
         rhs_hull = msp_alloc_hull(self, alpha->left, lhs_old_right, alpha);
+        if (rhs_hull == NULL) {
+            ret = MSP_ERR_NO_MEMORY;
+            goto out;
+        }
         ret = msp_insert_hull(self, rhs_hull);
         if (ret != 0) {
             goto out;

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -833,7 +833,6 @@ def _parse_sim_ancestry(
     models = _parse_model_arg(model)
     is_dtwf = isinstance(models[0], DiscreteTimeWrightFisher)
     is_pedigree = any(isinstance(model, FixedPedigree) for model in models)
-    is_smck = any(isinstance(model, SmcKApproxCoalescent) for model in models)
 
     if record_full_arg:
         if coalescing_segments_only is not None:
@@ -937,12 +936,6 @@ def _parse_sim_ancestry(
 
     if discrete_genome and math.floor(sequence_length) != sequence_length:
         raise ValueError("Must have integer sequence length with discrete_genome=True")
-
-    if is_smck:
-        if gene_conversion_rate is not None or gene_conversion_tract_length is not None:
-            raise ValueError(
-                "Gene conversion has not been implemented yet for smc_k models."
-            )
 
     recombination_map = _parse_rate_map(
         recombination_rate, sequence_length, "recombination"

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -443,12 +443,22 @@ class TestAlgorithms:
         for tree in ts.trees():
             assert tree.num_roots == 1
 
+        ts = self.run_script("10 -L 1000 -r 0.01 --model smc_k --offset 0.50")
+        assert ts.num_trees > 1
+        for tree in ts.trees():
+            assert tree.num_roots == 1
+
         ts = self.run_script("10 -L 1000 -d -r 0.01 --model smc_k -p 2 -g 0.1")
         assert ts.num_trees > 1
         for tree in ts.trees():
             assert tree.num_roots == 1
 
         ts = self.run_script("10 -L 1000 -d -c 0.04 2  --model smc_k")
+        assert ts.num_trees > 1
+        for tree in ts.trees():
+            assert tree.num_roots == 1
+
+        ts = self.run_script("10 -L 1000 -c 0.04 2  --model smc_k --offset 0.75")
         assert ts.num_trees > 1
         for tree in ts.trees():
             assert tree.num_roots == 1

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -2959,7 +2959,8 @@ class TestSMCK:
             assert tree.num_roots == 1
 
     @pytest.mark.parametrize("hull_offset", [2, 0.5, 1e-6, 2.133])
-    def test_smc_k_plus(self, hull_offset):
+    @pytest.mark.parametrize("discrete_genome", [True, False])
+    def test_smc_k_plus(self, hull_offset, discrete_genome):
         tss = msprime.sim_ancestry(
             samples=10,
             population_size=10_000,
@@ -2968,6 +2969,7 @@ class TestSMCK:
             recombination_rate=1e-5,
             sequence_length=100,
             num_replicates=10,
+            discrete_genome=discrete_genome,
         )
         for ts in tss:
             assert ts.num_trees > 1
@@ -2990,15 +2992,21 @@ class TestSMCK:
         for tree in ts.trees():
             assert tree.num_roots == 1
 
-    def test_gc(self):
-        with pytest.raises(
-            ValueError,
-            match="Gene conversion has not been implemented yet for smc_k models.",
-        ):
-            _ = msprime.sim_ancestry(
-                samples=10,
-                model=msprime.SmcKApproxCoalescent(),
-                sequence_length=100,
-                gene_conversion_rate=0.5,
-                gene_conversion_tract_length=5,
-            )
+    @pytest.mark.parametrize("hull_offset", [2, 0.5, 1e-6, 2.133])
+    @pytest.mark.parametrize("discrete_genome", [True, False])
+    @pytest.mark.parametrize("recombination_rate", [0.0, 0.1])
+    def test_gc(self, hull_offset, discrete_genome, recombination_rate):
+        tss = msprime.sim_ancestry(
+            samples=10,
+            model=msprime.SmcKApproxCoalescent(hull_offset=hull_offset),
+            sequence_length=100,
+            gene_conversion_rate=1.0,
+            gene_conversion_tract_length=5,
+            num_replicates=5,
+            discrete_genome=discrete_genome,
+            recombination_rate=recombination_rate,
+        )
+        for ts in tss:
+            assert ts.num_trees > 1
+            for tree in ts.trees():
+                assert tree.num_roots == 1


### PR DESCRIPTION
Implementation of gene conversion using SMC K logic. 
`alloc_hull` function was adapted and no longer automatically applies the `hull_offset`. This means there are now multiple `min(self.sequence_length, hull_right + self.hull_offset)` statements but it makes reasoning about the right endpoint of the hull easier in all other cases.

Will check if we need some additional statistical tests.
Solves #2280.