### PR TITLE
specify units for recombination rate; closes #2375

### DIFF
--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1162,7 +1162,8 @@ def sim_ancestry(
         case multiple events at precisely the same genome location are very
         unlikely (but technically possible).
         See the :ref:`sec_ancestry_discrete_genome` section for usage examples.
-    :param recombination_rate: The rate of recombination along the sequence;
+    :param recombination_rate: The rate of recombination along the sequence,
+        in units of recombinations per unit time and unit length;
         can be either a single value (specifying a single rate over the entire
         sequence) or an instance of :class:`RateMap`.
         See the :ref:`sec_ancestry_recombination` section for usage examples


### PR DESCRIPTION
I'm not clear this improves things, since what exactly the units are depends? (like, probably "per generation per bp" but only if that's what time and sequence length are measured in)

Hm, I should have done this on my branch (I did this just by clicking "edit"; probably we should disable that, since the default resulting option was "commit this directly to main".)