### PR TITLE
Remove hullend struct

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -170,8 +170,8 @@ cmp_hull(const void *a, const void *b)
     int ret = (ia->left > ib->left) - (ia->left < ib->left);
 
     if (ret == 0) {
-        ret = (ia->insertion_order > ib->insertion_order)
-              - (ia->insertion_order < ib->insertion_order);
+        ret = (ia->left_insertion_order > ib->left_insertion_order)
+              - (ia->left_insertion_order < ib->left_insertion_order);
     }
     return ret;
 }
@@ -974,7 +974,7 @@ msp_alloc_hull(msp_t *self, double left, double right, lineage_t *lineage)
     tsk_bug_assert(right <= self->sequence_length);
     hull->right = right;
     hull->count = 0;
-    hull->insertion_order = UINT64_MAX;
+    hull->left_insertion_order = UINT64_MAX;
     tsk_bug_assert(lineage->head->prev == NULL);
     tsk_bug_assert(lineage->hull == NULL);
     lineage->hull = hull;
@@ -1323,10 +1323,10 @@ hull_adjust_insertion_order(hull_t *h, avl_node_t *node)
     if (node->prev != NULL) {
         prev_hull = (hull_t *) node->prev->item;
         if (h->left == prev_hull->left) {
-            insertion_order = prev_hull->insertion_order + 1;
+            insertion_order = prev_hull->left_insertion_order + 1;
         }
     }
-    h->insertion_order = insertion_order;
+    h->left_insertion_order = insertion_order;
 }
 
 static inline void
@@ -1379,7 +1379,7 @@ msp_insert_hull(msp_t *self, lineage_t *lineage)
         goto out;
     }
     /* required for migration */
-    hull->insertion_order = UINT64_MAX;
+    hull->left_insertion_order = UINT64_MAX;
     avl_init_node(node, hull);
     node = avl_insert_node(hulls_left, node);
     tsk_bug_assert(node != NULL);
@@ -1465,7 +1465,7 @@ msp_remove_hull(msp_t *self, lineage_t *lin)
         curr_hull = (hull_t *) curr_node->item;
         /* adjust insertion order */
         if (hull->left == curr_hull->left) {
-            curr_hull->insertion_order--;
+            curr_hull->left_insertion_order--;
         }
         if (hull->right > curr_hull->left) {
             curr_hull->count--;
@@ -2089,7 +2089,7 @@ msp_verify_hulls(msp_t *self)
                         io = 0;
                     }
                 }
-                tsk_bug_assert(io == hull->insertion_order);
+                tsk_bug_assert(io == hull->left_insertion_order);
                 pos = hull->left;
             }
             tsk_bug_assert(count == num_coalescing_pairs);
@@ -3287,7 +3287,7 @@ msp_reset_hull_right(msp_t *self, lineage_t *lineage, double new_right)
 
     /* adapt count for lineages between old_right and new_right */
     query_hull.left = new_right;
-    query_hull.insertion_order = 0;
+    query_hull.left_insertion_order = 0;
     avl_search_closest(hulls_left, &query_hull, &node);
     tsk_bug_assert(node != NULL);
     for (; node != NULL; node = node->next) {

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -703,14 +703,11 @@ msp_set_num_labels(msp_t *self, size_t num_labels)
     }
     msp_safe_free(self->segment_heap);
     msp_safe_free(self->hull_heap);
-    msp_safe_free(self->hullend_heap);
 
     self->num_labels = (uint32_t) num_labels;
     self->segment_heap = calloc(self->num_labels, sizeof(*self->segment_heap));
     self->hull_heap = calloc(self->num_labels, sizeof(*self->hull_heap));
