### PR TITLE
Feat:/simulate after local mrca

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -2396,7 +2396,7 @@ class Simulator:
         new_lineage = self.alloc_lineage(None, population_index, label=label)
         coalescence = False
         defrag_required = False
-        min_overlap = 0
+        min_overlap = 2 if self.stop_at_local_mrca else 0
 
         while x is not None or y is not None:
             alpha = None
@@ -2863,7 +2863,7 @@ def run_simulate(args):
         gene_conversion_length=mean_tract_length,
         discrete_genome=args.discrete,
         hull_offset=args.offset,
-        stop_at_local_mrca=args.stop_at_local_mrca,
+        stop_at_local_mrca=not args.continue_after_local_mrca,
     )
     ts = s.simulate(args.end_time)
     ts.dump(args.output_file)
@@ -2950,7 +2950,12 @@ def add_simulator_arguments(parser):
         help="The delta_t value for selective sweeps",
     )
     parser.add_argument("--model", default="hudson")
-    parser.add_argument("--stop-at-local-mrca", default=True, type=bool)
+    parser.add_argument(
+        "--continue-after-local-mrca",
+        action='store_true',
+        default=False,
+        help="If set, continue after local MRCA (i.e., do not stop). Default: False (stop at local MRCA)."
+    )
     parser.add_argument("--offset", type=float, default=0.0)
     parser.add_argument(
         "--from-ts",

--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -329,6 +329,13 @@ out:
 }
 
 int
+msp_set_stop_at_local_mrca(msp_t *self, bool stop_at_local_mrca)
+{
+    self->stop_at_local_mrca = stop_at_local_mrca;
+    return 0;
+}
+
+int
 msp_set_discrete_genome(msp_t *self, bool is_discrete)
 {
     self->discrete_genome = is_discrete;
@@ -1030,6 +1037,7 @@ msp_alloc(msp_t *self, tsk_table_collection_t *tables, gsl_rng *rng)
     self->store_migrations = false;
     self->additional_nodes = 0;
     self->coalescing_segments_only = true;
+    self->stop_at_local_mrca = true;
     self->avl_node_block_size = 1024;
     self->node_mapping_block_size = 1024;
     self->segment_block_size = 1024;
@@ -3787,6 +3795,13 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
         goto out;
     }
 
+    uint32_t min_overlap;
+    if (self->stop_at_local_mrca) {
+    min_overlap = 2;
+    } else {
+    min_overlap = 0;
+    }
+
     x = a;
     y = b;
     /* Keep GCC happy */
@@ -3862,7 +3877,7 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                 node = avl_search(&self->overlap_counts, &search);
                 tsk_bug_assert(node != NULL);
                 nm = (node_mapping_t *) node->item;
-                if (nm->value == 2) {
+                if (nm->value == min_overlap) {
                     nm->value = 0;
                     node = node->next;
                     tsk_bug_assert(node != NULL);
@@ -3870,7 +3885,7 @@ msp_merge_two_ancestors(msp_t *self, population_id_t population_id, label_id_t l
                     r = nm->position;
                 } else {
                     r = l;
-                    while (nm->value != 2 && r < r_max) {
+                    while (nm->value != min_overlap && r < r_max) {
                         nm->value--;
                         node = node->next;
                         tsk_bug_assert(node != NULL);

--- a/lib/msprime.h
+++ b/lib/msprime.h
@@ -256,6 +256,7 @@ typedef struct _msp_t {
     bool store_full_arg;
     uint32_t additional_nodes;
     bool coalescing_segments_only;
+    bool stop_at_local_mrca;
     double sequence_length;
     bool discrete_genome;
     rate_map_t recomb_map;
@@ -497,6 +498,7 @@ int msp_set_store_migrations(msp_t *self, bool store_migrations);
 int msp_set_store_full_arg(msp_t *self, bool store_full_arg);
 int msp_set_additional_nodes(msp_t *self, uint32_t additional_nodes);
 int msp_set_coalescing_segments_only(msp_t *self, bool coalescing_segments_only);
+int msp_set_stop_at_local_mrca(msp_t *self, bool stop_at_local_mrca);
 int msp_set_ploidy(msp_t *self, int ploidy);
 int msp_set_recombination_map(msp_t *self, size_t size, double *position, double *rate);
 int msp_set_recombination_rate(msp_t *self, double rate);

--- a/msprime/_msprimemodule.c
+++ b/msprime/_msprimemodule.c
@@ -1790,8 +1790,8 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
         "demographic_events", "model", "avl_node_block_size", "segment_block_size",
         "node_mapping_block_size", "store_migrations", "start_time",
         "additional_nodes", "coalescing_segments_only",
-        "num_labels", "gene_conversion_rate", "gene_conversion_tract_length", 
-        "discrete_genome", "ploidy", NULL};
+        "num_labels", "gene_conversion_rate", "gene_conversion_tract_length",
+        "discrete_genome", "ploidy", "stop_at_local_mrca", NULL};
     PyObject *migration_matrix = NULL;
     PyObject *population_configuration = NULL;
     PyObject *demographic_events = NULL;
@@ -1813,11 +1813,13 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     double gene_conversion_rate = 0;
     double gene_conversion_tract_length = 1.0;
     int ploidy = 2;
+    int stop_at_local_mrca = true;
+
 
     self->sim = NULL;
     self->random_generator = NULL;
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-            "O!O!|O!O!OO!O!nnnidkinddii", kwlist,
+            "O!O!|O!O!OO!O!nnnidkinddiii", kwlist,
             &LightweightTableCollectionType, &tables,
             &RandomGeneratorType, &random_generator,
             /* optional */
@@ -1830,7 +1832,7 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
             &node_mapping_block_size, &store_migrations, &start_time,
             &additional_nodes, &coalescing_segments_only, &num_labels,
             &gene_conversion_rate, &gene_conversion_tract_length,
-            &discrete_genome, &ploidy)) {
+            &discrete_genome, &ploidy, &stop_at_local_mrca)) {
         goto out;
     }
     self->random_generator = random_generator;
@@ -1951,7 +1953,8 @@ Simulator_init(Simulator *self, PyObject *args, PyObject *kwds)
     }
     msp_set_additional_nodes(self->sim, (uint32_t) additional_nodes);
     msp_set_coalescing_segments_only(self->sim, coalescing_segments_only);
