### PR TITLE
Allow Demography init from provenance with preset pop IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Support for simulations after local mrca,
   ({issue}`2157`, {pr}`2396`, {user}`jeromekelleher`, {user}`hossam26644`).
 - Add wheels on Windows ({pr}`2414`, {issue}`2200`,{user}`benjeffery`)
+- Demography objects can now be created from provenance entries ({pr}`{2369}`, {user}`hyanwong`)
 
  **Performance improvements**
 

--- a/msprime/demography.py
+++ b/msprime/demography.py
@@ -292,10 +292,10 @@ class Demography(collections.abc.Mapping):
 
         # Assign the IDs and default names, if needed.
         for j, population in enumerate(self.populations):
-            if population.id is not None:
+            if population.id is not None and population.id != j:
                 raise ValueError(
-                    "Population ID should not be set before using to create "
-                    "a Demography"
+                    "Population ID should be unset or set to its index within"
+                    f" the Demography (expected None or {j}, got {population.id})"
                 )
             population.id = j
             if population.name is None:

--- a/tests/test_demography.py
+++ b/tests/test_demography.py
@@ -4312,9 +4312,11 @@ class TestDemographyObject:
         with pytest.raises(ValueError, match="must be distinct"):
             msprime.Demography([pop] * 2)
 
-    def test_population_ids_set_on_init(self):
-        pop = msprime.Population(10, id=0)
-        with pytest.raises(ValueError, match="ID should not be set"):
+    def test_population_ids_bad_on_init(self):
+        pop = msprime.Population(10, id=1)
+        with pytest.raises(
+            ValueError, match="ID should be unset or set to its index.*got 1"
+        ):
             msprime.Demography([pop])
 
     def test_add_population_error(self):


### PR DESCRIPTION
The last step to allow demographies to be instantiated from provenance entries. We exceptionally allow a `demography.Population` object to be created with an existing ID, but only if generated when decoding provenance JSON. This ensures that the IDs in the events etc match with what we expect. It's a slight hack in that we check for the error message. The alternative is to pick a different error (?RuntimeError) or make our own bespoke error that can be allowed through in this case.