-    self->hullend_heap = calloc(self->num_labels, sizeof(*self->hullend_heap));
-    if (self->segment_heap == NULL || self->hull_heap == NULL
-        || self->hullend_heap == NULL) {
+    if (self->segment_heap == NULL || self->hull_heap == NULL) {
         ret = MSP_ERR_NO_MEMORY;
         goto out;
     }
@@ -1139,9 +1136,6 @@ msp_free(msp_t *self)
         if (self->hull_heap != NULL) {
             object_heap_free(&self->hull_heap[j]);
         }
-        if (self->hullend_heap != NULL) {
-            object_heap_free(&self->hullend_heap[j]);
-        }
     }
     for (j = 0; j < self->num_populations; j++) {
         msp_safe_free(self->populations[j].ancestors);
@@ -1159,7 +1153,6 @@ msp_free(msp_t *self)
     msp_safe_free(self->gc_mass_index);
     msp_safe_free(self->segment_heap);
     msp_safe_free(self->hull_heap);
-    msp_safe_free(self->hullend_heap);
     msp_safe_free(self->initial_migration_matrix);
     msp_safe_free(self->migration_matrix);
     msp_safe_free(self->num_migration_events);
@@ -2490,8 +2483,6 @@ msp_print_state(msp_t *self, FILE *out)
         object_heap_print_state(&self->segment_heap[j], out);
         fprintf(out, "hull_heap[%d]:", j);
         object_heap_print_state(&self->hull_heap[j], out);
-        fprintf(out, "hullend_heap[%d]:", j);
-        object_heap_print_state(&self->hullend_heap[j], out);
     }
     fprintf(out, "avl_node_heap:");
     object_heap_print_state(&self->avl_node_heap, out);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -107,7 +107,7 @@ typedef struct hull_t_t {
     lineage_t *lineage;
     size_t id;
     uint64_t count;
-    uint64_t insertion_order;
+    uint64_t left_insertion_order;
 } hull_t;
 
 typedef struct {

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -288,7 +288,6 @@ typedef struct _msp_t {
     object_heap_t *segment_heap;
     /* We keep an independent hull heap for each label */
     object_heap_t *hull_heap;
-    object_heap_t *hullend_heap;
     /* The tables used to store the simulation state */
     tsk_table_collection_t *tables;
     tsk_bookmark_t input_position;

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -108,12 +108,9 @@ typedef struct hull_t_t {
     size_t id;
     uint64_t count;
     uint64_t left_insertion_order;
+    uint64_t right_insertion_order;
 } hull_t;
 
-typedef struct {
-    double position;
-    uint64_t insertion_order;
-} hullend_t;
 
 #define MSP_POP_STATE_INACTIVE 0
 #define MSP_POP_STATE_ACTIVE 1

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -109,6 +109,8 @@ typedef struct hull_t_t {
     uint64_t count;
     uint64_t left_insertion_order;
     uint64_t right_insertion_order;
+    avl_node_t left_avl_node;
+    avl_node_t right_avl_node;
 } hull_t;
 
 #define MSP_POP_STATE_INACTIVE 0

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -88,9 +88,9 @@ typedef struct segment_t_t {
 
 typedef struct lineage_t_t {
     population_id_t population;
+    label_id_t label;
     segment_t *head;
     segment_t *tail;
-    label_id_t label;
     struct hull_t_t *hull;
 } lineage_t;
 
@@ -111,7 +111,6 @@ typedef struct hull_t_t {
     uint64_t right_insertion_order;
 } hull_t;
 
-
 #define MSP_POP_STATE_INACTIVE 0
 #define MSP_POP_STATE_ACTIVE 1
 #define MSP_POP_STATE_PREVIOUSLY_ACTIVE 2
@@ -127,6 +126,7 @@ typedef struct {
     avl_tree_t *ancestors;
     tsk_size_t num_potential_destinations;
     tsk_id_t *potential_destinations;
+    /* These three indexes are only used in the SMCK model */
     avl_tree_t *hulls_left;
     avl_tree_t *hulls_right;
     fenwick_t *coal_mass_index;


### PR DESCRIPTION
Initial work on #2383 

As I work through it, I wonder if we can save some time on AVL tree maintenance by storing pointers to the left and right AVL tree nodes in the hull. It's not much space and would simplify things quite a bit.

Should probably work it out on the Python implementation first though.