### PR TITLE
Add a __class__ key to the demography .asdict methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+
+## [1.3.5] - 2025-XX-XX
+
+**Breaking changes**:
+
+- The `.asdict()` methods for Demography, Population, and Event classes in the
+  demography submodule now return a `__class__` key. This is also stored in their
+  provenance entries, to help recreate demography objects from provenance.
+  ({pr}`{2368}, {user}`hyanwong`)
+
 ## [1.3.4] - 2025-05-01
 
 **Bug fixes**:


### PR DESCRIPTION
And convert list input to numpy array.

The `__class__` key is useful in general because e.g. for events, the dictionary keys aren't enough to distinguish between the event types. This also means that the classes are properly output when saving provenance, aiding reproducibility.

Also makes sure that events are properly associated with the Demography object, if they are provided.

No tests yet, as I wanted to check if this seemed reasonable. This is the first of 2 steps to allow us to create a fully functional demography object from provenance records, which enables us e.g. to plot demographies from most stdpopsim-created tree sequences, which seems very worth it.