### PR TITLE
remove wrong statement

### DIFF
--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1220,10 +1220,7 @@ def sim_ancestry(
         (Default: None).
     :param float start_time: If specified, set the initial time that the
         simulation starts to this value. If not specified, the start
-        time is zero if performing a simulation of a set of samples,
-        or is the time of the oldest node if simulating from an
-        existing tree sequence (see the ``initial_state`` parameter).
-        See the :ref:`sec_ancestry_start_time` section for examples.
+        time is zero. See the :ref:`sec_ancestry_start_time` section for examples.
     :param float end_time: If specified, terminate the simulation at the
         specified time. In the returned tree sequence, all rootward paths from
         samples with time < ``end_time`` will end in a node with one child with


### PR DESCRIPTION
This statement in the docs was wrong
![Screenshot from 2025-01-03 15-45-26](https://github.com/user-attachments/assets/5e1b2339-8410-4c8b-a400-7408b985d4e7)
as demonstrated by:
```
tables = tskit.TableCollection(sequence_length=10)
tables.populations.add_row()
tables.nodes.add_row(time=0, flags=1, population=0)
tables.nodes.add_row(time=0, flags=1, population=0)
tables.nodes.add_row(time=0, flags=1, population=0)
tables.nodes.add_row(time=1, flags=0, population=0)
tables.edges.add_row(left=1, right=5, parent=3, child=1)
tables.edges.add_row(left=1, right=5, parent=3, child=2)

ts.tables.tree_sequence()
print(ts.draw_text())

# 1.00┊       ┊    3  ┊       ┊ 
#     ┊       ┊   ┏┻┓ ┊       ┊ 
# 0.00┊ 0 1 2 ┊ 0 1 2 ┊ 0 1 2 ┊ 
#     0       1       5      10 

mts = msprime.sim_ancestry(initial_state=ts, population_size=1, random_seed=123)
print(mts.draw_text())

# 3.71┊   5   ┊   5   ┊   5   ┊ 
#     ┊  ┏┻━┓ ┊ ┏━┻┓  ┊  ┏┻━┓ ┊ 
# 1.00┊  ┃  ┃ ┊ ┃  3  ┊  ┃  ┃ ┊ 
#     ┊  ┃  ┃ ┊ ┃ ┏┻┓ ┊  ┃  ┃ ┊ 
# 0.79┊  4  ┃ ┊ ┃ ┃ ┃ ┊  4  ┃ ┊ 
#     ┊ ┏┻┓ ┃ ┊ ┃ ┃ ┃ ┊ ┏┻┓ ┃ ┊ 
# 0.00┊ 0 2 1 ┊ 0 1 2 ┊ 0 2 1 ┊ 
#     0       1       5      10 
```
Note that `sim_ancestry` has created a node at `t=0.79`, before the age of the oldest root (which is at 1.0).

However, doing `mts = msprime.sim_ancestry(initial_state=ts, population_size=1, start_time=1.0` would start the simulation off at `1.0`. We could add something to the docs saying this, but it's kinda a can of worms - for instance, the bit on [recapitation](https://tskit.dev/msprime/docs/latest/ancestry.html#continuing-forwards-time-simulations-recapitating) says that "you *must* have all the input roots"; you might think it's okay to just specify `start_time` instead, but that's not right because you miss the recombinations that have happened to those root branches.