### PR TITLE
Multiple merger polyploid scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.3.3] - 2024-XX-XX
+
+**Bug fixes**:
+
+- Correct the Dirac coalescent time scaling with polyploidy and population growth.
+
 ## [1.3.2] - 2024-07-08
 
 - Add `record_provenance` argument to `sim_mutations` ({issue}`2272`, {pr}`2273`, {user}`peterlharp`)

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1199,8 +1199,8 @@ Simulator_parse_simulation_model(Simulator *self, PyObject *py_model)
             goto out;
         }
         c = PyFloat_AsDouble(value);
-        if (psi <= 0 || psi >= 1.0) {
-            PyErr_SetString(PyExc_ValueError, "Must have 0 < psi < 1");
+        if (psi <= 0 || psi > 1.0) {
+            PyErr_SetString(PyExc_ValueError, "Must have 0 < psi <= 1");
             goto out;
         }
         if (c < 0) {

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -206,7 +206,7 @@ class TestFullArg:
             recombination_rate=0.1,
             record_full_arg=True,
             sequence_length=10,
-            model=msprime.DiracCoalescent(psi=0.5, c=5),
+            model=msprime.DiracCoalescent(psi=0.5, c=100),
         )
         self.verify(sim, multiple_mergers=True)
 

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -1353,7 +1353,7 @@ class TestSimulator(LowLevelTestCase):
                 make_sim(model=model)
         with pytest.raises(ValueError):
             make_sim(model=get_simulation_model("dirac"))
-        for bad_psi in [-1, 0, -1e-6, 1, 1e6]:
+        for bad_psi in [-1, 0, -1e-6, 1 + 1e-6, 1e6]:
             with pytest.raises(ValueError):
                 make_sim(
                     model=get_simulation_model("dirac", c=1, psi=bad_psi),
@@ -1363,7 +1363,7 @@ class TestSimulator(LowLevelTestCase):
                 make_sim(
                     model=get_simulation_model("dirac", psi=0.5, c=bad_c),
                 )
-        for psi in [0.99, 0.2, 1e-4]:
+        for psi in [1, 0.2, 1e-4]:
             for c in [5.0, 1e2, 1e-4]:
                 model = get_simulation_model("dirac", psi=psi, c=c)
                 sim = make_sim(model=model)

--- a/verification.py
+++ b/verification.py
@@ -3431,12 +3431,14 @@ class BetaGrowth(XiGrowth):
         logging.debug(f"running Beta growth for {pop_size} {alpha} {growth_rate}")
         b = growth_rate * (alpha - 1)
         model = (msprime.BetaCoalescent(alpha=alpha),)
-        ploidy = 2
-        a = 1 / (2 * ploidy * self.compute_beta_timescale(pop_size, alpha, ploidy))
-        name = f"N={pop_size}_alpha={alpha}_growth_rate={growth_rate}_ploidy={ploidy}"
-        self.compare_tmrca(
-            pop_size, growth_rate, model, num_replicates, a, b, ploidy, name
-        )
+        for ploidy in range(2, 7):
+            a = 1 / (2 * ploidy * self.compute_beta_timescale(pop_size, alpha, ploidy))
+            name = (
+                f"N={pop_size}_alpha={alpha}_growth_rate={growth_rate}_ploidy={ploidy}"
+            )
+            self.compare_tmrca(
+                pop_size, growth_rate, model, num_replicates, a, b, ploidy, name
+            )
         ploidy = 1
         a = 1 / self.compute_beta_timescale(pop_size, alpha, ploidy)
         name = f"N={pop_size}_alpha={alpha}_growth_rate={growth_rate}_ploidy={ploidy}"
@@ -3474,12 +3476,14 @@ class BetaGrowth(XiGrowth):
 class DiracGrowth(XiGrowth):
     def _run(self, pop_size, c, psi, growth_rate, num_replicates=10000):
         logging.debug(f"running Dirac growth for {pop_size} {c} {psi} {growth_rate}")
-        b = growth_rate
+        b = 2 * growth_rate
         model = (msprime.DiracCoalescent(psi=psi, c=c),)
-        p = 2
-        a = (1 + c * psi * psi / (2 * p)) / (pop_size * pop_size)
-        name = f"N={pop_size}_c={c}_psi={psi}_growth_rate={growth_rate}_ploidy={p}"
-        self.compare_tmrca(pop_size, growth_rate, model, num_replicates, a, b, p, name)
+        for p in range(2, 7):
+            a = (1 + c * psi * psi / (2 * p)) / (pop_size * pop_size)
+            name = f"N={pop_size}_c={c}_psi={psi}_growth_rate={growth_rate}_ploidy={p}"
+            self.compare_tmrca(
+                pop_size, growth_rate, model, num_replicates, a, b, p, name
+            )
         p = 1
         a = (1 + c * psi * psi) / (pop_size * pop_size)
         name = f"N={pop_size}_c={c}_psi={psi}_growth_rate={growth_rate}_ploidy={p}"


### PR DESCRIPTION
Duplicate of #2309 from @JereKoskela , copying comment here for the record.

Adding tests for polyploid scaling for multiple merger coalescents turned out to be easy, but also sent me down a bit of a rabbit hole. Summary of changes:

- The extra spaces on various lines in `msprime.c` which are unrelated to anything I've done (1396, 1899...) were put in by clang. Let me know if you want me to do something about them.
- For the Dirac coalescent, population growth at rate `g` should yield a coalescent growth rate of `2g`,essentially because the coalescence probability in the Moran model is `1/N^2` rather than `1/N`. We had overlooked that, but it is now fixed. 
- Ploidy wasn't being handled quite right in the Dirac coalescent either, but is now fixed. In the process, I got rid of some `if (ploidy == 1) {...} else {...}` statements which became redundant.
- For both the Dirac and Beta coalescents, I moved the allocation of the ancestor buckets `Q` later into the rejection sampler. It is now only done once a multiple merger event is definitely taking place.
- The Dirac coalescent test in `test_ancestry.py` started failing after the ploidy fix because the rate of multiple mergers wasn't high enough to guarantee one anymore. I increased it.
- I also noticed we were disallowing `psi = 1` in the Dirac coalescent for no reason. The documented (and sensible) range is `0 < psi <= 1`. I tweaked the boundary values and associated tests to make the code consistent with the documentation.