### PR TITLE
Embed avl into lineage struct

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -4135,8 +4135,7 @@ msp_merge_n_ancestors(msp_t *self, avl_tree_t *Q, population_id_t population_id,
         tsk_bug_assert(u->lineage != NULL);
         if (u->lineage->population != population_id) {
             current_pop = &self->populations[u->lineage->population];
-            avl_node = avl_search(&current_pop->ancestors[label], u->lineage);
-            tsk_bug_assert(avl_node != NULL);
+            avl_node = &u->lineage->avl_node;
             ret = msp_move_individual(
                 self, avl_node, &current_pop->ancestors[label], population_id, label);
             if (ret != 0) {
@@ -5804,11 +5803,7 @@ static int
 msp_change_label(msp_t *self, lineage_t *lin, label_id_t label)
 {
     avl_tree_t *pop = &self->populations[lin->population].ancestors[lin->label];
-    avl_node_t *node;
-
-    /* Find the this individual in the AVL tree. */
-    node = avl_search(pop, lin);
-    tsk_bug_assert(node != NULL);
+    avl_node_t *node = &lin->avl_node;
     return msp_move_individual(self, node, pop, lin->population, label);
 }
 

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2015-2024 University of Oxford
+** Copyright (C) 2015-2025 University of Oxford
 **
 ** This file is part of msprime.
 **

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2015-2024 University of Oxford
+** Copyright (C) 2015-2025 University of Oxford
 **
 ** This file is part of msprime.
 **

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -91,6 +91,7 @@ typedef struct lineage_t_t {
     label_id_t label;
     segment_t *head;
     segment_t *tail;
+    avl_node_t avl_node;
     struct hull_t_t *hull;
 } lineage_t;
 

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2016-2024 University of Oxford
+** Copyright (C) 2016-2025 University of Oxford
 **
 ** This file is part of msprime.
 **

--- a/lib/tests/test_ancestry.c
+++ b/lib/tests/test_ancestry.c
@@ -795,7 +795,7 @@ test_dtwf_multi_locus_simulation(void)
     long seed = 10;
     double migration_matrix[] = { 0, 0.1, 0.1, 0 };
     const char *model_name;
-    size_t num_ca_events, num_re_events;
+    size_t num_ca_events, num_re_events, num_mig_events;
     double t;
     tsk_table_collection_t tables;
     msp_t msp;
@@ -809,6 +809,8 @@ test_dtwf_multi_locus_simulation(void)
     CU_ASSERT_EQUAL_FATAL(msp_set_recombination_rate(&msp, 0.1), 0);
     ret = msp_set_population_configuration(&msp, 0, n, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 1, n, 0, true);
+    CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_migration_matrix(&msp, 4, migration_matrix);
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_store_migrations(&msp, true);
@@ -819,12 +821,14 @@ test_dtwf_multi_locus_simulation(void)
     CU_ASSERT_STRING_EQUAL(model_name, "dtwf");
 
     ret = msp_run(&msp, DBL_MAX, ULONG_MAX);
+    CU_ASSERT_EQUAL(ret, 0);
     msp_verify(&msp, 0);
     num_ca_events = msp_get_num_common_ancestor_events(&msp);
     num_re_events = msp_get_num_recombination_events(&msp);
+    num_mig_events = tables.migrations.num_rows;
     CU_ASSERT_TRUE(num_ca_events > 0);
     CU_ASSERT_TRUE(num_re_events > 0);
-    CU_ASSERT_EQUAL(ret, 0);
+    CU_ASSERT_TRUE(num_mig_events > 0);
     msp_free(&msp);
     tsk_table_collection_free(&tables);
 
@@ -838,7 +842,12 @@ test_dtwf_multi_locus_simulation(void)
     CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_population_configuration(&msp, 0, n, 0, true);
     CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_population_configuration(&msp, 1, n, 0, true);
+    CU_ASSERT_EQUAL(ret, 0);
     ret = msp_set_migration_matrix(&msp, 4, migration_matrix);
+    CU_ASSERT_EQUAL(ret, 0);
+    ret = msp_set_store_migrations(&msp, true);
+    CU_ASSERT_EQUAL(ret, 0);
     ret = msp_initialise(&msp);
     CU_ASSERT_EQUAL(ret, 0);
     t = 1;
@@ -854,6 +863,7 @@ test_dtwf_multi_locus_simulation(void)
     CU_ASSERT_EQUAL(ret, 0);
     CU_ASSERT_TRUE(num_ca_events == msp_get_num_common_ancestor_events(&msp));
     CU_ASSERT_TRUE(num_re_events == msp_get_num_recombination_events(&msp));
+    CU_ASSERT_TRUE(num_mig_events == tables.migrations.num_rows);
 
     ret = msp_free(&msp);
     CU_ASSERT_EQUAL(ret, 0);


### PR DESCRIPTION
Following the ideas in #2383, we can also embed an avl_node_t in the lineage_t struct and save some memory management and AVL lookups.