### PR TITLE
Update to tskit 1.0, fix problems with initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,27 @@
 - The `FixedPedigree` simulation model now supports internal samples ({issue}`1855`,
   {pr}`2321`, {pr}`2326`, {pr}`2388`, {user}`abureau`, {user}`jeromekelleher`).
 
+- Add wheels on Windows ({pr}`2414`, {issue}`2200`,{user}`benjeffery`)
+
+**Maintenance**
+
 - Add support and wheels for Python3.13
 
 - Drop Python 3.9 support, require Python >= 3.10 ({pr}`2418`, {user}`benjeffery`)
 
-- Add wheels on Windows ({pr}`2414`, {issue}`2200`,{user}`benjeffery`)
-
 **Breaking changes**:
+
+- Require tskit >= 1.0 ({issue}`2434`).
 
 - The `.asdict()` methods for Demography, Population, and Event classes in the
   demography submodule now return a `__class__` key. This is also stored in their
   provenance entries, to help recreate demography objects from provenance.
   ({pr}`{2368}, {user}`hyanwong`)
+
+**Bugfixes**
+
+- Fix problem with initial_state and tskit 1.0 ({issue}`2434`, {pr}`2432`,
+  {user}`jeromekelleher'.
 
 ## [1.3.4] - 2025-05-01
 

--- a/msprime/ancestry.py
+++ b/msprime/ancestry.py
@@ -897,7 +897,9 @@ def _parse_sim_ancestry(
     if initial_state is not None:
         if isinstance(initial_state, tskit.TreeSequence):
             initial_state = initial_state.dump_tables()
-        elif not isinstance(initial_state, tskit.TableCollection):
+        elif not isinstance(
+            initial_state, (tskit.TableCollection, tskit.ImmutableTableCollection)
+        ):
             raise TypeError(
                 "initial_state must either be a TreeSequence or TableCollection instance"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 dependencies = [
     "numpy>=1.23.5",
     "newick>=1.3.0",
-    "tskit>=0.5.2",
+    "tskit>=1.0.0",
     "demes>=0.2"
 ]
 dynamic = ["version"]
@@ -85,7 +85,7 @@ test = [
     "setuptools==80.9.0",
     "scipy==1.13.1; python_version<='3.10'",
     "scipy==1.16.1; python_version>'3.10'",
-    "tskit==0.6.4",
+    "tskit==1.0.0",
     "twine==6.2.0"
 ]
 
@@ -101,7 +101,7 @@ docs = [
     "sphinx-argparse==0.5.2",
     "sphinx-book-theme",
     "sphinx-issues==5.0.1",
-    "tskit==0.6.4",
+    "tskit==1.0.0",
     "scipy==1.16.1"
 ]
 
@@ -124,7 +124,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
-    "tskit>=0.5.2",
+    "tskit>=1.0.0",
     "kastore",
     "sphinx-book-theme",
     "scipy",

--- a/tests/test_ancestry.py
+++ b/tests/test_ancestry.py
@@ -2628,7 +2628,7 @@ class TestSimulateInterface:
         # Running simulations with different numbers of labels in the default
         # setting should have no effect.
         tables = [
-            msprime.simulate(10, num_labels=num_labels, random_seed=1).tables
+            msprime.simulate(10, num_labels=num_labels, random_seed=1).dump_tables()
             for num_labels in range(1, 5)
         ]
         for t in tables:


### PR DESCRIPTION
Closes #2427 

I think it's best to just pin to 1.0 now, as there is a problem with using ``ts.tables`` as an ``initial_state``, which will likely break people's code. I don't think there's any harm in pulling in 1.0, now.