-    
+    msp_set_stop_at_local_mrca(self->sim, stop_at_local_mrca);
+
     sim_ret = msp_initialise(self->sim);
     if (sim_ret != 0) {
         handle_input_error("initialise", sim_ret);

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1411,7 +1411,7 @@ class Simulator(_msprime.Simulator):
         start_time=None,
         end_time=None,
         num_labels=None,
-        stop_at_local_mrca=None,
+        stop_at_local_mrca=True,
     ):
         # We always need at least n segments, so no point in making
         # allocation any smaller than this.
@@ -1462,6 +1462,7 @@ class Simulator(_msprime.Simulator):
             gene_conversion_tract_length=gene_conversion_tract_length,
             discrete_genome=discrete_genome,
             ploidy=ploidy,
+            stop_at_local_mrca=stop_at_local_mrca,
         )
         # Highlevel attributes used externally that have no lowlevel equivalent
         self.end_time = np.inf if end_time is None else end_time

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -1080,7 +1080,7 @@ def _parse_sim_ancestry(
     random_generator = _msprime.RandomGenerator(random_seed)
 
     if stop_at_local_mrca is None:
-        stop_at_local_mrca = False
+        stop_at_local_mrca = True
     elif not isinstance(stop_at_local_mrca, bool):
         raise TypeError(
             "stop_at_local_mrca must be a boolean value, or None which defaults to True."

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -815,6 +815,7 @@ def _parse_sim_ancestry(
     coalescing_segments_only=None,
     num_labels=None,
     random_seed=None,
+    stop_at_local_mrca=None,
     init_for_debugger=False,
 ):
     """
@@ -1078,6 +1079,20 @@ def _parse_sim_ancestry(
     random_seed = _parse_random_seed(random_seed)
     random_generator = _msprime.RandomGenerator(random_seed)
 
+    if stop_at_local_mrca is None:
+        stop_at_local_mrca = False
+    elif not isinstance(stop_at_local_mrca, bool):
+        raise TypeError(
+            "stop_at_local_mrca must be a boolean value, or None which defaults to True."
+        )
+    elif not stop_at_local_mrca: #when set to False
+        if end_time == math.inf or end_time is None:
+            raise ValueError(
+                "You have to specify an end_time when using stop_at_local_mrca, otherwise "
+                "the simulation will run indefinitely."
+            )
+
+
     return Simulator(
         tables=initial_state,
         recombination_map=recombination_map,
@@ -1094,6 +1109,7 @@ def _parse_sim_ancestry(
         end_time=end_time,
         num_labels=num_labels,
         random_generator=random_generator,
+        stop_at_local_mrca=stop_at_local_mrca,
     )
 
 
@@ -1121,6 +1137,7 @@ def sim_ancestry(
     num_replicates=None,
     replicate_index=None,
     record_provenance=None,
+    stop_at_local_mrca=None,
 ):
     """
     Simulates an ancestral process described by the specified model, demography and
@@ -1242,6 +1259,9 @@ def sim_ancestry(
         the :ref:`sec_ancestry_models_specifying` section for more details,
         and the :ref:`sec_ancestry_models` section for the available models
         and examples.
+    :param stop_at_local_mrca: If True (the default), the simulation will stop for a tree when
+        local mrca is reached. If False, simulations will continue on the path
+        to the grand mrca.
     :type model: str or msprime.AncestryModel or list
     :return: The :class:`tskit.TreeSequence` object representing the results
         of the simulation if no replication is performed, or an
@@ -1280,6 +1300,7 @@ def sim_ancestry(
             coalescing_segments_only=coalescing_segments_only,
             num_labels=num_labels,
             random_seed=random_seed,
+            stop_at_local_mrca=stop_at_local_mrca
             # num_replicates is excluded as provenance is per replicate
             # replicate index is excluded as it is inserted for each replicate
         )
@@ -1304,6 +1325,7 @@ def sim_ancestry(
         coalescing_segments_only=coalescing_segments_only,
         num_labels=num_labels,
         random_seed=random_seed,
+        stop_at_local_mrca=stop_at_local_mrca,
     )
     return _wrap_replicates(
         sim,
@@ -1389,6 +1411,7 @@ class Simulator(_msprime.Simulator):
         start_time=None,
         end_time=None,
         num_labels=None,
+        stop_at_local_mrca=None,
     ):
         # We always need at least n segments, so no point in making
         # allocation any smaller than this.


### PR DESCRIPTION
Here you go: @jeromekelleher 
Still missing some tests, and I want to change the flag name of the python algorithm to match the msprime implementation.
As a reminder, this implementation consumes more memory than the when stopping at the youngest root. It could be the node table getting much larger, and could be a memory leak.