### PR TITLE
add kastore to development.txt

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -17,6 +17,7 @@ pytest
 pytest-cov
 pytest-xdist
 tskit>=0.5.2
+kastore
 sphinx-book-theme
 stdpopsim==0.1.2 # Make sure we have correct version of OOA model
 scipy


### PR DESCRIPTION
Closes #2302.

I'm not sure why this is necessary, actually, as `kastore` is required by `tskit`. (But I assume that's just because I don't understand how python package management works.)