### PR TITLE
Fix boundary condition in SMCK 

### DIFF
--- a/lib/msprime.c
+++ b/lib/msprime.c
@@ -7690,7 +7690,7 @@ msp_smc_k_common_ancestor_event(
 
     /* find second hull */
     search = &x_hull->left_avl_node;
-    for (search = search->prev; remaining_mass >= 0; search = search->prev) {
+    for (search = search->prev; remaining_mass > 0; search = search->prev) {
         tsk_bug_assert(search != NULL);
         y_hull = (hull_t *) search->item;
         if (y_hull->left == x_hull->left || y_hull->right > x_hull->left) {


### PR DESCRIPTION
Hi again,

Related to https://github.com/tskit-dev/msprime/issues/2523

I cloned the source code and added a few print statements around the error. 

https://github.com/tskit-dev/msprime/blob/1b14a8a43cee4a0d57ba0c9878955da1d3699bc8/lib/msprime.c#L7691-L7699

In the failing case, at the iteration the `tsk_bug_assert` triggers, `remaining_mass` is exactly zero (!!!) 

I don't have a good understanding of the source code (nor C, really). Is this some sort of boundary condition error that is almost never triggered? 

After changing the condition into `remaining_mass > 0` rather than `remaining_mass >= 0`, the reproducible example of https://github.com/tskit-dev/msprime/issues/2523 runs without error on my machine: 

```bash
Platform: macOS-26.4.1-arm64-arm-64bit
Python: 3.12.12 (main, Dec  9 2025, 19:05:33) [Clang 21.1.4 ]
msprime: 0.1.dev4250
tskit: 1.0.0
numpy: 2.4.2

2026-05-04 17:17:40,038 [41544] INFO     msprime.ancestry: Sampling 50 individuals with ploidy 2 in population 0 (name='pop0') at time 0
2026-05-04 17:17:40,042 [41544] INFO     msprime.ancestry: Starting replicate 0
2026-05-04 17:17:40,042 [41544] INFO     msprime.ancestry: model[0] {'name': 'smc_k', 'k': 1.0} started at time=0 nodes=100 edges=0
2026-05-04 17:17:40,042 [41544] INFO     msprime.ancestry: Running model {'name': 'smc_k', 'k': 1.0} until max time: inf
2026-05-04 17:17:40,089 [41544] DEBUG    msprime.ancestry: time=554.851 ancestors=3239 ret=1
2026-05-04 17:17:40,131 [41544] DEBUG    msprime.ancestry: time=1491.18 ancestors=3753 ret=1
2026-05-04 17:17:40,164 [41544] DEBUG    msprime.ancestry: time=3131.51 ancestors=3985 ret=1
2026-05-04 17:17:40,192 [41544] DEBUG    msprime.ancestry: time=6154.73 ancestors=4027 ret=1
2026-05-04 17:17:40,218 [41544] DEBUG    msprime.ancestry: time=11301.7 ancestors=4099 ret=1
2026-05-04 17:17:40,240 [41544] DEBUG    msprime.ancestry: time=19977.2 ancestors=4015 ret=1
2026-05-04 17:17:40,261 [41544] DEBUG    msprime.ancestry: time=34372.7 ancestors=3771 ret=1
2026-05-04 17:17:40,279 [41544] DEBUG    msprime.ancestry: time=71819.1 ancestors=1739 ret=1
2026-05-04 17:17:40,282 [41544] DEBUG    msprime.ancestry: time=227877 ancestors=0 ret=0
2026-05-04 17:17:40,282 [41544] DEBUG    msprime.ancestry: Skipping remaining 0 models
2026-05-04 17:17:40,306 [41544] INFO     msprime.ancestry: Completed at time=227877 nodes=35505 edges=124253
35283
``